### PR TITLE
[Engine] feat/engine-lock-area — 잠금 칸 시스템: 영역 조건 (행/열/박스)

### DIFF
--- a/__tests__/sudoku/lockSystem-placement.test.ts
+++ b/__tests__/sudoku/lockSystem-placement.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest';
+import {
+  placeAreaLocks,
+  posKey,
+} from '@/lib/sudoku/lockSystem';
+import { generateSolution } from '@/lib/sudoku/generator';
+import { createPuzzleFromSolution, hasUniqueSolution } from '@/lib/sudoku/solver';
+
+// ─── placeAreaLocks ─────────────────────────────────
+// 배치 테스트는 시간이 걸릴 수 있으므로 별도 파일
+
+describe('placeAreaLocks', () => {
+  it('count=0이면 빈 잠금 목록을 반환한다', () => {
+    const solution = generateSolution();
+    const puzzle = createPuzzleFromSolution(solution, 30);
+    const result = placeAreaLocks(puzzle, solution, 0, ['row-complete']);
+    expect(result.lockedCells).toHaveLength(0);
+  }, 10000);
+
+  it('요청된 수만큼 잠금 칸을 배치한다', () => {
+    const solution = generateSolution();
+    const puzzle = createPuzzleFromSolution(solution, 35);
+    const result = placeAreaLocks(
+      puzzle, solution, 2, ['row-complete', 'col-complete', 'box-complete'],
+    );
+    // 최대 2개 배치 (조건에 따라 그보다 적을 수 있음)
+    expect(result.lockedCells.length).toBeGreaterThanOrEqual(1);
+    expect(result.lockedCells.length).toBeLessThanOrEqual(2);
+  }, 15000);
+
+  it('잠금 칸의 위치가 원래 빈 칸이다', () => {
+    const solution = generateSolution();
+    const puzzle = createPuzzleFromSolution(solution, 35);
+    const result = placeAreaLocks(
+      puzzle, solution, 3, ['row-complete', 'col-complete', 'box-complete'],
+    );
+
+    for (const lc of result.lockedCells) {
+      const { row, col } = lc.position;
+      // 원래 퍼즐에서 빈 칸이었어야 함
+      expect(puzzle[row][col]).toBeNull();
+    }
+  }, 15000);
+
+  it('잠금 칸의 조건 유형이 허용된 유형이다', () => {
+    const solution = generateSolution();
+    const puzzle = createPuzzleFromSolution(solution, 35);
+    const allowed = ['row-complete', 'col-complete', 'box-complete'] as const;
+    const result = placeAreaLocks(puzzle, solution, 3, [...allowed]);
+
+    for (const lc of result.lockedCells) {
+      for (const cond of lc.conditions) {
+        expect(allowed).toContain(cond.type);
+      }
+    }
+  }, 15000);
+
+  it('잠금 포함 퍼즐이 여전히 유일해를 가진다', () => {
+    const solution = generateSolution();
+    const puzzle = createPuzzleFromSolution(solution, 30);
+    const result = placeAreaLocks(
+      puzzle, solution, 2, ['row-complete', 'col-complete', 'box-complete'],
+    );
+
+    // 원본 퍼즐은 변경되지 않음 (잠금 칸은 여전히 null)
+    expect(hasUniqueSolution(result.puzzle)).toBe(true);
+  }, 15000);
+
+  it('잠금 칸끼리 위치가 중복되지 않는다', () => {
+    const solution = generateSolution();
+    const puzzle = createPuzzleFromSolution(solution, 40);
+    const result = placeAreaLocks(
+      puzzle, solution, 3, ['row-complete', 'col-complete', 'box-complete'],
+    );
+
+    const keys = result.lockedCells.map((lc) => posKey(lc.position.row, lc.position.col));
+    const uniqueKeys = new Set(keys);
+    expect(uniqueKeys.size).toBe(keys.length);
+  }, 15000);
+
+  it('조건 설명이 비어있지 않다', () => {
+    const solution = generateSolution();
+    const puzzle = createPuzzleFromSolution(solution, 35);
+    const result = placeAreaLocks(
+      puzzle, solution, 2, ['row-complete', 'col-complete', 'box-complete'],
+    );
+
+    for (const lc of result.lockedCells) {
+      for (const cond of lc.conditions) {
+        expect(cond.description.length).toBeGreaterThan(0);
+      }
+    }
+  }, 15000);
+
+  it('row-complete만 허용하면 행 조건만 생성된다', () => {
+    const solution = generateSolution();
+    const puzzle = createPuzzleFromSolution(solution, 35);
+    const result = placeAreaLocks(puzzle, solution, 2, ['row-complete']);
+
+    for (const lc of result.lockedCells) {
+      expect(lc.conditions[0].type).toBe('row-complete');
+    }
+  }, 15000);
+});

