### PR TITLE
[Engine] feat/engine-difficulty — 50스테이지 난이도 설정 시스템

### DIFF
--- a/__tests__/sudoku/difficulty-generation.test.ts
+++ b/__tests__/sudoku/difficulty-generation.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { generatePuzzle } from '@/lib/sudoku/difficulty';
+import { hasUniqueSolution } from '@/lib/sudoku/solver';
+import { isValidSolution } from '@/lib/sudoku/generator';
+import type { CellValue } from '@/types/game';
+
+// ─── generatePuzzle ─────────────────────────────────
+// 퍼즐 생성은 시간이 걸리므로 별도 파일로 분리
+
+/** 퍼즐의 빈 칸 수를 센다 */
+const countEmpty = (puzzle: CellValue[][]): number =>
+  puzzle.flat().filter((v: CellValue) => v === null).length;
+
+describe('generatePuzzle', () => {
+  it('스테이지 1 퍼즐이 유효하다', () => {
+    const result = generatePuzzle(1);
+
+    // 정답이 유효한 솔루션인지 확인
+    expect(isValidSolution(result.solution)).toBe(true);
+
+    // 퍼즐에 빈 칸이 있는지 확인
+    const emptyCells = countEmpty(result.puzzle);
+    expect(emptyCells).toBe(result.config.emptyCells);
+
+    // 스테이지 설정이 올바른지 확인
+    expect(result.config.stage).toBe(1);
+  }, 10000);
+
+  it('스테이지 1 퍼즐은 유일해를 가진다', () => {
+    const result = generatePuzzle(1);
+    expect(hasUniqueSolution(result.puzzle)).toBe(true);
+  }, 10000);
+
+  it('스테이지 5 퍼즐의 빈 칸 수가 범위 내이다', () => {
+    const result = generatePuzzle(5);
+    const emptyCells = countEmpty(result.puzzle);
+    expect(emptyCells).toBeGreaterThanOrEqual(28);
+    expect(emptyCells).toBeLessThanOrEqual(37);
+  }, 10000);
+
+  it('스테이지 10 퍼즐의 빈 칸이 기존 숫자와 일치한다', () => {
+    const result = generatePuzzle(10);
+
+    // 빈 칸이 아닌 셀의 값이 정답과 일치하는지 확인
+    for (let r = 0; r < 9; r++) {
+      for (let c = 0; c < 9; c++) {
+        const val = result.puzzle[r][c];
+        if (val !== null) {
+          expect(val).toBe(result.solution[r][c]);
+        }
+      }
+    }
+  }, 10000);
+
+  it('스테이지 15 퍼즐이 정상 생성된다', () => {
+    const result = generatePuzzle(15);
+    expect(result.config.lockedCellCount).toBeGreaterThanOrEqual(1);
+    expect(result.config.lockedCellCount).toBeLessThanOrEqual(3);
+
+    const emptyCells = countEmpty(result.puzzle);
+    expect(emptyCells).toBeGreaterThanOrEqual(38);
+    expect(emptyCells).toBeLessThanOrEqual(43);
+  }, 15000);
+
+  it('높은 난이도(스테이지 25) 퍼즐도 유일해를 가진다', () => {
+    const result = generatePuzzle(25);
+    expect(hasUniqueSolution(result.puzzle)).toBe(true);
+  }, 30000);
+
+  it('생성된 퍼즐과 정답의 크기가 9x9이다', () => {
+    const result = generatePuzzle(3);
+    expect(result.puzzle).toHaveLength(9);
+    expect(result.solution).toHaveLength(9);
+    result.puzzle.forEach((row: CellValue[]) => expect(row).toHaveLength(9));
+    result.solution.forEach((row: number[]) => expect(row).toHaveLength(9));
+  }, 10000);
+});

