### PR TITLE
[Engine] feat/engine-lock-number — 숫자 완성 조건 + 공통 유틸리티 추출

### DIFF
--- a/__tests__/sudoku/generator.test.ts
+++ b/__tests__/sudoku/generator.test.ts
@@ -2,12 +2,11 @@ import { describe, it, expect } from 'vitest';
 import {
   generateSolution,
   isValidSolution,
-  canPlace,
   createEmptyGrid,
   fillGrid,
-  shuffle,
   BOARD_SIZE,
 } from '@/lib/sudoku/generator';
+import { shuffle, canPlaceInNumberGrid as canPlace } from '@/lib/sudoku/utils';
 import type { SolutionGrid } from '@/types/game';
 
 describe('generator', () => {

--- a/__tests__/sudoku/lockSystem-number-placement.test.ts
+++ b/__tests__/sudoku/lockSystem-number-placement.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import {
+  placeAreaLocks,
+} from '@/lib/sudoku/lockSystem';
+import { posKey } from '@/lib/sudoku/utils';
+import { generateSolution } from '@/lib/sudoku/generator';
+import { createPuzzleFromSolution, hasUniqueSolution } from '@/lib/sudoku/solver';
+
+// ─── placeAreaLocks with number-complete ─────────────
+// 생성 기반 통합 테스트 (시간이 걸릴 수 있으므로 별도 파일)
+
+describe('placeAreaLocks — number-complete', () => {
+  it('number-complete만 허용하면 숫자 조건만 생성된다', () => {
+    const solution = generateSolution();
+    const puzzle = createPuzzleFromSolution(solution, 35);
+    const result = placeAreaLocks(puzzle, solution, 2, ['number-complete']);
+
+    for (const lc of result.lockedCells) {
+      for (const cond of lc.conditions) {
+        expect(cond.type).toBe('number-complete');
+      }
+    }
+  }, 15000);
+
+  it('영역+숫자 혼합 허용 시 잠금 칸이 배치된다', () => {
+    const solution = generateSolution();
+    const puzzle = createPuzzleFromSolution(solution, 40);
+    const allowed = ['row-complete', 'col-complete', 'box-complete', 'number-complete'] as const;
+    const result = placeAreaLocks(puzzle, solution, 3, [...allowed]);
+
+    // 최소 1개 이상 배치
+    expect(result.lockedCells.length).toBeGreaterThanOrEqual(1);
+    expect(result.lockedCells.length).toBeLessThanOrEqual(3);
+  }, 15000);
+
+  it('숫자 조건의 target은 1~9이다', () => {
+    const solution = generateSolution();
+    const puzzle = createPuzzleFromSolution(solution, 35);
+    const result = placeAreaLocks(puzzle, solution, 3, ['number-complete']);
+
+    for (const lc of result.lockedCells) {
+      for (const cond of lc.conditions) {
+        expect(cond.target).toBeGreaterThanOrEqual(1);
+        expect(cond.target).toBeLessThanOrEqual(9);
+      }
+    }
+  }, 15000);
+
+  it('잠금 포함 퍼즐이 여전히 유일해를 가진다', () => {
+    const solution = generateSolution();
+    const puzzle = createPuzzleFromSolution(solution, 30);
+    const result = placeAreaLocks(
+      puzzle, solution, 2, ['number-complete'],
+    );
+
+    expect(hasUniqueSolution(result.puzzle)).toBe(true);
+  }, 15000);
+
+  it('잠금 칸끼리 위치가 중복되지 않는다', () => {
+    const solution = generateSolution();
+    const puzzle = createPuzzleFromSolution(solution, 40);
+    const result = placeAreaLocks(
+      puzzle, solution, 3, ['row-complete', 'col-complete', 'box-complete', 'number-complete'],
+    );
+
+    const keys = result.lockedCells.map((lc) => posKey(lc.position.row, lc.position.col));
+    const uniqueKeys = new Set(keys);
+    expect(uniqueKeys.size).toBe(keys.length);
+  }, 15000);
+
+  it('조건 설명이 비어있지 않다', () => {
+    const solution = generateSolution();
+    const puzzle = createPuzzleFromSolution(solution, 35);
+    const result = placeAreaLocks(
+      puzzle, solution, 2, ['number-complete'],
+    );
+
+    for (const lc of result.lockedCells) {
+      for (const cond of lc.conditions) {
+        expect(cond.description.length).toBeGreaterThan(0);
+      }
+    }
+  }, 15000);
+});

--- a/__tests__/sudoku/lockSystem-number.test.ts
+++ b/__tests__/sudoku/lockSystem-number.test.ts
@@ -1,0 +1,372 @@
+import { describe, it, expect } from 'vitest';
+import {
+  countDigitPlacements,
+  isNumberConditionMet,
+  generateNumberCondition,
+  generateCondition,
+  isAreaConditionMet,
+  findUnlockableCells,
+  createConditionDescription,
+} from '@/lib/sudoku/lockSystem';
+import { posKey } from '@/lib/sudoku/utils';
+import type { Grid, SolutionGrid, Digit, LockCondition, LockedCell } from '@/types/game';
+
+// ─── 헬퍼: 알려진 솔루션으로 퍼즐 생성 ────────────────
+
+/** 테스트용 완성 솔루션 (유효한 9×9 그리드) */
+const createTestSolution = (): SolutionGrid => [
+  [5, 3, 4, 6, 7, 8, 9, 1, 2],
+  [6, 7, 2, 1, 9, 5, 3, 4, 8],
+  [1, 9, 8, 3, 4, 2, 5, 6, 7],
+  [8, 5, 9, 7, 6, 1, 4, 2, 3],
+  [4, 2, 6, 8, 5, 3, 7, 9, 1],
+  [7, 1, 3, 9, 2, 4, 8, 5, 6],
+  [9, 6, 1, 5, 3, 7, 2, 8, 4],
+  [2, 8, 7, 4, 1, 9, 6, 3, 5],
+  [3, 4, 5, 2, 8, 6, 1, 7, 9],
+];
+
+/** 솔루션에서 특정 셀들만 비워 퍼즐을 만든다 */
+const createTestPuzzle = (
+  solution: SolutionGrid,
+  emptyPositions: [number, number][],
+): Grid => {
+  const grid: Grid = solution.map((row) => row.map((v) => v as Digit | null));
+  for (const [r, c] of emptyPositions) {
+    grid[r][c] = null;
+  }
+  return grid;
+};
+
+// ─── countDigitPlacements ──────────────────────────
+
+describe('countDigitPlacements', () => {
+  it('완성된 보드에서 각 숫자가 9번씩 나타난다', () => {
+    const solution = createTestSolution();
+    const grid: Grid = solution.map((row) => row.map((v) => v as Digit | null));
+    const lockedKeys = new Set<string>();
+
+    for (let d = 1; d <= 9; d++) {
+      expect(countDigitPlacements(grid, d as Digit, lockedKeys)).toBe(9);
+    }
+  });
+
+  it('빈 칸이 있으면 해당 숫자 카운트가 줄어든다', () => {
+    const solution = createTestSolution();
+    // 5가 있는 셀 몇 개를 비운다
+    // solution[0][0] = 5, solution[3][1] = 5, solution[5][7] = 5
+    const puzzle = createTestPuzzle(solution, [[0, 0], [3, 1], [5, 7]]);
+    const lockedKeys = new Set<string>();
+
+    expect(countDigitPlacements(puzzle, 5, lockedKeys)).toBe(6); // 9 - 3
+  });
+
+  it('잠금 칸은 카운트에서 제외된다', () => {
+    const solution = createTestSolution();
+    const grid: Grid = solution.map((row) => row.map((v) => v as Digit | null));
+    // (0,0)=5를 잠금 칸으로 설정
+    const lockedKeys = new Set<string>([posKey(0, 0)]);
+
+    // 5의 카운트가 8이 되어야 함 (잠금 칸 1개 제외)
+    expect(countDigitPlacements(grid, 5, lockedKeys)).toBe(8);
+  });
+
+  it('빈 보드에서 카운트가 0이다', () => {
+    const grid: Grid = Array.from({ length: 9 }, () => Array(9).fill(null));
+    const lockedKeys = new Set<string>();
+
+    expect(countDigitPlacements(grid, 1, lockedKeys)).toBe(0);
+  });
+});
+
+// ─── isNumberConditionMet ──────────────────────────
+
+describe('isNumberConditionMet', () => {
+  it('숫자가 9개 모두 배치되면 true', () => {
+    const solution = createTestSolution();
+    const grid: Grid = solution.map((row) => row.map((v) => v as Digit | null));
+    const lockedKeys = new Set<string>();
+
+    expect(isNumberConditionMet(grid, 5, lockedKeys)).toBe(true);
+  });
+
+  it('숫자가 9개 미만이면 false', () => {
+    const solution = createTestSolution();
+    // 5를 하나 제거: solution[0][0] = 5
+    const puzzle = createTestPuzzle(solution, [[0, 0]]);
+    const lockedKeys = new Set<string>();
+
+    expect(isNumberConditionMet(puzzle, 5, lockedKeys)).toBe(false);
+  });
+
+  it('잠금 칸의 숫자는 카운트하지 않으므로 조건 미충족', () => {
+    const solution = createTestSolution();
+    const grid: Grid = solution.map((row) => row.map((v) => v as Digit | null));
+    // (0,0)=5를 잠금 처리
+    const lockedKeys = new Set<string>([posKey(0, 0)]);
+
+    // 잠금 칸 빼면 5가 8개 → false
+    expect(isNumberConditionMet(grid, 5, lockedKeys)).toBe(false);
+  });
+
+  it('다른 숫자가 충족되어도 대상 숫자가 미충족이면 false', () => {
+    const solution = createTestSolution();
+    // 3을 하나 제거: solution[0][1] = 3
+    const puzzle = createTestPuzzle(solution, [[0, 1]]);
+    const lockedKeys = new Set<string>();
+
+    // 5는 여전히 9개 → true
+    expect(isNumberConditionMet(puzzle, 5, lockedKeys)).toBe(true);
+    // 3은 8개 → false
+    expect(isNumberConditionMet(puzzle, 3, lockedKeys)).toBe(false);
+  });
+});
+
+// ─── isAreaConditionMet with number-complete ───────
+
+describe('isAreaConditionMet — number-complete', () => {
+  it('number-complete 조건을 올바르게 평가한다', () => {
+    const solution = createTestSolution();
+    const grid: Grid = solution.map((row) => row.map((v) => v as Digit | null));
+    const lockedKeys = new Set<string>();
+
+    const condition: LockCondition = {
+      type: 'number-complete',
+      target: 7,
+      description: '숫자 7을(를) 모두 배치하세요',
+    };
+
+    expect(isAreaConditionMet(grid, condition, lockedKeys)).toBe(true);
+  });
+
+  it('숫자가 부족하면 number-complete 조건 미충족', () => {
+    const solution = createTestSolution();
+    // 7을 하나 제거: solution[0][4] = 7
+    const puzzle = createTestPuzzle(solution, [[0, 4]]);
+    const lockedKeys = new Set<string>();
+
+    const condition: LockCondition = {
+      type: 'number-complete',
+      target: 7,
+      description: '숫자 7을(를) 모두 배치하세요',
+    };
+
+    expect(isAreaConditionMet(puzzle, condition, lockedKeys)).toBe(false);
+  });
+});
+
+// ─── generateNumberCondition ───────────────────────
+
+describe('generateNumberCondition', () => {
+  it('아직 완성되지 않은 숫자를 조건으로 생성한다', () => {
+    const solution = createTestSolution();
+    // 여러 셀을 비워 미완성 숫자 생성
+    const puzzle = createTestPuzzle(solution, [
+      [0, 0], // 5
+      [0, 1], // 3
+      [0, 2], // 4
+      [1, 0], // 6
+      [1, 1], // 7
+    ]);
+    const lockedKeys = new Set<string>();
+
+    const condition = generateNumberCondition(puzzle, { row: 2, col: 0 }, solution, lockedKeys);
+
+    expect(condition).not.toBeNull();
+    expect(condition!.type).toBe('number-complete');
+    // target은 1~9의 숫자
+    expect(condition!.target).toBeGreaterThanOrEqual(1);
+    expect(condition!.target).toBeLessThanOrEqual(9);
+    expect(condition!.description.length).toBeGreaterThan(0);
+  });
+
+  it('생성된 조건의 target 숫자는 아직 9개 미만이다', () => {
+    const solution = createTestSolution();
+    // 5를 2개 비움: [0,0]=5, [3,1]=5
+    const puzzle = createTestPuzzle(solution, [[0, 0], [3, 1]]);
+    const lockedKeys = new Set<string>();
+
+    // 반복하여 생성된 조건의 target 확인
+    for (let i = 0; i < 20; i++) {
+      const condition = generateNumberCondition(puzzle, { row: 5, col: 7 }, solution, lockedKeys);
+      if (condition) {
+        // target 숫자는 보드에 9개 미만이어야 함
+        const count = countDigitPlacements(puzzle, condition.target as Digit, new Set([...lockedKeys, posKey(5, 7)]));
+        expect(count).toBeLessThan(9);
+        expect(count).toBeGreaterThanOrEqual(1);
+      }
+    }
+  });
+
+  it('완성된 보드에서도 잠금 대상 셀의 숫자가 후보가 된다', () => {
+    const solution = createTestSolution();
+    // 빈 칸 없이 완성된 보드
+    const grid: Grid = solution.map((row) => row.map((v) => v as Digit | null));
+    const lockedKeys = new Set<string>();
+
+    // (0,0)=5를 잠금 대상으로 지정하면, 5는 잠금 칸 제외 시 8개 → 후보
+    const condition = generateNumberCondition(grid, { row: 0, col: 0 }, solution, lockedKeys);
+    expect(condition).not.toBeNull();
+    // 잠금 대상 셀의 숫자(5)만 후보가 됨 (다른 숫자는 여전히 9개)
+    expect(condition!.target).toBe(5);
+  });
+
+  it('모든 셀이 이미 잠금 처리되면 null을 반환한다', () => {
+    const solution = createTestSolution();
+    const grid: Grid = solution.map((row) => row.map((v) => v as Digit | null));
+    // 모든 셀을 잠금 처리
+    const lockedKeys = new Set<string>();
+    for (let r = 0; r < 9; r++) {
+      for (let c = 0; c < 9; c++) {
+        lockedKeys.add(posKey(r, c));
+      }
+    }
+
+    const condition = generateNumberCondition(grid, { row: 0, col: 0 }, solution, lockedKeys);
+    expect(condition).toBeNull();
+  });
+});
+
+// ─── generateCondition — 통합 조건 생성기 ──────────
+
+describe('generateCondition', () => {
+  it('영역 조건만 허용하면 영역 조건을 생성한다', () => {
+    const solution = createTestSolution();
+    const puzzle = createTestPuzzle(solution, [
+      [0, 0], [0, 1], [0, 2],
+      [1, 0], [1, 1],
+    ]);
+    const lockedKeys = new Set<string>();
+
+    for (let i = 0; i < 20; i++) {
+      const cond = generateCondition(puzzle, { row: 2, col: 0 }, lockedKeys, ['row-complete', 'col-complete', 'box-complete'], solution);
+      if (cond) {
+        expect(['row-complete', 'col-complete', 'box-complete']).toContain(cond.type);
+      }
+    }
+  });
+
+  it('number-complete만 허용하면 숫자 조건을 생성한다', () => {
+    const solution = createTestSolution();
+    const puzzle = createTestPuzzle(solution, [
+      [0, 0], [0, 1], [0, 2], [1, 0], [1, 1],
+    ]);
+    const lockedKeys = new Set<string>();
+
+    for (let i = 0; i < 20; i++) {
+      const cond = generateCondition(puzzle, { row: 2, col: 0 }, lockedKeys, ['number-complete'], solution);
+      if (cond) {
+        expect(cond.type).toBe('number-complete');
+      }
+    }
+  });
+
+  it('number-complete가 허용되지만 solution이 없으면 숫자 조건을 생성하지 않는다', () => {
+    const solution = createTestSolution();
+    const puzzle = createTestPuzzle(solution, [
+      [0, 0], [0, 1], [0, 2], [1, 0], [1, 1],
+    ]);
+    const lockedKeys = new Set<string>();
+
+    for (let i = 0; i < 20; i++) {
+      const cond = generateCondition(puzzle, { row: 2, col: 0 }, lockedKeys, ['number-complete']);
+      if (cond) {
+        // solution 없이는 number-complete가 생성 안 됨 → 이 경우 null
+        expect(cond.type).not.toBe('number-complete');
+      }
+    }
+  });
+
+  it('영역+숫자 혼합 허용 시 두 유형 모두 생성 가능하다', () => {
+    const solution = createTestSolution();
+    const puzzle = createTestPuzzle(solution, [
+      [0, 0], [0, 1], [0, 2], [0, 3],
+      [1, 0], [1, 1], [1, 2],
+      [2, 0], [2, 1],
+    ]);
+    const lockedKeys = new Set<string>();
+    const allTypes = ['row-complete', 'col-complete', 'box-complete', 'number-complete'] as const;
+
+    const types = new Set<string>();
+    for (let i = 0; i < 100; i++) {
+      const cond = generateCondition(
+        puzzle, { row: 3, col: 0 }, lockedKeys,
+        [...allTypes], solution,
+      );
+      if (cond) types.add(cond.type);
+    }
+
+    // 두 카테고리 모두 한 번 이상은 나와야 함 (확률적, 100회면 충분)
+    const hasAreaType = [...types].some((t) => ['row-complete', 'col-complete', 'box-complete'].includes(t));
+    const hasNumberType = types.has('number-complete');
+    expect(hasAreaType).toBe(true);
+    expect(hasNumberType).toBe(true);
+  });
+});
+
+// ─── createConditionDescription — number-complete ──
+
+describe('createConditionDescription — number-complete', () => {
+  it('숫자 조건 설명이 올바르다', () => {
+    const desc = createConditionDescription('number-complete', 5);
+    expect(desc).toBe('숫자 5을(를) 모두 배치하세요');
+  });
+
+  it('1~9 모든 숫자에 대해 설명을 생성한다', () => {
+    for (let d = 1; d <= 9; d++) {
+      const desc = createConditionDescription('number-complete', d);
+      expect(desc).toContain(`${d}`);
+      expect(desc.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ─── findUnlockableCells with number-complete ──────
+
+describe('findUnlockableCells — number-complete', () => {
+  it('숫자 조건 충족 시 잠금 칸이 해제 가능하다', () => {
+    const solution = createTestSolution();
+    const grid: Grid = solution.map((row) => row.map((v) => v as Digit | null));
+    // 모든 숫자가 완성 → number-complete 조건 충족
+
+    const lockedCells: LockedCell[] = [
+      {
+        position: { row: 0, col: 0 },
+        conditions: [{
+          type: 'number-complete',
+          target: 5,
+          description: '숫자 5을(를) 모두 배치하세요',
+        }],
+      },
+    ];
+
+    // 잠금 칸 자체는 카운트에서 제외되므로, grid에 5가 9개 있어도
+    // 잠금 칸(0,0)=5를 빼면 8개 → 조건 미충족
+    // 하지만 grid[0][0]=5이고 잠금 칸이 (0,0)이면,
+    // countDigitPlacements는 잠금 칸 제외하므로 5는 8개 → false
+    const unlockable = findUnlockableCells(grid, lockedCells);
+    expect(unlockable).toHaveLength(0); // 잠금 칸 자체의 5를 제외하면 8개
+  });
+
+  it('잠금 칸 외 나머지 셀로 숫자가 완성되면 해제된다', () => {
+    const solution = createTestSolution();
+    const grid: Grid = solution.map((row) => row.map((v) => v as Digit | null));
+    // grid에 5가 총 9개. 잠금 칸(2,4)=4이므로 5에 영향 없음
+    // → countDigitPlacements(grid, 5, locked(2,4)) = 9 → true
+
+    const lockedCells: LockedCell[] = [
+      {
+        position: { row: 2, col: 4 }, // solution[2][4] = 4 (5가 아님)
+        conditions: [{
+          type: 'number-complete',
+          target: 5,
+          description: '숫자 5을(를) 모두 배치하세요',
+        }],
+      },
+    ];
+
+    const unlockable = findUnlockableCells(grid, lockedCells);
+    expect(unlockable).toHaveLength(1);
+    expect(unlockable[0].position).toEqual({ row: 2, col: 4 });
+  });
+});

--- a/__tests__/sudoku/lockSystem-placement.test.ts
+++ b/__tests__/sudoku/lockSystem-placement.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from 'vitest';
 import {
   placeAreaLocks,
-  posKey,
 } from '@/lib/sudoku/lockSystem';
+import { posKey } from '@/lib/sudoku/utils';
 import { generateSolution } from '@/lib/sudoku/generator';
 import { createPuzzleFromSolution, hasUniqueSolution } from '@/lib/sudoku/solver';
 

--- a/__tests__/sudoku/lockSystem.test.ts
+++ b/__tests__/sudoku/lockSystem.test.ts
@@ -4,18 +4,17 @@ import {
   findUnlockableCells,
   generateAreaCondition,
   validateSolvabilityWithLocks,
-  posKey,
   getRowPositions,
   getColPositions,
   getBoxPositions,
-  getBoxIndex,
   getAreaPositions,
   countEmptyInArea,
   createConditionDescription,
 } from '@/lib/sudoku/lockSystem';
+import { posKey, getBoxIndex } from '@/lib/sudoku/utils';
 import { generateSolution } from '@/lib/sudoku/generator';
 import { createPuzzleFromSolution } from '@/lib/sudoku/solver';
-import type { Grid, LockedCell, LockCondition } from '@/types/game';
+import type { Grid, LockedCell, LockCondition, LockConditionType } from '@/types/game';
 
 // ─── posKey ─────────────────────────────────────────
 
@@ -150,10 +149,16 @@ describe('isAreaConditionMet', () => {
     expect(isAreaConditionMet(grid, condition, lockedKeys)).toBe(true);
   });
 
-  it('영역 조건이 아닌 유형은 false를 반환한다', () => {
+  it('미지원 조건 유형은 false를 반환한다', () => {
+    const grid: Grid = Array.from({ length: 9 }, () => Array(9).fill(1));
+    const condition: LockCondition = { type: 'cell-fill' as LockConditionType, target: 0, description: '' };
+    expect(isAreaConditionMet(grid, condition, new Set())).toBe(false);
+  });
+
+  it('number-complete 조건이 충족되면 true를 반환한다', () => {
     const grid: Grid = Array.from({ length: 9 }, () => Array(9).fill(1));
     const condition: LockCondition = { type: 'number-complete', target: 1, description: '' };
-    expect(isAreaConditionMet(grid, condition, new Set())).toBe(false);
+    expect(isAreaConditionMet(grid, condition, new Set())).toBe(true);
   });
 });
 

--- a/src/lib/sudoku/generator.ts
+++ b/src/lib/sudoku/generator.ts
@@ -138,7 +138,3 @@ export const isValidSolution = (grid: SolutionGrid): boolean => {
  */
 export { createEmptyGrid, fillGrid, BOARD_SIZE, BOX_SIZE, DIGITS };
 
-/**
- * @deprecated 테스트 호환용 re-export — 새 코드에서는 utils에서 직접 import
- */
-export { shuffle, canPlaceInNumberGrid as canPlace } from '@/lib/sudoku/utils';

--- a/src/lib/sudoku/generator.ts
+++ b/src/lib/sudoku/generator.ts
@@ -11,64 +11,13 @@
  */
 
 import type { Digit, SolutionGrid } from '@/types/game';
-
-/** 유효한 숫자 목록 */
-const DIGITS: Digit[] = [1, 2, 3, 4, 5, 6, 7, 8, 9];
-
-/** 보드 크기 */
-const BOARD_SIZE = 9;
-
-/** 3×3 박스 크기 */
-const BOX_SIZE = 3;
-
-/**
- * 배열을 Fisher-Yates 알고리즘으로 셔플한다 (불변 — 새 배열 반환).
- */
-const shuffle = <T>(arr: readonly T[]): T[] => {
-  const result = [...arr];
-  for (let i = result.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [result[i], result[j]] = [result[j], result[i]];
-  }
-  return result;
-};
-
-/**
- * 특정 위치에 숫자를 놓을 수 있는지 검사한다.
- *
- * @param grid - 현재 그리드 (number[][] — 0은 빈 칸)
- * @param row - 행 인덱스 (0~8)
- * @param col - 열 인덱스 (0~8)
- * @param num - 놓으려는 숫자 (1~9)
- * @returns 배치 가능 여부
- */
-const canPlace = (
-  grid: number[][],
-  row: number,
-  col: number,
-  num: number,
-): boolean => {
-  // 행 검사
-  for (let c = 0; c < BOARD_SIZE; c++) {
-    if (grid[row][c] === num) return false;
-  }
-
-  // 열 검사
-  for (let r = 0; r < BOARD_SIZE; r++) {
-    if (grid[r][col] === num) return false;
-  }
-
-  // 3×3 박스 검사
-  const boxRow = Math.floor(row / BOX_SIZE) * BOX_SIZE;
-  const boxCol = Math.floor(col / BOX_SIZE) * BOX_SIZE;
-  for (let r = boxRow; r < boxRow + BOX_SIZE; r++) {
-    for (let c = boxCol; c < boxCol + BOX_SIZE; c++) {
-      if (grid[r][c] === num) return false;
-    }
-  }
-
-  return true;
-};
+import {
+  BOARD_SIZE,
+  BOX_SIZE,
+  DIGITS,
+  shuffle,
+  canPlaceInNumberGrid,
+} from '@/lib/sudoku/utils';
 
 /**
  * 빈 9×9 그리드를 생성한다 (0으로 채움).
@@ -89,7 +38,7 @@ const fillGrid = (grid: number[][]): boolean => {
 
       const candidates = shuffle(DIGITS);
       for (const num of candidates) {
-        if (canPlace(grid, row, col, num)) {
+        if (canPlaceInNumberGrid(grid, row, col, num)) {
           grid[row][col] = num;
           if (fillGrid(grid)) return true;
           grid[row][col] = 0;
@@ -103,10 +52,6 @@ const fillGrid = (grid: number[][]): boolean => {
 
 /**
  * number[][] 그리드를 SolutionGrid(Digit[][])로 변환한다.
- *
- * @param grid - 완성된 그리드 (1~9만 포함)
- * @returns SolutionGrid 타입의 그리드
- * @throws 유효하지 않은 값이 있으면 에러
  */
 const toSolutionGrid = (grid: number[][]): SolutionGrid => {
   return grid.map((row) =>
@@ -148,13 +93,11 @@ export const generateSolution = (): SolutionGrid => {
  * @returns 유효 여부
  */
 export const isValidSolution = (grid: SolutionGrid): boolean => {
-  // 크기 검사
   if (grid.length !== BOARD_SIZE) return false;
   for (const row of grid) {
     if (row.length !== BOARD_SIZE) return false;
   }
 
-  // 행 검사
   for (let r = 0; r < BOARD_SIZE; r++) {
     const seen = new Set<number>();
     for (let c = 0; c < BOARD_SIZE; c++) {
@@ -164,7 +107,6 @@ export const isValidSolution = (grid: SolutionGrid): boolean => {
     }
   }
 
-  // 열 검사
   for (let c = 0; c < BOARD_SIZE; c++) {
     const seen = new Set<number>();
     for (let r = 0; r < BOARD_SIZE; r++) {
@@ -174,7 +116,6 @@ export const isValidSolution = (grid: SolutionGrid): boolean => {
     }
   }
 
-  // 3×3 박스 검사
   for (let boxRow = 0; boxRow < BOARD_SIZE; boxRow += BOX_SIZE) {
     for (let boxCol = 0; boxCol < BOARD_SIZE; boxCol += BOX_SIZE) {
       const seen = new Set<number>();
@@ -195,4 +136,9 @@ export const isValidSolution = (grid: SolutionGrid): boolean => {
  * @internal 테스트 전용 export — 외부에서 직접 사용 금지
  * fillGrid는 grid를 in-place 수정하므로 주의 필요
  */
-export { canPlace, shuffle, createEmptyGrid, fillGrid, BOARD_SIZE, BOX_SIZE, DIGITS };
+export { createEmptyGrid, fillGrid, BOARD_SIZE, BOX_SIZE, DIGITS };
+
+/**
+ * @deprecated 테스트 호환용 re-export — 새 코드에서는 utils에서 직접 import
+ */
+export { shuffle, canPlaceInNumberGrid as canPlace } from '@/lib/sudoku/utils';

--- a/src/lib/sudoku/lockSystem.ts
+++ b/src/lib/sudoku/lockSystem.ts
@@ -1,12 +1,13 @@
 /**
- * 잠금 칸 시스템 — 영역 조건 (행/열/박스)
- * 특정 영역을 완성하면 잠금 칸이 해제되는 시스템을 구현한다.
+ * 잠금 칸 시스템 — 영역 조건 + 숫자 조건
+ * 특정 영역 완성 또는 숫자 완성 시 잠금 칸이 해제되는 시스템을 구현한다.
  *
  * @description
  * 1. 영역 조건: row-complete, col-complete, box-complete
- * 2. 잠금 칸은 빈 칸 중에서 선택하여 조건을 부여
- * 3. 잠금 포함 상태에서도 퍼즐이 풀이 가능해야 함
- * 4. 순수 함수 — 사이드 이펙트 없음
+ * 2. 숫자 조건: number-complete (특정 숫자 9개 모두 배치)
+ * 3. 잠금 칸은 빈 칸 중에서 선택하여 조건을 부여
+ * 4. 잠금 포함 상태에서도 퍼즐이 풀이 가능해야 함
+ * 5. 순수 함수 — 사이드 이펙트 없음
  *
  * @see GitHub Issue #3 — Epic: 스도쿠 엔진 개발
  */
@@ -19,30 +20,10 @@ import type {
   LockCondition,
   LockConditionType,
   CellValue,
+  Digit,
 } from '@/types/game';
-import { BOARD_SIZE, BOX_SIZE } from '@/lib/sudoku/generator';
+import { BOARD_SIZE, BOX_SIZE, DIGITS, cloneGrid, shuffle, posKey, getBoxIndex } from '@/lib/sudoku/utils';
 import { hasUniqueSolution } from '@/lib/sudoku/solver';
-
-// ─── 유틸 ───────────────────────────────────────────
-
-/** Position을 문자열 키로 변환 */
-const posKey = (row: number, col: number): string => `${row},${col}`;
-
-/** Grid를 깊은 복사한다 */
-const cloneGrid = (grid: Grid): Grid =>
-  grid.map((row) => [...row]);
-
-/**
- * 배열을 Fisher-Yates 알고리즘으로 셔플한다 (불변 — 새 배열 반환).
- */
-const shuffle = <T>(arr: readonly T[]): T[] => {
-  const result = [...arr];
-  for (let i = result.length - 1; i > 0; i--) {
-    const j = Math.floor(Math.random() * (i + 1));
-    [result[i], result[j]] = [result[j], result[i]];
-  }
-  return result;
-};
 
 // ─── 영역 조회 ──────────────────────────────────────
 
@@ -73,12 +54,6 @@ const getBoxPositions = (boxIndex: number): Position[] => {
   }
   return positions;
 };
-
-/**
- * 셀이 속한 3×3 박스 인덱스를 반환한다.
- */
-const getBoxIndex = (row: number, col: number): number =>
-  Math.floor(row / BOX_SIZE) * BOX_SIZE + Math.floor(col / BOX_SIZE);
 
 /**
  * 조건 유형에 따른 영역 셀 위치를 반환한다.
@@ -129,12 +104,98 @@ export const isAreaConditionMet = (
 ): boolean => {
   const { type, target } = condition;
 
+  if (type === 'number-complete') {
+    return isNumberConditionMet(grid, target as Digit, lockedKeys);
+  }
+
   if (type !== 'row-complete' && type !== 'col-complete' && type !== 'box-complete') {
-    return false; // 영역 조건이 아닌 경우
+    return false; // 미지원 조건 유형
   }
 
   const positions = getAreaPositions(type, target);
   return countEmptyInArea(grid, positions, lockedKeys) === 0;
+};
+
+// ─── 숫자 조건 평가 ─────────────────────────────────
+
+/**
+ * 보드에서 특정 숫자가 나타나야 할 총 횟수(9) 대비 현재 채워진 수를 센다.
+ * 잠금 칸은 제외한다.
+ *
+ * @param grid - 현재 보드
+ * @param digit - 대상 숫자 (1~9)
+ * @param lockedKeys - 잠금 칸 키 Set
+ * @returns 해당 숫자가 채워진 횟수 (잠금 칸 제외)
+ */
+export const countDigitPlacements = (
+  grid: Grid,
+  digit: Digit,
+  lockedKeys: Set<string>,
+): number => {
+  let count = 0;
+  for (let r = 0; r < BOARD_SIZE; r++) {
+    for (let c = 0; c < BOARD_SIZE; c++) {
+      if (lockedKeys.has(posKey(r, c))) continue;
+      if (grid[r][c] === digit) count++;
+    }
+  }
+  return count;
+};
+
+/**
+ * 숫자 완성 조건이 충족되었는지 검사한다.
+ * 특정 숫자가 보드에 9번 모두 배치되면(잠금 칸 제외) true.
+ *
+ * @param grid - 현재 보드 상태
+ * @param digit - 대상 숫자
+ * @param lockedKeys - 잠금 칸 키 Set
+ * @returns 조건 충족 여부
+ */
+export const isNumberConditionMet = (
+  grid: Grid,
+  digit: Digit,
+  lockedKeys: Set<string>,
+): boolean => {
+  return countDigitPlacements(grid, digit, lockedKeys) >= BOARD_SIZE;
+};
+
+/**
+ * 특정 위치에 대해 유효한 숫자 조건을 생성한다.
+ * 잠금 칸이 가진 정답 숫자가 아닌, 보드에 아직 완성되지 않은 다른 숫자를 조건으로 선택.
+ *
+ * @param grid - 퍼즐 그리드
+ * @param pos - 잠금 칸 위치
+ * @param solution - 정답 그리드
+ * @param lockedKeys - 이미 잠긴 셀 키 Set
+ * @returns 유효한 숫자 조건 또는 null
+ */
+export const generateNumberCondition = (
+  grid: Grid,
+  pos: Position,
+  solution: SolutionGrid,
+  lockedKeys: Set<string>,
+): LockCondition | null => {
+  const updatedLockedKeys = new Set(lockedKeys);
+  updatedLockedKeys.add(posKey(pos.row, pos.col));
+
+  // 아직 보드에 9개 미만인 숫자 후보를 수집
+  const candidates: Digit[] = [];
+  for (const d of DIGITS) {
+    const placed = countDigitPlacements(grid, d, updatedLockedKeys);
+    // 이미 완성된 숫자는 제외, 최소 1개 이상 채워진 숫자만 선택 (너무 어렵지 않게)
+    if (placed >= 1 && placed < BOARD_SIZE) {
+      candidates.push(d);
+    }
+  }
+
+  if (candidates.length === 0) return null;
+
+  const digit = candidates[Math.floor(Math.random() * candidates.length)];
+  return {
+    type: 'number-complete',
+    target: digit,
+    description: createConditionDescription('number-complete', digit),
+  };
 };
 
 /**
@@ -175,38 +236,39 @@ const createConditionDescription = (type: LockConditionType, target: number): st
       const boxCol = (target % 3) + 1;
       return `${boxRow}-${boxCol} 박스를 완성하세요`;
     }
+    case 'number-complete': return `숫자 ${target}을(를) 모두 배치하세요`;
     default: return '';
   }
 };
 
 /**
- * 특정 위치에 대해 유효한 영역 조건을 생성한다.
- * 잠금 칸이 속한 영역 중, 다른 빈 칸이 1개 이상인 영역을 조건으로 선택.
+ * 특정 위치에 대해 유효한 조건을 생성한다 (영역 + 숫자 조건 통합).
+ * 허용된 유형 중에서 유효한 조건을 랜덤 선택.
  *
  * @param grid - 퍼즐 그리드
  * @param pos - 잠금 칸 위치
  * @param lockedKeys - 이미 잠긴 셀 키 Set
  * @param allowedTypes - 허용된 조건 유형
+ * @param solution - 정답 그리드 (number-complete 조건 생성 시 필요)
  * @returns 유효한 조건 또는 null
  */
-export const generateAreaCondition = (
+export const generateCondition = (
   grid: Grid,
   pos: Position,
   lockedKeys: Set<string>,
   allowedTypes: LockConditionType[],
+  solution?: SolutionGrid,
 ): LockCondition | null => {
-  const areaTypes = allowedTypes.filter(
-    (t): t is 'row-complete' | 'col-complete' | 'box-complete' => AREA_LOCK_TYPES.includes(t),
-  );
-
-  if (areaTypes.length === 0) return null;
+  const candidates: LockCondition[] = [];
 
   // 이 셀을 잠금 후보로 추가
   const updatedLockedKeys = new Set(lockedKeys);
   updatedLockedKeys.add(posKey(pos.row, pos.col));
 
-  // 가능한 조건 후보 수집
-  const candidates: LockCondition[] = [];
+  // 영역 조건 후보
+  const areaTypes = allowedTypes.filter(
+    (t): t is 'row-complete' | 'col-complete' | 'box-complete' => AREA_LOCK_TYPES.includes(t),
+  );
 
   for (const type of areaTypes) {
     let target: number;
@@ -219,7 +281,6 @@ export const generateAreaCondition = (
     const positions = getAreaPositions(type, target);
     const emptyCount = countEmptyInArea(grid, positions, updatedLockedKeys);
 
-    // 영역에 다른 빈 칸이 1개 이상이어야 의미 있는 조건
     if (emptyCount >= 1) {
       candidates.push({
         type,
@@ -229,10 +290,35 @@ export const generateAreaCondition = (
     }
   }
 
+  // 숫자 조건 후보
+  if (allowedTypes.includes('number-complete') && solution) {
+    for (const d of DIGITS) {
+      const placed = countDigitPlacements(grid, d, updatedLockedKeys);
+      if (placed >= 1 && placed < BOARD_SIZE) {
+        candidates.push({
+          type: 'number-complete',
+          target: d,
+          description: createConditionDescription('number-complete', d),
+        });
+      }
+    }
+  }
+
   if (candidates.length === 0) return null;
 
-  // 랜덤 선택
   return candidates[Math.floor(Math.random() * candidates.length)];
+};
+
+/**
+ * @deprecated generateCondition으로 대체. 하위 호환용.
+ */
+export const generateAreaCondition = (
+  grid: Grid,
+  pos: Position,
+  lockedKeys: Set<string>,
+  allowedTypes: LockConditionType[],
+): LockCondition | null => {
+  return generateCondition(grid, pos, lockedKeys, allowedTypes);
 };
 
 // ─── 풀이 가능성 검증 ───────────────────────────────
@@ -329,7 +415,7 @@ export const placeAreaLocks = (
     if (lockedCells.length >= count) break;
 
     // 이 위치에 조건 생성 시도
-    const condition = generateAreaCondition(workingPuzzle, pos, lockedKeys, allowedTypes);
+    const condition = generateCondition(workingPuzzle, pos, lockedKeys, allowedTypes, solution);
     if (!condition) continue;
 
     // 잠금 추가
@@ -354,15 +440,13 @@ export const placeAreaLocks = (
 
 /**
  * @internal 테스트 전용 export — 외부에서 직접 사용 금지
+ * countDigitPlacements, isNumberConditionMet, generateNumberCondition은
+ * 이미 export const로 선언되어 있으므로 여기에 중복하지 않음.
  */
 export {
-  posKey,
-  cloneGrid,
-  shuffle,
   getRowPositions,
   getColPositions,
   getBoxPositions,
-  getBoxIndex,
   getAreaPositions,
   countEmptyInArea,
   createConditionDescription,

--- a/src/lib/sudoku/lockSystem.ts
+++ b/src/lib/sudoku/lockSystem.ts
@@ -160,6 +160,30 @@ export const isNumberConditionMet = (
 };
 
 /**
+ * 숫자 조건 후보를 수집한다.
+ * 보드에 1개 이상 배치되었지만 9개 미만인 숫자만 반환한다.
+ * 보드에 아예 없는 숫자(0개)는 제외 — 완전히 빈 숫자를 조건으로 쓰면
+ * 플레이어가 해당 숫자를 처음부터 전부 채워야 하므로 난이도 조절상 제외한다.
+ *
+ * @param grid - 퍼즐 그리드
+ * @param lockedKeys - 잠금 칸 키 Set (해당 셀 포함)
+ * @returns 후보 숫자 배열
+ */
+const getNumberConditionCandidates = (
+  grid: Grid,
+  lockedKeys: Set<string>,
+): Digit[] => {
+  const candidates: Digit[] = [];
+  for (const d of DIGITS) {
+    const placed = countDigitPlacements(grid, d, lockedKeys);
+    if (placed >= 1 && placed < BOARD_SIZE) {
+      candidates.push(d);
+    }
+  }
+  return candidates;
+};
+
+/**
  * 특정 위치에 대해 유효한 숫자 조건을 생성한다.
  * 잠금 칸이 가진 정답 숫자가 아닌, 보드에 아직 완성되지 않은 다른 숫자를 조건으로 선택.
  *
@@ -178,16 +202,7 @@ export const generateNumberCondition = (
   const updatedLockedKeys = new Set(lockedKeys);
   updatedLockedKeys.add(posKey(pos.row, pos.col));
 
-  // 아직 보드에 9개 미만인 숫자 후보를 수집
-  const candidates: Digit[] = [];
-  for (const d of DIGITS) {
-    const placed = countDigitPlacements(grid, d, updatedLockedKeys);
-    // 이미 완성된 숫자는 제외, 최소 1개 이상 채워진 숫자만 선택 (너무 어렵지 않게)
-    if (placed >= 1 && placed < BOARD_SIZE) {
-      candidates.push(d);
-    }
-  }
-
+  const candidates = getNumberConditionCandidates(grid, updatedLockedKeys);
   if (candidates.length === 0) return null;
 
   const digit = candidates[Math.floor(Math.random() * candidates.length)];
@@ -291,10 +306,14 @@ export const generateCondition = (
   }
 
   // 숫자 조건 후보
-  if (allowedTypes.includes('number-complete') && solution) {
-    for (const d of DIGITS) {
-      const placed = countDigitPlacements(grid, d, updatedLockedKeys);
-      if (placed >= 1 && placed < BOARD_SIZE) {
+  if (allowedTypes.includes('number-complete')) {
+    if (!solution) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.warn('[lockSystem] number-complete 조건 생성에는 solution 파라미터가 필요합니다.');
+      }
+    } else {
+      const numberCandidates = getNumberConditionCandidates(grid, updatedLockedKeys);
+      for (const d of numberCandidates) {
         candidates.push({
           type: 'number-complete',
           target: d,

--- a/src/lib/sudoku/solver.ts
+++ b/src/lib/sudoku/solver.ts
@@ -11,46 +11,7 @@
  */
 
 import type { CellValue, Digit, Grid, SolutionGrid, SolveResult } from '@/types/game';
-import { BOARD_SIZE, BOX_SIZE, DIGITS } from '@/lib/sudoku/generator';
-
-// ─── 내부 유틸 ──────────────────────────────────────
-
-/**
- * Grid를 깊은 복사한다.
- */
-const cloneGrid = (grid: Grid): Grid =>
-  grid.map((row) => [...row]);
-
-/**
- * 특정 위치에 숫자를 놓을 수 있는지 검사한다. (Grid 타입용)
- *
- * @todo generator.ts의 canPlace와 로직 중복 — 추후 공통 유틸로 통합 예정
- *       (현재는 Grid(CellValue[][]) vs number[][] 타입 차이로 분리)
- */
-const canPlaceInGrid = (
-  grid: Grid,
-  row: number,
-  col: number,
-  num: Digit,
-): boolean => {
-  // 행 검사
-  for (let c = 0; c < BOARD_SIZE; c++) {
-    if (grid[row][c] === num) return false;
-  }
-  // 열 검사
-  for (let r = 0; r < BOARD_SIZE; r++) {
-    if (grid[r][col] === num) return false;
-  }
-  // 3×3 박스 검사
-  const boxRow = Math.floor(row / BOX_SIZE) * BOX_SIZE;
-  const boxCol = Math.floor(col / BOX_SIZE) * BOX_SIZE;
-  for (let r = boxRow; r < boxRow + BOX_SIZE; r++) {
-    for (let c = boxCol; c < boxCol + BOX_SIZE; c++) {
-      if (grid[r][c] === num) return false;
-    }
-  }
-  return true;
-};
+import { BOARD_SIZE, BOX_SIZE, DIGITS, cloneGrid, canPlaceInGrid } from '@/lib/sudoku/utils';
 
 /**
  * 특정 셀의 후보 숫자 목록을 구한다.

--- a/src/lib/sudoku/utils.ts
+++ b/src/lib/sudoku/utils.ts
@@ -1,0 +1,100 @@
+/**
+ * 스도쿠 엔진 공통 유틸리티
+ * generator, solver, lockSystem 등에서 공통으로 사용하는 함수들.
+ *
+ * @see GitHub Issue #3 — Epic: 스도쿠 엔진 개발
+ */
+
+import type { Grid, Digit } from '@/types/game';
+
+/** 보드 크기 */
+export const BOARD_SIZE = 9;
+
+/** 3×3 박스 크기 */
+export const BOX_SIZE = 3;
+
+/** 유효한 숫자 목록 */
+export const DIGITS: Digit[] = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+/**
+ * Grid를 깊은 복사한다.
+ */
+export const cloneGrid = (grid: Grid): Grid =>
+  grid.map((row) => [...row]);
+
+/**
+ * 배열을 Fisher-Yates 알고리즘으로 셔플한다 (불변 — 새 배열 반환).
+ */
+export const shuffle = <T>(arr: readonly T[]): T[] => {
+  const result = [...arr];
+  for (let i = result.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [result[i], result[j]] = [result[j], result[i]];
+  }
+  return result;
+};
+
+/**
+ * Position을 문자열 키로 변환한다.
+ */
+export const posKey = (row: number, col: number): string => `${row},${col}`;
+
+/**
+ * 특정 위치에 숫자를 놓을 수 있는지 검사한다 (Grid 타입용, null=빈칸).
+ */
+export const canPlaceInGrid = (
+  grid: Grid,
+  row: number,
+  col: number,
+  num: Digit,
+): boolean => {
+  // 행 검사
+  for (let c = 0; c < BOARD_SIZE; c++) {
+    if (grid[row][c] === num) return false;
+  }
+  // 열 검사
+  for (let r = 0; r < BOARD_SIZE; r++) {
+    if (grid[r][col] === num) return false;
+  }
+  // 3×3 박스 검사
+  const boxRow = Math.floor(row / BOX_SIZE) * BOX_SIZE;
+  const boxCol = Math.floor(col / BOX_SIZE) * BOX_SIZE;
+  for (let r = boxRow; r < boxRow + BOX_SIZE; r++) {
+    for (let c = boxCol; c < boxCol + BOX_SIZE; c++) {
+      if (grid[r][c] === num) return false;
+    }
+  }
+  return true;
+};
+
+/**
+ * 특정 위치에 숫자를 놓을 수 있는지 검사한다 (number[][] 타입용, 0=빈칸).
+ * generator의 내부 그리드용.
+ */
+export const canPlaceInNumberGrid = (
+  grid: number[][],
+  row: number,
+  col: number,
+  num: number,
+): boolean => {
+  for (let c = 0; c < BOARD_SIZE; c++) {
+    if (grid[row][c] === num) return false;
+  }
+  for (let r = 0; r < BOARD_SIZE; r++) {
+    if (grid[r][col] === num) return false;
+  }
+  const boxRow = Math.floor(row / BOX_SIZE) * BOX_SIZE;
+  const boxCol = Math.floor(col / BOX_SIZE) * BOX_SIZE;
+  for (let r = boxRow; r < boxRow + BOX_SIZE; r++) {
+    for (let c = boxCol; c < boxCol + BOX_SIZE; c++) {
+      if (grid[r][c] === num) return false;
+    }
+  }
+  return true;
+};
+
+/**
+ * 셀이 속한 3×3 박스 인덱스를 반환한다.
+ */
+export const getBoxIndex = (row: number, col: number): number =>
+  Math.floor(row / BOX_SIZE) * BOX_SIZE + Math.floor(col / BOX_SIZE);


### PR DESCRIPTION
## Summary
- **number-complete 잠금 조건** 구현: 특정 숫자(1~9)를 보드에 9개 모두 배치하면 잠금 해제
  - `countDigitPlacements`: 잠금 칸 제외 숫자 배치 수 카운트
  - `isNumberConditionMet`: 숫자 완성 조건 충족 검사
  - `generateNumberCondition`: 미완성 숫자 후보 중 랜덤 선택
  - `generateCondition`: 영역(row/col/box) + 숫자 통합 조건 생성기
- **공통 유틸리티 `utils.ts` 추출**: generator/solver/lockSystem에 걸쳐 중복되던 함수들을 단일 모듈로 통합
  - `BOARD_SIZE`, `BOX_SIZE`, `DIGITS`, `cloneGrid`, `shuffle`, `posKey`, `canPlaceInGrid`, `canPlaceInNumberGrid`, `getBoxIndex`
- `isAreaConditionMet`에 `number-complete` 분기 추가
- `placeAreaLocks`가 `generateCondition(solution 포함)` 호출하도록 업데이트
- 기존 테스트 파일 import 경로 수정 (posKey, getBoxIndex → utils)

## Test plan
- [x] `lockSystem-number.test.ts` — 22 tests (countDigitPlacements, isNumberConditionMet, generateNumberCondition, generateCondition, findUnlockableCells with number-complete)
- [x] `lockSystem-number-placement.test.ts` — 6 tests (placeAreaLocks with number-complete 통합 테스트)
- [x] 기존 150 tests 전체 통과 (회귀 없음)
- [x] `pnpm type-check` 통과
- [x] `pnpm lint` 통과

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)