--- a/__tests__/sudoku/lockSystem.test.ts
+++ b/__tests__/sudoku/lockSystem.test.ts
@@ -1,0 +1,294 @@
+import { describe, it, expect } from 'vitest';
+import {
+  isAreaConditionMet,
+  findUnlockableCells,
+  generateAreaCondition,
+  validateSolvabilityWithLocks,
+  posKey,
+  getRowPositions,
+  getColPositions,
+  getBoxPositions,
+  getBoxIndex,
+  getAreaPositions,
+  countEmptyInArea,
+  createConditionDescription,
+} from '@/lib/sudoku/lockSystem';
+import { generateSolution } from '@/lib/sudoku/generator';
+import { createPuzzleFromSolution } from '@/lib/sudoku/solver';
+import type { Grid, LockedCell, LockCondition } from '@/types/game';
+
+// ─── posKey ─────────────────────────────────────────
+
+describe('posKey', () => {
+  it('좌표를 문자열로 변환한다', () => {
+    expect(posKey(3, 7)).toBe('3,7');
+    expect(posKey(0, 0)).toBe('0,0');
+  });
+});
+
+// ─── 영역 조회 ──────────────────────────────────────
+
+describe('getRowPositions', () => {
+  it('9개 위치를 반환한다', () => {
+    const positions = getRowPositions(3);
+    expect(positions).toHaveLength(9);
+    positions.forEach((p) => expect(p.row).toBe(3));
+  });
+});
+
+describe('getColPositions', () => {
+  it('9개 위치를 반환한다', () => {
+    const positions = getColPositions(5);
+    expect(positions).toHaveLength(9);
+    positions.forEach((p) => expect(p.col).toBe(5));
+  });
+});
+
+describe('getBoxPositions', () => {
+  it('9개 위치를 반환한다', () => {
+    const positions = getBoxPositions(0);
+    expect(positions).toHaveLength(9);
+    // 박스 0 = (0,0)~(2,2)
+    for (const p of positions) {
+      expect(p.row).toBeGreaterThanOrEqual(0);
+      expect(p.row).toBeLessThanOrEqual(2);
+      expect(p.col).toBeGreaterThanOrEqual(0);
+      expect(p.col).toBeLessThanOrEqual(2);
+    }
+  });
+
+  it('박스 8은 (6,6)~(8,8)이다', () => {
+    const positions = getBoxPositions(8);
+    for (const p of positions) {
+      expect(p.row).toBeGreaterThanOrEqual(6);
+      expect(p.col).toBeGreaterThanOrEqual(6);
+    }
+  });
+});
+
+describe('getBoxIndex', () => {
+  it.each([
+    [0, 0, 0], [1, 2, 0], [0, 3, 1], [0, 8, 2],
+    [3, 0, 3], [4, 4, 4], [5, 8, 5],
+    [6, 0, 6], [7, 5, 7], [8, 8, 8],
+  ])('(%d, %d) → 박스 %d', (row, col, expected) => {
+    expect(getBoxIndex(row, col)).toBe(expected);
+  });
+});
+
+describe('getAreaPositions', () => {
+  it('row-complete는 행 위치를 반환한다', () => {
+    expect(getAreaPositions('row-complete', 0)).toHaveLength(9);
+  });
+
+  it('col-complete는 열 위치를 반환한다', () => {
+    expect(getAreaPositions('col-complete', 0)).toHaveLength(9);
+  });
+
+  it('box-complete는 박스 위치를 반환한다', () => {
+    expect(getAreaPositions('box-complete', 4)).toHaveLength(9);
+  });
+});
+
+// ─── countEmptyInArea ───────────────────────────────
+
+describe('countEmptyInArea', () => {
+  it('모든 셀이 채워지면 0이다', () => {
+    const solution = generateSolution();
+    const grid: Grid = solution.map((row) => [...row]);
+    const positions = getRowPositions(0);
+    expect(countEmptyInArea(grid, positions, new Set())).toBe(0);
+  });
+
+  it('빈 칸을 정확히 센다', () => {
+    const solution = generateSolution();
+    const grid: Grid = solution.map((row) => [...row]);
+    grid[0][0] = null;
+    grid[0][3] = null;
+    grid[0][7] = null;
+    const positions = getRowPositions(0);
+    expect(countEmptyInArea(grid, positions, new Set())).toBe(3);
+  });
+
+  it('잠금 칸은 빈 칸에서 제외한다', () => {
+    const solution = generateSolution();
+    const grid: Grid = solution.map((row) => [...row]);
+    grid[0][0] = null;
+    grid[0][3] = null;
+    grid[0][7] = null;
+    const lockedKeys = new Set(['0,0']);
+    const positions = getRowPositions(0);
+    expect(countEmptyInArea(grid, positions, lockedKeys)).toBe(2);
+  });
+});
+
+// ─── isAreaConditionMet ─────────────────────────────
+
+describe('isAreaConditionMet', () => {
+  it('행이 완성되면 true', () => {
+    const solution = generateSolution();
+    const grid: Grid = solution.map((row) => [...row]);
+    const condition: LockCondition = { type: 'row-complete', target: 0, description: '' };
+    expect(isAreaConditionMet(grid, condition, new Set())).toBe(true);
+  });
+
+  it('행에 빈 칸이 있으면 false', () => {
+    const solution = generateSolution();
+    const grid: Grid = solution.map((row) => [...row]);
+    grid[0][5] = null;
+    const condition: LockCondition = { type: 'row-complete', target: 0, description: '' };
+    expect(isAreaConditionMet(grid, condition, new Set())).toBe(false);
+  });
+
+  it('잠금 칸은 빈 칸에서 제외하여 평가한다', () => {
+    const solution = generateSolution();
+    const grid: Grid = solution.map((row) => [...row]);
+    grid[0][5] = null; // 이 칸이 잠금 칸
+    const condition: LockCondition = { type: 'row-complete', target: 0, description: '' };
+    const lockedKeys = new Set(['0,5']); // 잠금 칸으로 등록
+    // 잠금 칸 제외하면 행은 완성
+    expect(isAreaConditionMet(grid, condition, lockedKeys)).toBe(true);
+  });
+
+  it('영역 조건이 아닌 유형은 false를 반환한다', () => {
+    const grid: Grid = Array.from({ length: 9 }, () => Array(9).fill(1));
+    const condition: LockCondition = { type: 'number-complete', target: 1, description: '' };
+    expect(isAreaConditionMet(grid, condition, new Set())).toBe(false);
+  });
+});
+
+// ─── findUnlockableCells ────────────────────────────
+
+describe('findUnlockableCells', () => {
+  it('조건이 충족된 잠금 칸을 반환한다', () => {
+    const solution = generateSolution();
+    const grid: Grid = solution.map((row) => [...row]);
+    grid[0][0] = null; // 잠금 칸
+
+    const lockedCells: LockedCell[] = [{
+      position: { row: 0, col: 0 },
+      conditions: [{ type: 'row-complete', target: 0, description: '' }],
+    }];
+
+    // 행 0의 나머지는 모두 채워져 있으므로 해제 가능
+    const unlockable = findUnlockableCells(grid, lockedCells);
+    expect(unlockable).toHaveLength(1);
+  });
+
+  it('조건 미충족 시 빈 배열을 반환한다', () => {
+    const solution = generateSolution();
+    const grid: Grid = solution.map((row) => [...row]);
+    grid[0][0] = null; // 잠금 칸
+    grid[0][5] = null; // 다른 빈 칸
+
+    const lockedCells: LockedCell[] = [{
+      position: { row: 0, col: 0 },
+      conditions: [{ type: 'row-complete', target: 0, description: '' }],
+    }];
+
+    // 행 0에 빈 칸(0,5)이 있어 조건 미충족
+    const unlockable = findUnlockableCells(grid, lockedCells);
+    expect(unlockable).toHaveLength(0);
+  });
+});
+
+// ─── createConditionDescription ─────────────────────
+
+describe('createConditionDescription', () => {
+  it('행 조건 설명', () => {
+    expect(createConditionDescription('row-complete', 0)).toBe('1행을 완성하세요');
+    expect(createConditionDescription('row-complete', 8)).toBe('9행을 완성하세요');
+  });
+
+  it('열 조건 설명', () => {
+    expect(createConditionDescription('col-complete', 2)).toBe('3열을 완성하세요');
+  });
+
+  it('박스 조건 설명', () => {
+    expect(createConditionDescription('box-complete', 0)).toBe('1-1 박스를 완성하세요');
+    expect(createConditionDescription('box-complete', 4)).toBe('2-2 박스를 완성하세요');
+    expect(createConditionDescription('box-complete', 8)).toBe('3-3 박스를 완성하세요');
+  });
+});
+
+// ─── generateAreaCondition ──────────────────────────
+
+describe('generateAreaCondition', () => {
+  it('빈 칸이 충분한 영역에 조건을 생성한다', () => {
+    const solution = generateSolution();
+    const puzzle = createPuzzleFromSolution(solution, 30);
+    const emptyPos = { row: -1, col: -1 };
+
+    // 빈 칸 찾기
+    outer:
+    for (let r = 0; r < 9; r++) {
+      for (let c = 0; c < 9; c++) {
+        if (puzzle[r][c] === null) {
+          emptyPos.row = r;
+          emptyPos.col = c;
+          break outer;
+        }
+      }
+    }
+
+    const condition = generateAreaCondition(
+      puzzle, emptyPos, new Set(), ['row-complete', 'col-complete', 'box-complete'],
+    );
+    expect(condition).not.toBeNull();
+    expect(['row-complete', 'col-complete', 'box-complete']).toContain(condition!.type);
+  });
+
+  it('허용되지 않은 유형은 생성하지 않는다', () => {
+    const solution = generateSolution();
+    const puzzle = createPuzzleFromSolution(solution, 30);
+
+    for (let r = 0; r < 9; r++) {
+      for (let c = 0; c < 9; c++) {
+        if (puzzle[r][c] === null) {
+          const condition = generateAreaCondition(
+            puzzle, { row: r, col: c }, new Set(), ['number-complete'],
+          );
+          // number-complete는 영역 조건이 아니므로 null
+          expect(condition).toBeNull();
+          return;
+        }
+      }
+    }
+  });
+
+  it('빈 타입 배열이면 null을 반환한다', () => {
+    const grid: Grid = Array.from({ length: 9 }, () => Array(9).fill(null));
+    const condition = generateAreaCondition(grid, { row: 0, col: 0 }, new Set(), []);
+    expect(condition).toBeNull();
+  });
+});
+
+// ─── validateSolvabilityWithLocks ───────────────────
+
+describe('validateSolvabilityWithLocks', () => {
+  it('잠금 없으면 항상 true', () => {
+    const solution = generateSolution();
+    const puzzle = createPuzzleFromSolution(solution, 20);
+    expect(validateSolvabilityWithLocks(puzzle, solution, [])).toBe(true);
+  });
+
+  it('유효한 잠금 배치는 true', () => {
+    const solution = generateSolution();
+    const puzzle = createPuzzleFromSolution(solution, 30);
+
+    // 빈 칸 하나를 잠금으로 설정
+    for (let r = 0; r < 9; r++) {
+      for (let c = 0; c < 9; c++) {
+        if (puzzle[r][c] === null) {
+          const lockedCells: LockedCell[] = [{
+            position: { row: r, col: c },
+            conditions: [{ type: 'row-complete', target: r, description: '' }],
+          }];
+          const result = validateSolvabilityWithLocks(puzzle, solution, lockedCells);
+          expect(result).toBe(true);
+          return;
+        }
+      }
+    }
+  });
+});