--- a/__tests__/sudoku/difficulty.test.ts
+++ b/__tests__/sudoku/difficulty.test.ts
@@ -1,0 +1,180 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getStageRange,
+  getStageConfig,
+  getStageLabel,
+  getAllStageConfigs,
+  interpolate,
+} from '@/lib/sudoku/difficulty';
+import { STAGE_RANGES } from '@/types/game';
+
+// ─── getStageRange ──────────────────────────────────
+
+describe('getStageRange', () => {
+  it('스테이지 1은 입문 구간을 반환한다', () => {
+    const range = getStageRange(1);
+    expect(range.label).toBe('입문');
+    expect(range.startStage).toBe(1);
+    expect(range.endStage).toBe(10);
+  });
+
+  it('스테이지 10은 입문 구간의 끝이다', () => {
+    const range = getStageRange(10);
+    expect(range.label).toBe('입문');
+  });
+
+  it('스테이지 11은 초급 구간이다', () => {
+    const range = getStageRange(11);
+    expect(range.label).toBe('초급');
+  });
+
+  it('스테이지 50은 마스터 구간이다', () => {
+    const range = getStageRange(50);
+    expect(range.label).toBe('마스터');
+    expect(range.allowChainLocks).toBe(true);
+  });
+
+  it('0 이하의 스테이지는 에러를 던진다', () => {
+    expect(() => getStageRange(0)).toThrow('Invalid stage number');
+    expect(() => getStageRange(-1)).toThrow('Invalid stage number');
+  });
+
+  it('51 이상의 스테이지는 에러를 던진다', () => {
+    expect(() => getStageRange(51)).toThrow('Invalid stage number');
+  });
+
+  it('소수점 스테이지는 에러를 던진다', () => {
+    expect(() => getStageRange(1.5)).toThrow('Invalid stage number');
+  });
+
+  it('모든 구간 경계가 정상적으로 매핑된다', () => {
+    for (const range of STAGE_RANGES) {
+      expect(getStageRange(range.startStage).label).toBe(range.label);
+      expect(getStageRange(range.endStage).label).toBe(range.label);
+    }
+  });
+});
+
+// ─── interpolate ────────────────────────────────────
+
+describe('interpolate', () => {
+  const sampleRange = STAGE_RANGES[0]; // 입문: 1~10
+
+  it('구간 시작 스테이지는 최솟값을 반환한다', () => {
+    const result = interpolate(1, sampleRange, [28, 37]);
+    expect(result).toBe(28);
+  });
+
+  it('구간 끝 스테이지는 최댓값을 반환한다', () => {
+    const result = interpolate(10, sampleRange, [28, 37]);
+    expect(result).toBe(37);
+  });
+
+  it('구간 중간은 보간된 값을 반환한다', () => {
+    const result = interpolate(5, sampleRange, [28, 37]);
+    // (5-1)/(10-1) = 4/9 ≈ 0.444 → 28 + 0.444*9 ≈ 32
+    expect(result).toBe(32);
+  });
+
+  it('반환값은 정수이다', () => {
+    for (let stage = 1; stage <= 10; stage++) {
+      const result = interpolate(stage, sampleRange, [28, 37]);
+      expect(Number.isInteger(result)).toBe(true);
+    }
+  });
+});
+
+// ─── getStageConfig ─────────────────────────────────
+
+describe('getStageConfig', () => {
+  it('스테이지 1의 설정이 올바르다', () => {
+    const config = getStageConfig(1);
+    expect(config.stage).toBe(1);
+    expect(config.emptyCells).toBe(28);
+    expect(config.lockedCellCount).toBe(0);
+    expect(config.allowedLockTypes).toEqual([]);
+    expect(config.allowChainLocks).toBe(false);
+  });
+
+  it('스테이지 10의 빈 칸 수는 최댓값이다', () => {
+    const config = getStageConfig(10);
+    expect(config.emptyCells).toBe(37);
+    expect(config.lockedCellCount).toBe(0);
+  });
+
+  it('스테이지 15의 잠금 칸이 1~3 범위이다', () => {
+    const config = getStageConfig(15);
+    expect(config.lockedCellCount).toBeGreaterThanOrEqual(1);
+    expect(config.lockedCellCount).toBeLessThanOrEqual(3);
+    expect(config.allowedLockTypes).toContain('row-complete');
+  });
+
+  it('스테이지 25의 잠금 유형에 number-complete가 포함된다', () => {
+    const config = getStageConfig(25);
+    expect(config.allowedLockTypes).toContain('number-complete');
+  });
+
+  it('스테이지 45는 연쇄 잠금이 허용된다', () => {
+    const config = getStageConfig(45);
+    expect(config.allowChainLocks).toBe(true);
+    expect(config.lockedCellCount).toBeGreaterThanOrEqual(8);
+  });
+
+  it('빈 칸 수는 스테이지가 올라갈수록 단조증가한다 (구간별)', () => {
+    for (const range of STAGE_RANGES) {
+      const startConfig = getStageConfig(range.startStage);
+      const endConfig = getStageConfig(range.endStage);
+      expect(endConfig.emptyCells).toBeGreaterThanOrEqual(startConfig.emptyCells);
+    }
+  });
+
+  it('모든 50 스테이지의 빈 칸 수가 28~58 범위이다', () => {
+    for (let stage = 1; stage <= 50; stage++) {
+      const config = getStageConfig(stage);
+      expect(config.emptyCells).toBeGreaterThanOrEqual(28);
+      expect(config.emptyCells).toBeLessThanOrEqual(58);
+    }
+  });
+
+  it('allowedLockTypes는 원본 배열의 참조가 아니다 (불변성)', () => {
+    const config1 = getStageConfig(15);
+    const config2 = getStageConfig(15);
+    expect(config1.allowedLockTypes).not.toBe(config2.allowedLockTypes);
+    expect(config1.allowedLockTypes).toEqual(config2.allowedLockTypes);
+  });
+});
+
+// ─── getAllStageConfigs ──────────────────────────────
+
+describe('getAllStageConfigs', () => {
+  it('50개의 StageConfig를 반환한다', () => {
+    const configs = getAllStageConfigs();
+    expect(configs).toHaveLength(50);
+  });
+
+  it('스테이지 번호가 1~50 순서이다', () => {
+    const configs = getAllStageConfigs();
+    configs.forEach((config, i) => {
+      expect(config.stage).toBe(i + 1);
+    });
+  });
+});
+
+// ─── getStageLabel ──────────────────────────────────
+
+describe('getStageLabel', () => {
+  it.each([
+    [1, '입문'],
+    [10, '입문'],
+    [11, '초급'],
+    [20, '초급'],
+    [21, '중급'],
+    [30, '중급'],
+    [31, '고급'],
+    [40, '고급'],
+    [41, '마스터'],
+    [50, '마스터'],
+  ])('스테이지 %d → %s', (stage, label) => {
+    expect(getStageLabel(stage)).toBe(label);
+  });
+});