--- a/src/lib/sudoku/lockSystem.ts
+++ b/src/lib/sudoku/lockSystem.ts
@@ -1,0 +1,370 @@
+/**
+ * 잠금 칸 시스템 — 영역 조건 (행/열/박스)
+ * 특정 영역을 완성하면 잠금 칸이 해제되는 시스템을 구현한다.
+ *
+ * @description
+ * 1. 영역 조건: row-complete, col-complete, box-complete
+ * 2. 잠금 칸은 빈 칸 중에서 선택하여 조건을 부여
+ * 3. 잠금 포함 상태에서도 퍼즐이 풀이 가능해야 함
+ * 4. 순수 함수 — 사이드 이펙트 없음
+ *
+ * @see GitHub Issue #3 — Epic: 스도쿠 엔진 개발
+ */
+
+import type {
+  Grid,
+  SolutionGrid,
+  Position,
+  LockedCell,
+  LockCondition,
+  LockConditionType,
+  CellValue,
+} from '@/types/game';
+import { BOARD_SIZE, BOX_SIZE } from '@/lib/sudoku/generator';
+import { hasUniqueSolution } from '@/lib/sudoku/solver';
+
+// ─── 유틸 ───────────────────────────────────────────
+
+/** Position을 문자열 키로 변환 */
+const posKey = (row: number, col: number): string => `${row},${col}`;
+
+/** Grid를 깊은 복사한다 */
+const cloneGrid = (grid: Grid): Grid =>
+  grid.map((row) => [...row]);
+
+/**
+ * 배열을 Fisher-Yates 알고리즘으로 셔플한다 (불변 — 새 배열 반환).
+ */
+const shuffle = <T>(arr: readonly T[]): T[] => {
+  const result = [...arr];
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result;
+};
+
+// ─── 영역 조회 ──────────────────────────────────────
+
+/**
+ * 특정 행의 모든 셀 위치를 반환한다.
+ */
+const getRowPositions = (row: number): Position[] =>
+  Array.from({ length: BOARD_SIZE }, (_, c) => ({ row, col: c }));
+
+/**
+ * 특정 열의 모든 셀 위치를 반환한다.
+ */
+const getColPositions = (col: number): Position[] =>
+  Array.from({ length: BOARD_SIZE }, (_, r) => ({ row: r, col }));
+
+/**
+ * 특정 3×3 박스의 모든 셀 위치를 반환한다.
+ * @param boxIndex - 박스 인덱스 (0~8, 좌→우 상→하)
+ */
+const getBoxPositions = (boxIndex: number): Position[] => {
+  const boxRow = Math.floor(boxIndex / BOX_SIZE) * BOX_SIZE;
+  const boxCol = (boxIndex % BOX_SIZE) * BOX_SIZE;
+  const positions: Position[] = [];
+  for (let r = boxRow; r < boxRow + BOX_SIZE; r++) {
+    for (let c = boxCol; c < boxCol + BOX_SIZE; c++) {
+      positions.push({ row: r, col: c });
+    }
+  }
+  return positions;
+};
+
+/**
+ * 셀이 속한 3×3 박스 인덱스를 반환한다.
+ */
+const getBoxIndex = (row: number, col: number): number =>
+  Math.floor(row / BOX_SIZE) * BOX_SIZE + Math.floor(col / BOX_SIZE);
+
+/**
+ * 조건 유형에 따른 영역 셀 위치를 반환한다.
+ */
+const getAreaPositions = (
+  type: 'row-complete' | 'col-complete' | 'box-complete',
+  target: number,
+): Position[] => {
+  switch (type) {
+    case 'row-complete': return getRowPositions(target);
+    case 'col-complete': return getColPositions(target);
+    case 'box-complete': return getBoxPositions(target);
+  }
+};
+
+// ─── 조건 평가 ──────────────────────────────────────
+
+/**
+ * 영역의 빈 칸 수를 센다 (잠금 칸 제외).
+ */
+const countEmptyInArea = (
+  grid: Grid,
+  positions: Position[],
+  lockedKeys: Set<string>,
+): number => {
+  let count = 0;
+  for (const pos of positions) {
+    if (grid[pos.row][pos.col] === null && !lockedKeys.has(posKey(pos.row, pos.col))) {
+      count++;
+    }
+  }
+  return count;
+};
+
+/**
+ * 영역 조건이 충족되었는지 검사한다.
+ * 해당 영역의 모든 빈 칸(잠금 칸 제외)이 채워졌으면 true.
+ *
+ * @param grid - 현재 보드 상태
+ * @param condition - 검사할 조건
+ * @param lockedKeys - 현재 잠겨 있는 셀 키 Set
+ * @returns 조건 충족 여부
+ */
+export const isAreaConditionMet = (
+  grid: Grid,
+  condition: LockCondition,
+  lockedKeys: Set<string>,
+): boolean => {
+  const { type, target } = condition;
+
+  if (type !== 'row-complete' && type !== 'col-complete' && type !== 'box-complete') {
+    return false; // 영역 조건이 아닌 경우
+  }
+
+  const positions = getAreaPositions(type, target);
+  return countEmptyInArea(grid, positions, lockedKeys) === 0;
+};
+
+/**
+ * 잠금 칸 목록에서 현재 해제 가능한 셀들을 찾는다.
+ * 모든 조건이 충족된 잠금 칸을 반환한다.
+ *
+ * @param grid - 현재 보드 상태
+ * @param lockedCells - 잠금 칸 목록
+ * @returns 해제 가능한 잠금 칸들
+ */
+export const findUnlockableCells = (
+  grid: Grid,
+  lockedCells: LockedCell[],
+): LockedCell[] => {
+  const lockedKeys = new Set(
+    lockedCells.map((lc) => posKey(lc.position.row, lc.position.col)),
+  );
+
+  return lockedCells.filter((lc) =>
+    lc.conditions.every((cond) => isAreaConditionMet(grid, cond, lockedKeys)),
+  );
+};
+
+// ─── 조건 생성 ──────────────────────────────────────
+
+/** 영역 조건 유형 목록 */
+const AREA_LOCK_TYPES: LockConditionType[] = ['row-complete', 'col-complete', 'box-complete'];
+
+/**
+ * 조건 설명 문자열을 생성한다.
+ */
+const createConditionDescription = (type: LockConditionType, target: number): string => {
+  switch (type) {
+    case 'row-complete': return `${target + 1}행을 완성하세요`;
+    case 'col-complete': return `${target + 1}열을 완성하세요`;
+    case 'box-complete': {
+      const boxRow = Math.floor(target / 3) + 1;
+      const boxCol = (target % 3) + 1;
+      return `${boxRow}-${boxCol} 박스를 완성하세요`;
+    }
+    default: return '';
+  }
+};
+
+/**
+ * 특정 위치에 대해 유효한 영역 조건을 생성한다.
+ * 잠금 칸이 속한 영역 중, 다른 빈 칸이 1개 이상인 영역을 조건으로 선택.
+ *
+ * @param grid - 퍼즐 그리드
+ * @param pos - 잠금 칸 위치
+ * @param lockedKeys - 이미 잠긴 셀 키 Set
+ * @param allowedTypes - 허용된 조건 유형
+ * @returns 유효한 조건 또는 null
+ */
+export const generateAreaCondition = (
+  grid: Grid,
+  pos: Position,
+  lockedKeys: Set<string>,
+  allowedTypes: LockConditionType[],
+): LockCondition | null => {
+  const areaTypes = allowedTypes.filter(
+    (t): t is 'row-complete' | 'col-complete' | 'box-complete' => AREA_LOCK_TYPES.includes(t),
+  );
+
+  if (areaTypes.length === 0) return null;
+
+  // 이 셀을 잠금 후보로 추가
+  const updatedLockedKeys = new Set(lockedKeys);
+  updatedLockedKeys.add(posKey(pos.row, pos.col));
+
+  // 가능한 조건 후보 수집
+  const candidates: LockCondition[] = [];
+
+  for (const type of areaTypes) {
+    let target: number;
+    switch (type) {
+      case 'row-complete': target = pos.row; break;
+      case 'col-complete': target = pos.col; break;
+      case 'box-complete': target = getBoxIndex(pos.row, pos.col); break;
+    }
+
+    const positions = getAreaPositions(type, target);
+    const emptyCount = countEmptyInArea(grid, positions, updatedLockedKeys);
+
+    // 영역에 다른 빈 칸이 1개 이상이어야 의미 있는 조건
+    if (emptyCount >= 1) {
+      candidates.push({
+        type,
+        target,
+        description: createConditionDescription(type, target),
+      });
+    }
+  }
+
+  if (candidates.length === 0) return null;
+
+  // 랜덤 선택
+  return candidates[Math.floor(Math.random() * candidates.length)];
+};
+
+// ─── 풀이 가능성 검증 ───────────────────────────────
+
+/**
+ * 잠금 칸 포함 상태에서 퍼즐이 풀이 가능한지 검증한다.
+ *
+ * 검증 전략:
+ * 잠금 칸의 정답값을 given으로 넣은 그리드를 만들고,
+ * 나머지 빈 칸(플레이어가 채울 칸)이 유일해를 가지는지 확인.
+ * → 유일해가 있으면 플레이어가 모든 빈 칸을 채울 수 있고,
+ *   빈 칸이 채워지면 영역 조건이 충족되어 잠금 칸이 해제된다.
+ *
+ * @param puzzle - 퍼즐 그리드
+ * @param solution - 정답 그리드
+ * @param lockedCells - 잠금 칸 목록
+ * @returns 풀이 가능 여부
+ */
+export const validateSolvabilityWithLocks = (
+  puzzle: Grid,
+  solution: SolutionGrid,
+  lockedCells: LockedCell[],
+): boolean => {
+  if (lockedCells.length === 0) return true;
+
+  // 잠금 칸의 정답값을 given으로 넣은 테스트 그리드
+  // → 플레이어 관점: 잠금 칸은 "언젠가 공개될 값"
+  // → 이 값을 미리 넣으면 나머지 빈 칸이 풀리는지 확인 가능
+  const testGrid = cloneGrid(puzzle);
+
+  for (const lc of lockedCells) {
+    const { row, col } = lc.position;
+    testGrid[row][col] = solution[row][col] as CellValue;
+  }
+
+  // 나머지 빈 칸이 유일해를 가지는지 확인
+  return hasUniqueSolution(testGrid);
+};
+
+// ─── 잠금 배치 ──────────────────────────────────────
+
+/**
+ * 잠금 칸 배치 결과
+ */
+export interface LockPlacementResult {
+  /** 배치된 잠금 칸 정보 */
+  lockedCells: LockedCell[];
+  /** 잠금 칸이 반영된 퍼즐 (잠금 칸은 null로 유지) */
+  puzzle: Grid;
+}
+
+/**
+ * 퍼즐에 영역 조건 기반 잠금 칸을 배치한다.
+ * 잠금 포함 상태에서 풀이 가능성을 검증한다.
+ *
+ * @param puzzle - 원본 퍼즐 (빈 칸 포함)
+ * @param solution - 정답 그리드
+ * @param count - 배치할 잠금 칸 수
+ * @param allowedTypes - 허용된 조건 유형
+ * @returns 잠금 배치 결과 (잠금 칸 목록 + 검증된 퍼즐)
+ *
+ * @example
+ * ```ts
+ * const result = placeAreaLocks(puzzle, solution, 3, ['row-complete', 'col-complete', 'box-complete']);
+ * console.log(result.lockedCells.length); // 최대 3
+ * ```
+ */
+export const placeAreaLocks = (
+  puzzle: Grid,
+  solution: SolutionGrid,
+  count: number,
+  allowedTypes: LockConditionType[],
+): LockPlacementResult => {
+  if (count <= 0) {
+    return { lockedCells: [], puzzle: cloneGrid(puzzle) };
+  }
+
+  // 빈 칸 위치 수집 + 셔플
+  const emptyPositions: Position[] = [];
+  for (let r = 0; r < BOARD_SIZE; r++) {
+    for (let c = 0; c < BOARD_SIZE; c++) {
+      if (puzzle[r][c] === null) {
+        emptyPositions.push({ row: r, col: c });
+      }
+    }
+  }
+  const shuffled = shuffle(emptyPositions);
+
+  const lockedCells: LockedCell[] = [];
+  const lockedKeys = new Set<string>();
+  const workingPuzzle = cloneGrid(puzzle);
+
+  for (const pos of shuffled) {
+    if (lockedCells.length >= count) break;
+
+    // 이 위치에 조건 생성 시도
+    const condition = generateAreaCondition(workingPuzzle, pos, lockedKeys, allowedTypes);
+    if (!condition) continue;
+
+    // 잠금 추가
+    const key = posKey(pos.row, pos.col);
+    const candidateLocks = [...lockedCells, { position: pos, conditions: [condition] }];
+
+    // 검증: 잠금 포함 상태에서 풀이 가능한지 확인
+    if (validateSolvabilityWithLocks(workingPuzzle, solution, candidateLocks)) {
+      lockedKeys.add(key);
+      lockedCells.push({
+        position: pos,
+        conditions: [condition],
+      });
+    }
+  }
+
+  return {
+    lockedCells,
+    puzzle: workingPuzzle,
+  };
+};
+
+/**
+ * @internal 테스트 전용 export — 외부에서 직접 사용 금지
+ */
+export {
+  posKey,
+  cloneGrid,
+  shuffle,
+  getRowPositions,
+  getColPositions,
+  getBoxPositions,
+  getBoxIndex,
+  getAreaPositions,
+  countEmptyInArea,
+  createConditionDescription,
+  AREA_LOCK_TYPES,
+};