--- a/__tests__/sudoku/solver-puzzle-creation.test.ts
+++ b/__tests__/sudoku/solver-puzzle-creation.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from 'vitest';
+import {
+  createPuzzleFromSolution,
+  hasUniqueSolution,
+  solve,
+} from '@/lib/sudoku/solver';
+import { generateSolution, isValidSolution } from '@/lib/sudoku/generator';
+
+// ─── createPuzzleFromSolution ───────────────────────
+// 퍼즐 생성은 시간이 걸리므로 별도 파일로 분리
+
+describe('createPuzzleFromSolution', () => {
+  it('생성된 퍼즐이 유일해를 가진다', () => {
+    const solution = generateSolution();
+    const puzzle = createPuzzleFromSolution(solution, 30);
+    expect(hasUniqueSolution(puzzle)).toBe(true);
+  }, 15000);
+
+  it('제거된 셀 수가 요청값 이하이다', () => {
+    const solution = generateSolution();
+    const puzzle = createPuzzleFromSolution(solution, 30);
+    const emptyCells = puzzle.flat().filter((v) => v === null).length;
+    // 유일해 보장 때문에 요청값보다 적을 수 있음
+    expect(emptyCells).toBeLessThanOrEqual(30);
+    expect(emptyCells).toBeGreaterThan(0);
+  }, 15000);
+
+  it('빈 칸이 아닌 셀의 값이 원래 솔루션과 일치한다', () => {
+    const solution = generateSolution();
+    const puzzle = createPuzzleFromSolution(solution, 25);
+
+    for (let r = 0; r < 9; r++) {
+      for (let c = 0; c < 9; c++) {
+        if (puzzle[r][c] !== null) {
+          expect(puzzle[r][c]).toBe(solution[r][c]);
+        }
+      }
+    }
+  }, 15000);
+
+  it('풀이 결과가 원래 솔루션과 일치한다', () => {
+    const solution = generateSolution();
+    const puzzle = createPuzzleFromSolution(solution, 20);
+    const result = solve(puzzle);
+
+    expect(result.solved).toBe(true);
+    if (result.solved) {
+      expect(isValidSolution(result.grid)).toBe(true);
+      for (let r = 0; r < 9; r++) {
+        for (let c = 0; c < 9; c++) {
+          expect(result.grid[r][c]).toBe(solution[r][c]);
+        }
+      }
+    }
+  }, 15000);
+
+  it('emptyCellCount=0이면 빈 칸 없음', () => {
+    const solution = generateSolution();
+    const puzzle = createPuzzleFromSolution(solution, 0);
+    const emptyCells = puzzle.flat().filter((v) => v === null).length;
+    expect(emptyCells).toBe(0);
+  }, 5000);
+
+  it('매우 많은 빈 칸 요청 시 유일해 유지하며 최대한 제거', () => {
+    const solution = generateSolution();
+    const puzzle = createPuzzleFromSolution(solution, 60);
+    // 60개 요청했지만 유일해 보장 때문에 실제 제거 수는 60 이하
+    const emptyCells = puzzle.flat().filter((v) => v === null).length;
+    expect(emptyCells).toBeLessThanOrEqual(60);
+    expect(hasUniqueSolution(puzzle)).toBe(true);
+  }, 30000);
+});