### PR DESCRIPTION
## Summary
- **잠금 칸 영역 조건 시스템** 구현: `row-complete`, `col-complete`, `box-complete` 3가지 조건 유형
- 조건 평가, 잠금 배치, 풀이 가능성 검증까지 완전한 파이프라인 구축
- 테스트 43개 전부 통과 (전체 엔진 121개 통과)

## 구현 목록

### lockSystem.ts — 주요 함수
| 함수 | 설명 |
|------|------|
| `isAreaConditionMet` | 행/열/박스 완성 여부 평가 (잠금 칸 제외) |
| `findUnlockableCells` | 모든 조건이 충족된 잠금 칸 탐색 |
| `generateAreaCondition` | 위치에 맞는 유효한 영역 조건 랜덤 생성 |
| `placeAreaLocks` | 퍼즐에 잠금 칸 N개 배치 + 풀이 검증 |
| `validateSolvabilityWithLocks` | 잠금 포함 유일해 보장 |

### 검증 전략
잠금 칸의 정답값을 given으로 넣은 테스트 그리드를 만들고, 나머지 빈 칸이 유일해를 가지는지 `hasUniqueSolution`으로 확인. 유일해가 있으면 플레이어가 모든 빈 칸을 채울 수 있고, 영역 조건이 자동 충족되어 잠금이 해제됨.

### 설계 원칙
- **순수 함수**: 모든 함수가 사이드 이펙트 없이 입력→출력만 처리
- **불변성**: `cloneGrid`로 원본 그리드 보호
- **조건 유효성**: 영역에 다른 빈 칸이 1개 이상일 때만 조건 생성

## 테스트 결과
```
Test Files  7 passed (7)
     Tests  121 passed (121)
  Duration  866ms
```

## 관련 이슈
- Epic #3 — 스도쿠 엔진 개발
- 다음 작업: `feat/engine-lock-number` (숫자 조건)

## Test plan
- [x] lockSystem.test.ts — 35개 순수 로직 테스트
- [x] lockSystem-placement.test.ts — 8개 배치 통합 테스트
- [x] 기존 엔진 테스트 78개 회귀 없음
- [x] pnpm lint: 0 errors
- [x] pnpm type-check: 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)