--- a/__tests__/sudoku/solver.test.ts
+++ b/__tests__/sudoku/solver.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect } from 'vitest';
-import { solve, hasUniqueSolution, countPuzzleSolutions } from '@/lib/sudoku/solver';
+import {
+  solve,
+  hasUniqueSolution,
+  countPuzzleSolutions,
+  hasNoConflicts,
+} from '@/lib/sudoku/solver';
 import { generateSolution, isValidSolution } from '@/lib/sudoku/generator';
 import type { Grid } from '@/types/game';
+
+// ─── solve ──────────────────────────────────────────
 
 describe('solve', () => {
   it('2개 빈 칸 퍼즐을 풀 수 있다', () => {
@@ -23,13 +30,69 @@ describe('solve', () => {
     expect(solve(grid).solved).toBe(true);
   });
 
-  it('풀이 불가능한 퍼즐 → solved: false', () => {
+  it('행 내 중복 → 사전 검증으로 즉시 실패', () => {
     const grid: Grid = Array.from({ length: 9 }, () => Array(9).fill(null));
     grid[0][0] = 1;
     grid[0][1] = 1;
-    expect(solve(grid).solved).toBe(false);
+    const result = solve(grid);
+    expect(result.solved).toBe(false);
+    expect(result.solutionCount).toBe(0);
+  });
+
+  it('열 내 중복 → 즉시 실패', () => {
+    const grid: Grid = Array.from({ length: 9 }, () => Array(9).fill(null));
+    grid[0][0] = 5;
+    grid[3][0] = 5;
+    const result = solve(grid);
+    expect(result.solved).toBe(false);
+  });
+
+  it('3×3 박스 내 중복 → 즉시 실패', () => {
+    const grid: Grid = Array.from({ length: 9 }, () => Array(9).fill(null));
+    grid[0][0] = 7;
+    grid[2][2] = 7;
+    const result = solve(grid);
+    expect(result.solved).toBe(false);
   });
 });
+
+// ─── hasNoConflicts ─────────────────────────────────
+
+describe('hasNoConflicts', () => {
+  it('빈 그리드는 모순 없음', () => {
+    const grid: Grid = Array.from({ length: 9 }, () => Array(9).fill(null));
+    expect(hasNoConflicts(grid)).toBe(true);
+  });
+
+  it('유효한 솔루션은 모순 없음', () => {
+    const solution = generateSolution();
+    const grid: Grid = solution.map((row) => [...row]);
+    expect(hasNoConflicts(grid)).toBe(true);
+  });
+
+  it('행 중복 감지', () => {
+    const grid: Grid = Array.from({ length: 9 }, () => Array(9).fill(null));
+    grid[3][0] = 4;
+    grid[3][5] = 4;
+    expect(hasNoConflicts(grid)).toBe(false);
+  });
+
+  it('열 중복 감지', () => {
+    const grid: Grid = Array.from({ length: 9 }, () => Array(9).fill(null));
+    grid[1][7] = 9;
+    grid[8][7] = 9;
+    expect(hasNoConflicts(grid)).toBe(false);
+  });
+
+  it('박스 중복 감지', () => {
+    const grid: Grid = Array.from({ length: 9 }, () => Array(9).fill(null));
+    grid[6][6] = 2;
+    grid[8][8] = 2;
+    expect(hasNoConflicts(grid)).toBe(false);
+  });
+});
+
+// ─── hasUniqueSolution ──────────────────────────────
 
 describe('hasUniqueSolution', () => {
   it('빈 칸 1개 → true', () => {
@@ -38,7 +101,16 @@ describe('hasUniqueSolution', () => {
     grid[0][0] = null;
     expect(hasUniqueSolution(grid)).toBe(true);
   });
+
+  it('모순 있는 퍼즐 → false', () => {
+    const grid: Grid = Array.from({ length: 9 }, () => Array(9).fill(null));
+    grid[0][0] = 1;
+    grid[0][1] = 1;
+    expect(hasUniqueSolution(grid)).toBe(false);
+  });
 });
+
+// ─── countPuzzleSolutions ───────────────────────────
 
 describe('countPuzzleSolutions', () => {
   it('모순 → 0', () => {
@@ -46,5 +118,12 @@ describe('countPuzzleSolutions', () => {
     grid[0][0] = 1;
     grid[0][1] = 1;
     expect(countPuzzleSolutions(grid, 2)).toBe(0);
+  });
+
+  it('빈 칸 1개 → 1', () => {
+    const solution = generateSolution();
+    const grid: Grid = solution.map((row) => [...row]);
+    grid[0][0] = null;
+    expect(countPuzzleSolutions(grid, 2)).toBe(1);
   });
 });

--- a/src/lib/sudoku/difficulty.ts
+++ b/src/lib/sudoku/difficulty.ts
@@ -136,6 +136,10 @@ export const generatePuzzle = (stage: number): PuzzleGenerationResult => {
   const solution = generateSolution();
   const puzzle = createPuzzleFromSolution(solution, config.emptyCells);
 
+  // TODO: 잠금 칸 생성 로직 — feat/engine-lock-area, lock-number, lock-chain PR에서 구현 예정
+  // config.lockedCellCount > 0인 스테이지(11+)에서 잠금 칸을 배치하고
+  // 잠금 포함 상태에서도 풀이 가능성을 보장해야 함
+
   return {
     puzzle,
     solution,

--- a/src/lib/sudoku/difficulty.ts
+++ b/src/lib/sudoku/difficulty.ts
@@ -1,0 +1,169 @@
+/**
+ * 스도쿠 난이도 시스템
+ * 50스테이지 기반 난이도 설정을 관리하고, 스테이지별 퍼즐을 생성한다.
+ *
+ * @description
+ * 1. 스테이지 번호(1~50)에 따라 빈 칸 수, 잠금 칸 수, 조건 유형 결정
+ * 2. 구간 내에서 스테이지가 올라갈수록 선형 보간으로 난이도 증가
+ * 3. generateSolution + createPuzzleFromSolution 파이프라인으로 퍼즐 생성
+ *
+ * @see GitHub Issue #3 — Epic: 스도쿠 엔진 개발
+ */
+
+import type { StageConfig, StageRange, Grid, SolutionGrid } from '@/types/game';
+import { STAGE_RANGES } from '@/types/game';
+import { generateSolution } from '@/lib/sudoku/generator';
+import { createPuzzleFromSolution } from '@/lib/sudoku/solver';
+
+// ─── 상수 ───────────────────────────────────────────
+
+/** 최소 스테이지 */
+const MIN_STAGE = 1;
+
+/** 최대 스테이지 */
+const MAX_STAGE = 50;
+
+// ─── 스테이지 구간 조회 ─────────────────────────────
+
+/**
+ * 스테이지 번호에 해당하는 구간(StageRange)을 찾는다.
+ *
+ * @param stage - 스테이지 번호 (1~50)
+ * @returns 해당 구간 설정
+ * @throws 유효하지 않은 스테이지 번호
+ */
+export const getStageRange = (stage: number): StageRange => {
+  if (!Number.isInteger(stage) || stage < MIN_STAGE || stage > MAX_STAGE) {
+    throw new Error(`Invalid stage number: ${stage}. Must be between ${MIN_STAGE} and ${MAX_STAGE}.`);
+  }
+
+  const range = STAGE_RANGES.find(
+    (r) => stage >= r.startStage && stage <= r.endStage,
+  );
+
+  if (!range) {
+    throw new Error(`No stage range found for stage ${stage}.`);
+  }
+
+  return range;
+};
+
+// ─── 선형 보간 ──────────────────────────────────────
+
+/**
+ * 구간 내에서 스테이지 위치에 따라 값을 선형 보간한다.
+ * 스테이지가 구간 시작이면 min, 끝이면 max를 반환.
+ *
+ * @param stage - 스테이지 번호
+ * @param range - 구간 설정
+ * @param valueRange - [min, max] 범위
+ * @returns 보간된 정수 값
+ */
+const interpolate = (
+  stage: number,
+  range: StageRange,
+  valueRange: [number, number],
+): number => {
+  const [min, max] = valueRange;
+
+  // 구간 내 상대 위치 (0.0 ~ 1.0)
+  const span = range.endStage - range.startStage;
+  if (span === 0) return min;
+
+  const progress = (stage - range.startStage) / span;
+  return Math.round(min + progress * (max - min));
+};
+
+// ─── StageConfig 생성 ───────────────────────────────
+
+/**
+ * 스테이지 번호에 해당하는 StageConfig를 생성한다.
+ *
+ * @param stage - 스테이지 번호 (1~50)
+ * @returns 해당 스테이지의 설정 (빈 칸 수, 잠금 칸 수, 조건 유형 등)
+ *
+ * @example
+ * ```ts
+ * const config = getStageConfig(15);
+ * // { stage: 15, emptyCells: 40, lockedCellCount: 2,
+ * //   allowedLockTypes: ['row-complete', 'col-complete', 'box-complete'],
+ * //   allowChainLocks: false }
+ * ```
+ */
+export const getStageConfig = (stage: number): StageConfig => {
+  const range = getStageRange(stage);
+
+  return {
+    stage,
+    emptyCells: interpolate(stage, range, range.emptyRange),
+    lockedCellCount: interpolate(stage, range, range.lockRange),
+    allowedLockTypes: [...range.allowedLockTypes],
+    allowChainLocks: range.allowChainLocks,
+  };
+};
+
+// ─── 퍼즐 생성 파이프라인 ────────────────────────────
+
+/**
+ * 스테이지별 퍼즐 생성 결과
+ */
+export interface PuzzleGenerationResult {
+  /** 빈 칸이 포함된 퍼즐 그리드 */
+  puzzle: Grid;
+  /** 완성된 정답 그리드 */
+  solution: SolutionGrid;
+  /** 적용된 스테이지 설정 */
+  config: StageConfig;
+}
+
+/**
+ * 스테이지 번호에 맞는 퍼즐을 생성한다.
+ * 유일해가 보장된 퍼즐을 반환한다.
+ *
+ * @param stage - 스테이지 번호 (1~50)
+ * @returns 퍼즐, 정답, 스테이지 설정
+ *
+ * @example
+ * ```ts
+ * const result = generatePuzzle(25);
+ * console.log(result.config.emptyCells); // 44~49 범위
+ * console.log(result.puzzle);            // 빈 칸이 포함된 Grid
+ * console.log(result.solution);          // 완성된 SolutionGrid
+ * ```
+ */
+export const generatePuzzle = (stage: number): PuzzleGenerationResult => {
+  const config = getStageConfig(stage);
+  const solution = generateSolution();
+  const puzzle = createPuzzleFromSolution(solution, config.emptyCells);
+
+  return {
+    puzzle,
+    solution,
+    config,
+  };
+};
+
+/**
+ * 모든 스테이지(1~50)의 StageConfig 목록을 반환한다.
+ * 주로 UI에서 스테이지 선택 화면을 렌더링할 때 사용.
+ *
+ * @returns 50개 StageConfig 배열
+ */
+export const getAllStageConfigs = (): StageConfig[] => {
+  return Array.from({ length: MAX_STAGE }, (_, i) => getStageConfig(i + 1));
+};
+
+/**
+ * 스테이지의 구간 라벨을 반환한다.
+ *
+ * @param stage - 스테이지 번호 (1~50)
+ * @returns 구간 라벨 (예: '입문', '초급', '중급', '고급', '마스터')
+ */
+export const getStageLabel = (stage: number): string => {
+  return getStageRange(stage).label;
+};
+
+/**
+ * @internal 테스트 전용 export — 외부에서 직접 사용 금지
+ */
+export { interpolate, MIN_STAGE, MAX_STAGE };

--- a/src/lib/sudoku/solver.ts
+++ b/src/lib/sudoku/solver.ts
@@ -23,6 +23,9 @@ const cloneGrid = (grid: Grid): Grid =>
 
 /**
  * 특정 위치에 숫자를 놓을 수 있는지 검사한다. (Grid 타입용)
+ *
+ * @todo generator.ts의 canPlace와 로직 중복 — 추후 공통 유틸로 통합 예정
+ *       (현재는 Grid(CellValue[][]) vs number[][] 타입 차이로 분리)
  */
 const canPlaceInGrid = (
   grid: Grid,
@@ -78,7 +81,7 @@ const findMostConstrainedCell = (
 
   for (let row = 0; row < BOARD_SIZE; row++) {
     for (let col = 0; col < BOARD_SIZE; col++) {
-      if (grid[row][col] !== null && grid[row][col] !== 0) continue;
+      if (grid[row][col] !== null) continue;
 
       const candidates = getCandidates(grid, row, col);
 
@@ -99,6 +102,57 @@ const findMostConstrainedCell = (
   if (bestRow === -1) return null; // 빈 셀 없음 → 완성
 
   return [bestRow, bestCol, bestCandidates];
+};
+
+// ─── 사전 검증 ──────────────────────────────────────
+
+/**
+ * 그리드에 이미 존재하는 값들 사이에 모순이 있는지 검사한다.
+ * 행/열/3×3 박스에 같은 숫자가 중복되면 즉시 false 반환.
+ * 백트래킹 전에 호출하여 명백한 모순을 빠르게 걸러낸다.
+ *
+ * @param grid - 검사할 그리드
+ * @returns 모순이 없으면 true, 있으면 false
+ */
+const hasNoConflicts = (grid: Grid): boolean => {
+  // 행 검사
+  for (let r = 0; r < BOARD_SIZE; r++) {
+    const seen = new Set<number>();
+    for (let c = 0; c < BOARD_SIZE; c++) {
+      const val = grid[r][c];
+      if (val === null) continue;
+      if (seen.has(val)) return false;
+      seen.add(val);
+    }
+  }
+
+  // 열 검사
+  for (let c = 0; c < BOARD_SIZE; c++) {
+    const seen = new Set<number>();
+    for (let r = 0; r < BOARD_SIZE; r++) {
+      const val = grid[r][c];
+      if (val === null) continue;
+      if (seen.has(val)) return false;
+      seen.add(val);
+    }
+  }
+
+  // 3×3 박스 검사
+  for (let boxRow = 0; boxRow < BOARD_SIZE; boxRow += BOX_SIZE) {
+    for (let boxCol = 0; boxCol < BOARD_SIZE; boxCol += BOX_SIZE) {
+      const seen = new Set<number>();
+      for (let r = boxRow; r < boxRow + BOX_SIZE; r++) {
+        for (let c = boxCol; c < boxCol + BOX_SIZE; c++) {
+          const val = grid[r][c];
+          if (val === null) continue;
+          if (seen.has(val)) return false;
+          seen.add(val);
+        }
+      }
+    }
+  }
+
+  return true;
 };
 
 // ─── 풀이 함수 ──────────────────────────────────────
@@ -142,6 +196,12 @@ const solveBacktrack = (grid: Grid): boolean => {
  */
 export const solve = (puzzle: Grid): SolveResult => {
   const grid = cloneGrid(puzzle);
+
+  // 사전 모순 검출: 기존 값끼리 충돌하면 즉시 실패
+  if (!hasNoConflicts(grid)) {
+    return { solved: false, grid, solutionCount: 0 };
+  }
+
   const solved = solveBacktrack(grid);
 
   if (solved) {
@@ -209,8 +269,11 @@ const countSolutions = (
  */
 export const hasUniqueSolution = (puzzle: Grid): boolean => {
   const grid = cloneGrid(puzzle);
-  const count = { value: 0 };
 
+  // 사전 모순 검출
+  if (!hasNoConflicts(grid)) return false;
+
+  const count = { value: 0 };
   countSolutions(grid, count, 2);
 
   return count.value === 1;
@@ -225,8 +288,11 @@ export const hasUniqueSolution = (puzzle: Grid): boolean => {
  */
 export const countPuzzleSolutions = (puzzle: Grid, maxCount: number = 2): number => {
   const grid = cloneGrid(puzzle);
-  const count = { value: 0 };
 
+  // 사전 모순 검출
+  if (!hasNoConflicts(grid)) return 0;
+
+  const count = { value: 0 };
   countSolutions(grid, count, maxCount);
 
   return count.value;
@@ -290,4 +356,4 @@ export const createPuzzleFromSolution = (
 /**
  * @internal 테스트 전용 export — 외부에서 직접 사용 금지
  */
-export { cloneGrid, canPlaceInGrid, getCandidates, findMostConstrainedCell, countSolutions };
+export { cloneGrid, canPlaceInGrid, getCandidates, findMostConstrainedCell, countSolutions, hasNoConflicts };


### PR DESCRIPTION
## Summary
- **50스테이지 난이도 시스템** 구현: 스테이지(1~50)별 빈 칸 수, 잠금 칸 수, 조건 유형을 선형 보간으로 결정
- **solver PR 리뷰 반영**: `hasNoConflicts` 사전 모순 검출 추가로 타임아웃 해결, 불필요한 `0` 체크 제거, `canPlaceInGrid` 중복 TODO 추가
- **테스트 보강**: solver 테스트 5→14개, createPuzzleFromSolution 테스트 6개, difficulty 테스트 39개 (총 78개 전체 통과)

## 구현 목록
### difficulty.ts
- `getStageRange(stage)`: 스테이지 → 구간(StageRange) 매핑
- `getStageConfig(stage)`: 선형 보간으로 StageConfig 계산
- `generatePuzzle(stage)`: 스테이지별 퍼즐 생성 파이프라인 (유일해 보장)
- `getAllStageConfigs()`: 50개 StageConfig 일괄 조회
- `getStageLabel(stage)`: 구간 라벨 반환

### solver.ts 개선 (PR #24 리뷰 반영)
- `hasNoConflicts`: 행/열/박스 사전 중복 검출 → 모순 퍼즐 즉시 실패
- `findMostConstrainedCell`: `grid[row][col] !== 0` 제거 (타입 시스템 신뢰)
- `canPlaceInGrid`: `canPlace`와 중복 TODO 주석

## 테스트 결과
```
Test Files  5 passed (5)
     Tests  78 passed (78)
  Duration  369ms
```

## 관련 이슈
- Epic #3 — 스도쿠 엔진 개발
- PR #24 리뷰 코멘트 반영

## Test plan
- [x] difficulty.test.ts — 32개 순수 로직 테스트 (구간 매핑, 보간, 설정 검증)
- [x] difficulty-generation.test.ts — 7개 퍼즐 생성 테스트 (유일해, 빈 칸 범위)
- [x] solver.test.ts — 14개 (사전 모순 검출, hasNoConflicts 등)
- [x] solver-puzzle-creation.test.ts — 6개 (createPuzzleFromSolution)
- [x] pnpm lint: 0 errors
- [x] pnpm type-check: 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)