### PR TITLE
[Engine] feat/engine-lock-chain — 복합 조건 + 연쇄 잠금 시스템 구현

### DIFF
--- a/__tests__/sudoku/difficulty-generation.test.ts
+++ b/__tests__/sudoku/difficulty-generation.test.ts
@@ -52,14 +52,30 @@ describe('generatePuzzle', () => {
     }
   }, 10000);
 
-  it('스테이지 15 퍼즐이 정상 생성된다', () => {
+  it('스테이지 1~10 퍼즐에는 잠금 칸이 없다', () => {
+    const result = generatePuzzle(5);
+    expect(result.lockedCells).toHaveLength(0);
+  }, 10000);
+
+  it('스테이지 15 퍼즐이 잠금 칸을 포함한다', () => {
     const result = generatePuzzle(15);
     expect(result.config.lockedCellCount).toBeGreaterThanOrEqual(1);
     expect(result.config.lockedCellCount).toBeLessThanOrEqual(3);
 
+    // 잠금 칸이 실제로 배치됨
+    expect(result.lockedCells.length).toBeGreaterThanOrEqual(1);
+    expect(result.lockedCells.length).toBeLessThanOrEqual(result.config.lockedCellCount);
+
     const emptyCells = countEmpty(result.puzzle);
     expect(emptyCells).toBeGreaterThanOrEqual(38);
     expect(emptyCells).toBeLessThanOrEqual(43);
+  }, 15000);
+
+  it('스테이지 15 잠금 칸의 위치가 빈 칸이다', () => {
+    const result = generatePuzzle(15);
+    for (const lc of result.lockedCells) {
+      expect(result.puzzle[lc.position.row][lc.position.col]).toBeNull();
+    }
   }, 15000);
 
   it('높은 난이도(스테이지 25) 퍼즐도 유일해를 가진다', () => {

--- a/__tests__/sudoku/lockSystem-chain-placement.test.ts
+++ b/__tests__/sudoku/lockSystem-chain-placement.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect } from 'vitest';
+import {
+  placeLocks,
+} from '@/lib/sudoku/lockSystem';
+import { posKey } from '@/lib/sudoku/utils';
+import { generateSolution } from '@/lib/sudoku/generator';
+import { createPuzzleFromSolution, hasUniqueSolution } from '@/lib/sudoku/solver';
+
+// ─── placeLocks — 통합 잠금 배치 ─────────────────────
+// 생성 기반 통합 테스트 (시간이 걸릴 수 있으므로 별도 파일)
+
+describe('placeLocks — 단순 모드', () => {
+  it('allowComposite=false이면 각 셀에 조건 1개만 부여된다', () => {
+    const solution = generateSolution();
+    const puzzle = createPuzzleFromSolution(solution, 35);
+    const result = placeLocks(
+      puzzle, solution, 3,
+      ['row-complete', 'col-complete', 'box-complete'],
+      { allowComposite: false, allowChain: false },
+    );
+
+    for (const lc of result.lockedCells) {
+      expect(lc.conditions).toHaveLength(1);
+    }
+  }, 15000);
+});
+
+describe('placeLocks — 복합 조건 모드', () => {
+  it('allowComposite=true이면 일부 셀에 2개 조건이 부여된다', () => {
+    const solution = generateSolution();
+    const puzzle = createPuzzleFromSolution(solution, 40);
+    const allTypes = ['row-complete', 'col-complete', 'box-complete', 'number-complete'] as const;
+
+    // 여러 번 시도하여 복합 조건이 한 번이라도 나오는지 확인
+    let gotComposite = false;
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const result = placeLocks(
+        puzzle, solution, 6, [...allTypes],
+        { allowComposite: true, allowChain: false, compositeRatio: 0.5 },
+      );
+      if (result.lockedCells.some((lc) => lc.conditions.length >= 2)) {
+        gotComposite = true;
+        break;
+      }
+    }
+    expect(gotComposite).toBe(true);
+  }, 30000);
+
+  it('복합 조건 포함 퍼즐이 여전히 유일해를 가진다', () => {
+    const solution = generateSolution();
+    const puzzle = createPuzzleFromSolution(solution, 35);
+    const result = placeLocks(
+      puzzle, solution, 4,
+      ['row-complete', 'col-complete', 'box-complete', 'number-complete'],
+      { allowComposite: true, allowChain: false },
+    );
+
+    expect(hasUniqueSolution(result.puzzle)).toBe(true);
+  }, 15000);
+});
+
+describe('placeLocks — 연쇄 잠금 모드', () => {
+  it('allowChain=true이면 체인 링크가 생성된다', () => {
+    const solution = generateSolution();
+    const puzzle = createPuzzleFromSolution(solution, 40);
+    const allTypes = ['row-complete', 'col-complete', 'box-complete', 'number-complete'] as const;
+
+    let hasChain = false;
+    for (let attempt = 0; attempt < 5; attempt++) {
+      const result = placeLocks(
+        puzzle, solution, 6, [...allTypes],
+        { allowComposite: true, allowChain: true, chainRatio: 0.5 },
+      );
+      if (result.lockedCells.some((lc) => lc.chainUnlocks && lc.chainUnlocks.length > 0)) {
+        hasChain = true;
+        break;
+      }
+    }
+    expect(hasChain).toBe(true);
+  }, 30000);
+
+  it('잠금 칸 위치가 중복되지 않는다', () => {
+    const solution = generateSolution();
+    const puzzle = createPuzzleFromSolution(solution, 40);
+    const result = placeLocks(
+      puzzle, solution, 5,
+      ['row-complete', 'col-complete', 'box-complete', 'number-complete'],
+      { allowComposite: true, allowChain: true },
+    );
+
+    const keys = result.lockedCells.map((lc) => posKey(lc.position.row, lc.position.col));
+    expect(new Set(keys).size).toBe(keys.length);
+  }, 15000);
+
+  it('체인 타겟은 실제 잠금 셀이다', () => {
+    const solution = generateSolution();
+    const puzzle = createPuzzleFromSolution(solution, 40);
+    const result = placeLocks(
+      puzzle, solution, 6,
+      ['row-complete', 'col-complete', 'box-complete', 'number-complete'],
+      { allowComposite: true, allowChain: true, chainRatio: 0.5 },
+    );
+
+    const lockedKeySet = new Set(
+      result.lockedCells.map((lc) => posKey(lc.position.row, lc.position.col)),
+    );
+
+    for (const lc of result.lockedCells) {
+      if (lc.chainUnlocks) {
+        for (const target of lc.chainUnlocks) {
+          expect(lockedKeySet.has(posKey(target.row, target.col))).toBe(true);
+        }
+      }
+    }
+  }, 15000);
+
+  it('연쇄 포함 퍼즐이 여전히 유일해를 가진다', () => {
+    const solution = generateSolution();
+    const puzzle = createPuzzleFromSolution(solution, 35);
+    const result = placeLocks(
+      puzzle, solution, 5,
+      ['row-complete', 'col-complete', 'box-complete', 'number-complete'],
+      { allowComposite: true, allowChain: true },
+    );
+
+    expect(hasUniqueSolution(result.puzzle)).toBe(true);
+  }, 15000);
+
+  it('count=0이면 빈 결과를 반환한다', () => {
+    const solution = generateSolution();
+    const puzzle = createPuzzleFromSolution(solution, 30);
+    const result = placeLocks(
+      puzzle, solution, 0,
+      ['row-complete'],
+      { allowComposite: false, allowChain: false },
+    );
+
+    expect(result.lockedCells).toHaveLength(0);
+  }, 10000);
+});

--- a/__tests__/sudoku/lockSystem-chain.test.ts
+++ b/__tests__/sudoku/lockSystem-chain.test.ts
@@ -1,0 +1,358 @@
+import { describe, it, expect } from 'vitest';
+import {
+  generateCompositeConditions,
+  setupChainLinks,
+  findUnlockableCellsWithChain,
+  findUnlockableCells,
+} from '@/lib/sudoku/lockSystem';
+import { posKey } from '@/lib/sudoku/utils';
+import type { Grid, SolutionGrid, Digit, LockedCell } from '@/types/game';
+
+// ─── 헬퍼 ──────────────────────────────────────────
+
+const createTestSolution = (): SolutionGrid => [
+  [5, 3, 4, 6, 7, 8, 9, 1, 2],
+  [6, 7, 2, 1, 9, 5, 3, 4, 8],
+  [1, 9, 8, 3, 4, 2, 5, 6, 7],
+  [8, 5, 9, 7, 6, 1, 4, 2, 3],
+  [4, 2, 6, 8, 5, 3, 7, 9, 1],
+  [7, 1, 3, 9, 2, 4, 8, 5, 6],
+  [9, 6, 1, 5, 3, 7, 2, 8, 4],
+  [2, 8, 7, 4, 1, 9, 6, 3, 5],
+  [3, 4, 5, 2, 8, 6, 1, 7, 9],
+];
+
+const createTestPuzzle = (
+  solution: SolutionGrid,
+  emptyPositions: [number, number][],
+): Grid => {
+  const grid: Grid = solution.map((row) => row.map((v) => v as Digit | null));
+  for (const [r, c] of emptyPositions) {
+    grid[r][c] = null;
+  }
+  return grid;
+};
+
+// ─── generateCompositeConditions ────────────────────
+
+describe('generateCompositeConditions', () => {
+  it('빈 칸이 충분하면 2개 조건을 생성한다', () => {
+    const solution = createTestSolution();
+    const puzzle = createTestPuzzle(solution, [
+      [0, 0], [0, 1], [0, 2], [0, 3],
+      [1, 0], [1, 1], [1, 2],
+      [2, 0], [2, 1],
+    ]);
+    const lockedKeys = new Set<string>();
+    const allTypes = ['row-complete', 'col-complete', 'box-complete', 'number-complete'] as const;
+
+    // 여러 번 시도하여 2개가 나오는 경우 확인
+    let gotTwo = false;
+    for (let i = 0; i < 30; i++) {
+      const conditions = generateCompositeConditions(
+        puzzle, { row: 3, col: 0 }, lockedKeys, [...allTypes], solution,
+      );
+      if (conditions.length === 2) {
+        gotTwo = true;
+        break;
+      }
+    }
+    expect(gotTwo).toBe(true);
+  });
+
+  it('조건 2개의 유형이 서로 다르다', () => {
+    const solution = createTestSolution();
+    const puzzle = createTestPuzzle(solution, [
+      [0, 0], [0, 1], [0, 2], [0, 3],
+      [1, 0], [1, 1], [1, 2],
+      [2, 0], [2, 1],
+    ]);
+    const lockedKeys = new Set<string>();
+    const allTypes = ['row-complete', 'col-complete', 'box-complete', 'number-complete'] as const;
+
+    for (let i = 0; i < 30; i++) {
+      const conditions = generateCompositeConditions(
+        puzzle, { row: 3, col: 0 }, lockedKeys, [...allTypes], solution,
+      );
+      if (conditions.length === 2) {
+        // 유형이 다르거나, 같더라도 target이 달라야 함
+        const isDifferent =
+          conditions[0].type !== conditions[1].type ||
+          conditions[0].target !== conditions[1].target;
+        expect(isDifferent).toBe(true);
+      }
+    }
+  });
+
+  it('후보가 없으면 빈 배열을 반환한다', () => {
+    const solution = createTestSolution();
+    // 거의 완성된 보드 — 빈 칸 1개만
+    const puzzle = createTestPuzzle(solution, [[0, 0]]);
+    const lockedKeys = new Set<string>();
+
+    // 빈 칸이 1개뿐이면 영역 조건 emptyCount=0이 되어 후보 없음
+    // 단, number-complete는 가능할 수 있으므로 영역만 허용
+    const conditions = generateCompositeConditions(
+      puzzle, { row: 0, col: 0 }, lockedKeys, ['row-complete', 'col-complete', 'box-complete'], solution,
+    );
+    // 빈 칸이 자기 자신뿐이면 영역 조건 emptyCount=0 → 빈 배열
+    expect(conditions).toHaveLength(0);
+  });
+
+  it('최소 1개는 항상 반환한다 (후보가 있을 때)', () => {
+    const solution = createTestSolution();
+    const puzzle = createTestPuzzle(solution, [
+      [0, 0], [0, 1], [0, 2],
+      [1, 0], [1, 1],
+    ]);
+    const lockedKeys = new Set<string>();
+
+    const conditions = generateCompositeConditions(
+      puzzle, { row: 2, col: 0 }, lockedKeys,
+      ['row-complete', 'col-complete', 'box-complete', 'number-complete'], solution,
+    );
+    expect(conditions.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('조건 설명이 비어있지 않다', () => {
+    const solution = createTestSolution();
+    const puzzle = createTestPuzzle(solution, [
+      [0, 0], [0, 1], [0, 2],
+      [1, 0], [1, 1],
+    ]);
+    const lockedKeys = new Set<string>();
+
+    const conditions = generateCompositeConditions(
+      puzzle, { row: 3, col: 0 }, lockedKeys,
+      ['row-complete', 'col-complete', 'box-complete', 'number-complete'], solution,
+    );
+    for (const cond of conditions) {
+      expect(cond.description.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+// ─── setupChainLinks ────────────────────────────────
+
+describe('setupChainLinks', () => {
+  const makeLockedCells = (count: number): LockedCell[] =>
+    Array.from({ length: count }, (_, i) => ({
+      position: { row: i, col: 0 },
+      conditions: [{
+        type: 'row-complete' as const,
+        target: i,
+        description: `${i + 1}행을 완성하세요`,
+      }],
+    }));
+
+  it('chainCount=0이면 체인 없이 반환한다', () => {
+    const cells = makeLockedCells(5);
+    const result = setupChainLinks(cells, 0);
+
+    for (const lc of result) {
+      expect(lc.chainUnlocks).toBeUndefined();
+    }
+  });
+
+  it('요청된 수만큼 체인 링크를 생성한다', () => {
+    const cells = makeLockedCells(5);
+    const result = setupChainLinks(cells, 2);
+
+    let totalChains = 0;
+    for (const lc of result) {
+      if (lc.chainUnlocks) {
+        totalChains += lc.chainUnlocks.length;
+      }
+    }
+    expect(totalChains).toBe(2);
+  });
+
+  it('셀이 2개 미만이면 체인을 생성하지 않는다', () => {
+    const cells = makeLockedCells(1);
+    const result = setupChainLinks(cells, 1);
+
+    expect(result[0].chainUnlocks).toBeUndefined();
+  });
+
+  it('체인 타겟은 중복되지 않는다', () => {
+    const cells = makeLockedCells(6);
+    const result = setupChainLinks(cells, 3);
+
+    const allTargets: string[] = [];
+    for (const lc of result) {
+      if (lc.chainUnlocks) {
+        for (const pos of lc.chainUnlocks) {
+          allTargets.push(posKey(pos.row, pos.col));
+        }
+      }
+    }
+
+    const uniqueTargets = new Set(allTargets);
+    expect(uniqueTargets.size).toBe(allTargets.length);
+  });
+
+  it('원본 배열을 수정하지 않는다', () => {
+    const cells = makeLockedCells(4);
+    const originalStr = JSON.stringify(cells);
+    setupChainLinks(cells, 2);
+    expect(JSON.stringify(cells)).toBe(originalStr);
+  });
+
+  it('체인 타겟이 된 셀은 소스가 되지 않는다 (단방향 트리)', () => {
+    const cells = makeLockedCells(6);
+    const result = setupChainLinks(cells, 3);
+
+    // 모든 체인 타겟 수집
+    const targets = new Set<string>();
+    for (const lc of result) {
+      if (lc.chainUnlocks) {
+        for (const pos of lc.chainUnlocks) {
+          targets.add(posKey(pos.row, pos.col));
+        }
+      }
+    }
+
+    // 소스(chainUnlocks가 있는 셀)가 타겟에 포함되지 않아야 함
+    for (const lc of result) {
+      if (lc.chainUnlocks && lc.chainUnlocks.length > 0) {
+        const sourceKey = posKey(lc.position.row, lc.position.col);
+        expect(targets.has(sourceKey)).toBe(false);
+      }
+    }
+  });
+});
+
+// ─── findUnlockableCellsWithChain ───────────────────
+
+describe('findUnlockableCellsWithChain', () => {
+  it('체인이 없으면 findUnlockableCells와 동일하게 동작한다', () => {
+    const solution = createTestSolution();
+    const grid: Grid = solution.map((row) => row.map((v) => v as Digit | null));
+
+    const lockedCells: LockedCell[] = [
+      {
+        position: { row: 2, col: 4 },
+        conditions: [{
+          type: 'number-complete',
+          target: 5,
+          description: '숫자 5을(를) 모두 배치하세요',
+        }],
+      },
+    ];
+
+    const withChain = findUnlockableCellsWithChain(grid, lockedCells);
+    const without = findUnlockableCells(grid, lockedCells);
+
+    expect(withChain.length).toBe(without.length);
+  });
+
+  it('조건 충족된 셀의 체인 타겟도 해제된다', () => {
+    const solution = createTestSolution();
+    const grid: Grid = solution.map((row) => row.map((v) => v as Digit | null));
+    // grid[2][4]=4, 5는 grid에 9개(모두 배치됨)
+
+    const lockedCells: LockedCell[] = [
+      {
+        position: { row: 2, col: 4 }, // 4가 들어있음 (5 아님)
+        conditions: [{
+          type: 'number-complete',
+          target: 5,
+          description: '숫자 5을(를) 모두 배치하세요',
+        }],
+        chainUnlocks: [{ row: 3, col: 0 }], // 체인 타겟
+      },
+      {
+        position: { row: 3, col: 0 },
+        conditions: [{
+          type: 'row-complete',
+          target: 8, // 9행 — 완성 여부 상관없이 체인으로 해제
+          description: '9행을 완성하세요',
+        }],
+      },
+    ];
+
+    const unlockable = findUnlockableCellsWithChain(grid, lockedCells);
+
+    // (2,4)는 number-complete(5) 조건 충족 → 해제
+    // (3,0)은 (2,4)의 체인 타겟 → 연쇄 해제
+    expect(unlockable).toHaveLength(2);
+    const keys = unlockable.map((lc) => posKey(lc.position.row, lc.position.col));
+    expect(keys).toContain(posKey(2, 4));
+    expect(keys).toContain(posKey(3, 0));
+  });
+
+  it('조건 미충족 셀의 체인 타겟은 해제되지 않는다', () => {
+    const solution = createTestSolution();
+    // 5를 하나 제거하여 number-complete(5) 미충족
+    const puzzle = createTestPuzzle(solution, [[0, 0]]);
+
+    const lockedCells: LockedCell[] = [
+      {
+        position: { row: 2, col: 4 },
+        conditions: [{
+          type: 'number-complete',
+          target: 5,
+          description: '숫자 5을(를) 모두 배치하세요',
+        }],
+        chainUnlocks: [{ row: 3, col: 0 }],
+      },
+      {
+        position: { row: 3, col: 0 },
+        conditions: [{
+          type: 'row-complete',
+          target: 0,
+          description: '1행을 완성하세요',
+        }],
+      },
+    ];
+
+    const unlockable = findUnlockableCellsWithChain(puzzle, lockedCells);
+    // 5가 8개뿐 → number-complete 미충족 → 체인도 작동 안 함
+    expect(unlockable).toHaveLength(0);
+  });
+
+  it('다단계 연쇄 해제가 동작한다 (A→B→C)', () => {
+    const solution = createTestSolution();
+    const grid: Grid = solution.map((row) => row.map((v) => v as Digit | null));
+
+    const lockedCells: LockedCell[] = [
+      {
+        position: { row: 0, col: 1 }, // solution[0][1]=3
+        conditions: [{
+          type: 'number-complete',
+          target: 7, // 7은 grid에 9개 → 충족
+          description: '숫자 7을(를) 모두 배치하세요',
+        }],
+        chainUnlocks: [{ row: 1, col: 0 }], // A → B
+      },
+      {
+        position: { row: 1, col: 0 }, // B
+        conditions: [{
+          type: 'row-complete',
+          target: 8, // 조건 자체는 미충족 가능하지만 체인으로 해제
+          description: '9행을 완성하세요',
+        }],
+        chainUnlocks: [{ row: 2, col: 0 }], // B → C
+      },
+      {
+        position: { row: 2, col: 0 }, // C
+        conditions: [{
+          type: 'row-complete',
+          target: 7,
+          description: '8행을 완성하세요',
+        }],
+      },
+    ];
+
+    const unlockable = findUnlockableCellsWithChain(grid, lockedCells);
+
+    // A 조건 충족 → A 해제 → B 체인 해제 → C 체인 해제
+    expect(unlockable).toHaveLength(3);
+  });
+
+  it('빈 목록이면 빈 결과를 반환한다', () => {
+    const grid: Grid = Array.from({ length: 9 }, () => Array(9).fill(null));
+    const unlockable = findUnlockableCellsWithChain(grid, []);
+    expect(unlockable).toHaveLength(0);
+  });
+});

--- a/src/lib/sudoku/difficulty.ts
+++ b/src/lib/sudoku/difficulty.ts
@@ -10,10 +10,11 @@
  * @see GitHub Issue #3 — Epic: 스도쿠 엔진 개발
  */
 
-import type { StageConfig, StageRange, Grid, SolutionGrid } from '@/types/game';
+import type { StageConfig, StageRange, Grid, SolutionGrid, LockedCell } from '@/types/game';
 import { STAGE_RANGES } from '@/types/game';
 import { generateSolution } from '@/lib/sudoku/generator';
 import { createPuzzleFromSolution } from '@/lib/sudoku/solver';
+import { placeLocks } from '@/lib/sudoku/lockSystem';
 
 // ─── 상수 ───────────────────────────────────────────
 
@@ -114,14 +115,16 @@ export interface PuzzleGenerationResult {
   solution: SolutionGrid;
   /** 적용된 스테이지 설정 */
   config: StageConfig;
+  /** 잠금 칸 목록 (Stage 11+ 에서만 존재) */
+  lockedCells: LockedCell[];
 }
 
 /**
  * 스테이지 번호에 맞는 퍼즐을 생성한다.
- * 유일해가 보장된 퍼즐을 반환한다.
+ * 유일해가 보장되고, 잠금 칸이 포함된 퍼즐을 반환한다.
  *
  * @param stage - 스테이지 번호 (1~50)
- * @returns 퍼즐, 정답, 스테이지 설정
+ * @returns 퍼즐, 정답, 스테이지 설정, 잠금 칸 목록
  *
  * @example
  * ```ts
@@ -129,6 +132,7 @@ export interface PuzzleGenerationResult {
  * console.log(result.config.emptyCells); // 44~49 범위
  * console.log(result.puzzle);            // 빈 칸이 포함된 Grid
  * console.log(result.solution);          // 완성된 SolutionGrid
+ * console.log(result.lockedCells);       // 잠금 칸 목록
  * ```
  */
 export const generatePuzzle = (stage: number): PuzzleGenerationResult => {
@@ -136,14 +140,27 @@ export const generatePuzzle = (stage: number): PuzzleGenerationResult => {
   const solution = generateSolution();
   const puzzle = createPuzzleFromSolution(solution, config.emptyCells);
 
-  // TODO: 잠금 칸 생성 로직 — feat/engine-lock-area, lock-number, lock-chain PR에서 구현 예정
-  // config.lockedCellCount > 0인 스테이지(11+)에서 잠금 칸을 배치하고
-  // 잠금 포함 상태에서도 풀이 가능성을 보장해야 함
+  // 잠금 칸 배치 (Stage 11+)
+  let lockedCells: LockedCell[] = [];
+  if (config.lockedCellCount > 0) {
+    const lockResult = placeLocks(
+      puzzle,
+      solution,
+      config.lockedCellCount,
+      config.allowedLockTypes,
+      {
+        allowComposite: config.allowedLockTypes.length > 3, // Stage 31+ (cell-fill 포함)
+        allowChain: config.allowChainLocks,
+      },
+    );
+    lockedCells = lockResult.lockedCells;
+  }
 
   return {
     puzzle,
     solution,
     config,
+    lockedCells,
   };
 };
 

--- a/src/lib/sudoku/lockSystem.ts
+++ b/src/lib/sudoku/lockSystem.ts
@@ -1,13 +1,14 @@
 /**
- * 잠금 칸 시스템 — 영역 조건 + 숫자 조건
- * 특정 영역 완성 또는 숫자 완성 시 잠금 칸이 해제되는 시스템을 구현한다.
+ * 잠금 칸 시스템 — 영역 조건 + 숫자 조건 + 복합 조건 + 연쇄 잠금
+ * 특정 영역/숫자 완성 시 잠금 칸이 해제되는 시스템을 구현한다.
  *
  * @description
  * 1. 영역 조건: row-complete, col-complete, box-complete
  * 2. 숫자 조건: number-complete (특정 숫자 9개 모두 배치)
- * 3. 잠금 칸은 빈 칸 중에서 선택하여 조건을 부여
- * 4. 잠금 포함 상태에서도 퍼즐이 풀이 가능해야 함
- * 5. 순수 함수 — 사이드 이펙트 없음
+ * 3. 복합 조건: 하나의 잠금 칸에 2개 이상의 조건 (모두 충족 시 해제)
+ * 4. 연쇄 잠금: 셀 A 해제 시 연결된 셀 B도 함께 해제 (캐스케이드)
+ * 5. 잠금 포함 상태에서도 퍼즐이 풀이 가능해야 함
+ * 6. 순수 함수 — 사이드 이펙트 없음
  *
  * @see GitHub Issue #3 — Epic: 스도쿠 엔진 개발
  */
@@ -457,9 +458,339 @@ export const placeAreaLocks = (
   };
 };
 
+// ─── 복합 조건 생성 ──────────────────────────────────
+
+/**
+ * 특정 위치에 대해 복합 조건(2개)을 생성한다.
+ * 서로 다른 유형의 조건 2개를 반환한다.
+ * 2개를 확보할 수 없으면 1개만 반환한다.
+ *
+ * @param grid - 퍼즐 그리드
+ * @param pos - 잠금 칸 위치
+ * @param lockedKeys - 이미 잠긴 셀 키 Set
+ * @param allowedTypes - 허용된 조건 유형
+ * @param solution - 정답 그리드
+ * @returns 조건 배열 (최대 2개) 또는 빈 배열
+ */
+export const generateCompositeConditions = (
+  grid: Grid,
+  pos: Position,
+  lockedKeys: Set<string>,
+  allowedTypes: LockConditionType[],
+  solution: SolutionGrid,
+): LockCondition[] => {
+  const allCandidates: LockCondition[] = [];
+
+  const updatedLockedKeys = new Set(lockedKeys);
+  updatedLockedKeys.add(posKey(pos.row, pos.col));
+
+  // 영역 조건 후보
+  const areaTypes = allowedTypes.filter(
+    (t): t is 'row-complete' | 'col-complete' | 'box-complete' => AREA_LOCK_TYPES.includes(t),
+  );
+
+  for (const type of areaTypes) {
+    let target: number;
+    switch (type) {
+      case 'row-complete': target = pos.row; break;
+      case 'col-complete': target = pos.col; break;
+      case 'box-complete': target = getBoxIndex(pos.row, pos.col); break;
+    }
+
+    const positions = getAreaPositions(type, target);
+    const emptyCount = countEmptyInArea(grid, positions, updatedLockedKeys);
+
+    if (emptyCount >= 1) {
+      allCandidates.push({
+        type,
+        target,
+        description: createConditionDescription(type, target),
+      });
+    }
+  }
+
+  // 숫자 조건 후보
+  if (allowedTypes.includes('number-complete') && solution) {
+    const numberCandidates = getNumberConditionCandidates(grid, updatedLockedKeys);
+    for (const d of numberCandidates) {
+      allCandidates.push({
+        type: 'number-complete',
+        target: d,
+        description: createConditionDescription('number-complete', d),
+      });
+    }
+  }
+
+  if (allCandidates.length === 0) return [];
+
+  // 셔플 후 서로 다른 유형 2개 선택
+  const shuffled = shuffle(allCandidates);
+  const selected: LockCondition[] = [shuffled[0]];
+
+  if (shuffled.length >= 2) {
+    // 첫 번째와 다른 유형의 조건 찾기
+    const different = shuffled.find((c) => c.type !== selected[0].type);
+    if (different) {
+      selected.push(different);
+    } else {
+      // 같은 유형이라도 target이 다르면 추가
+      const sameTypeDiffTarget = shuffled.find(
+        (c) => c !== selected[0] && c.target !== selected[0].target,
+      );
+      if (sameTypeDiffTarget) {
+        selected.push(sameTypeDiffTarget);
+      }
+    }
+  }
+
+  return selected;
+};
+
+// ─── 연쇄 잠금 설정 ──────────────────────────────────
+
+/**
+ * 잠금 셀들 사이에 연쇄 관계를 설정한다.
+ * chainCount개의 연쇄 링크를 생성하여 트리 구조를 만든다.
+ * 순환 참조를 방지한다.
+ *
+ * @param lockedCells - 기존 잠금 셀 목록 (수정하지 않음)
+ * @param chainCount - 생성할 연쇄 링크 수
+ * @returns 연쇄 관계가 설정된 새 잠금 셀 목록
+ */
+export const setupChainLinks = (
+  lockedCells: LockedCell[],
+  chainCount: number,
+): LockedCell[] => {
+  if (lockedCells.length < 2 || chainCount <= 0) {
+    return lockedCells.map((lc) => ({ ...lc }));
+  }
+
+  const result = lockedCells.map((lc) => ({
+    ...lc,
+    conditions: [...lc.conditions],
+    chainUnlocks: lc.chainUnlocks ? [...lc.chainUnlocks] : undefined,
+  }));
+
+  // 연쇄 대상이 될 수 있는 셀 (아직 다른 셀의 체인 타겟이 아닌 셀)
+  const chainTargetUsed = new Set<string>();
+  // 연쇄 소스가 될 수 있는 셀
+  const indices = Array.from({ length: result.length }, (_, i) => i);
+  const shuffledIndices = shuffle(indices);
+
+  let created = 0;
+
+  for (const sourceIdx of shuffledIndices) {
+    if (created >= chainCount) break;
+
+    const source = result[sourceIdx];
+    const sourceKey = posKey(source.position.row, source.position.col);
+
+    // 이미 체인 타겟인 셀은 소스가 될 수 없음 (단방향 트리 보장)
+    if (chainTargetUsed.has(sourceKey)) continue;
+
+    // 타겟 후보: 아직 체인 타겟이 아닌 다른 셀
+    for (let i = 0; i < result.length; i++) {
+      if (i === sourceIdx) continue;
+      if (created >= chainCount) break;
+
+      const target = result[i];
+      const targetKey = posKey(target.position.row, target.position.col);
+
+      if (chainTargetUsed.has(targetKey)) continue;
+      // 소스가 이미 타겟의 체인 대상이면 스킵 (역방향 방지)
+      if (target.chainUnlocks?.some(
+        (p) => posKey(p.row, p.col) === sourceKey,
+      )) continue;
+
+      // 연쇄 링크 생성
+      if (!source.chainUnlocks) {
+        source.chainUnlocks = [];
+      }
+      source.chainUnlocks.push({ ...target.position });
+      chainTargetUsed.add(targetKey);
+      created++;
+    }
+  }
+
+  return result;
+};
+
+// ─── 연쇄 해제 처리 ──────────────────────────────────
+
+/**
+ * 연쇄 잠금을 포함하여 해제 가능한 셀들을 찾는다.
+ * 1. 조건이 모두 충족된 셀을 찾는다.
+ * 2. 해제된 셀의 chainUnlocks 타겟도 해제 대상에 추가한다.
+ * 3. 캐스케이드를 재귀적으로 처리한다.
+ *
+ * @param grid - 현재 보드 상태
+ * @param lockedCells - 잠금 칸 목록
+ * @returns 해제 가능한 잠금 칸들 (조건 충족 + 연쇄 해제 포함)
+ */
+export const findUnlockableCellsWithChain = (
+  grid: Grid,
+  lockedCells: LockedCell[],
+): LockedCell[] => {
+  // 잠금 셀을 키로 빠르게 조회할 수 있는 맵
+  const cellMap = new Map<string, LockedCell>();
+  for (const lc of lockedCells) {
+    cellMap.set(posKey(lc.position.row, lc.position.col), lc);
+  }
+
+  const lockedKeys = new Set(cellMap.keys());
+
+  // 1단계: 조건 충족으로 직접 해제 가능한 셀
+  const directUnlockable = new Set<string>();
+  for (const lc of lockedCells) {
+    if (lc.conditions.every((cond) => isAreaConditionMet(grid, cond, lockedKeys))) {
+      directUnlockable.add(posKey(lc.position.row, lc.position.col));
+    }
+  }
+
+  // 2단계: 연쇄 캐스케이드 (BFS)
+  const allUnlockable = new Set(directUnlockable);
+  const queue = [...directUnlockable];
+
+  while (queue.length > 0) {
+    const key = queue.shift()!;
+    const cell = cellMap.get(key);
+    if (!cell?.chainUnlocks) continue;
+
+    for (const targetPos of cell.chainUnlocks) {
+      const targetKey = posKey(targetPos.row, targetPos.col);
+      if (allUnlockable.has(targetKey)) continue; // 이미 해제됨
+      if (!cellMap.has(targetKey)) continue; // 잠금 셀이 아님
+
+      allUnlockable.add(targetKey);
+      queue.push(targetKey);
+    }
+  }
+
+  // 결과 반환
+  return lockedCells.filter((lc) =>
+    allUnlockable.has(posKey(lc.position.row, lc.position.col)),
+  );
+};
+
+// ─── 통합 잠금 배치 ──────────────────────────────────
+
+/**
+ * 잠금 배치 옵션
+ */
+export interface LockPlacementOptions {
+  /** 복합 조건 허용 (하나의 잠금 칸에 2개 조건) */
+  allowComposite: boolean;
+  /** 연쇄 잠금 허용 */
+  allowChain: boolean;
+  /** 복합 조건 비율 (0.0~1.0, 기본 0.4) — 잠금 칸 중 복합 조건을 가질 비율 */
+  compositeRatio?: number;
+  /** 연쇄 링크 수 (기본: 잠금 칸 수의 30%) */
+  chainRatio?: number;
+}
+
+/**
+ * 퍼즐에 잠금 칸을 배치한다 (복합 조건 + 연쇄 잠금 지원).
+ * 잠금 포함 상태에서 풀이 가능성을 검증한다.
+ *
+ * @param puzzle - 원본 퍼즐 (빈 칸 포함)
+ * @param solution - 정답 그리드
+ * @param count - 배치할 잠금 칸 수
+ * @param allowedTypes - 허용된 조건 유형
+ * @param options - 복합/연쇄 옵션
+ * @returns 잠금 배치 결과
+ *
+ * @example
+ * ```ts
+ * // 단순 잠금 (Stage 11~20)
+ * placeLocks(puzzle, solution, 2, ['row-complete'], { allowComposite: false, allowChain: false });
+ *
+ * // 복합 조건 (Stage 31~40)
+ * placeLocks(puzzle, solution, 6, allTypes, { allowComposite: true, allowChain: false });
+ *
+ * // 연쇄 잠금 (Stage 41~50)
+ * placeLocks(puzzle, solution, 10, allTypes, { allowComposite: true, allowChain: true });
+ * ```
+ */
+export const placeLocks = (
+  puzzle: Grid,
+  solution: SolutionGrid,
+  count: number,
+  allowedTypes: LockConditionType[],
+  options: LockPlacementOptions = { allowComposite: false, allowChain: false },
+): LockPlacementResult => {
+  if (count <= 0) {
+    return { lockedCells: [], puzzle: cloneGrid(puzzle) };
+  }
+
+  const compositeRatio = options.compositeRatio ?? 0.4;
+  const chainRatio = options.chainRatio ?? 0.3;
+
+  // 빈 칸 위치 수집 + 셔플
+  const emptyPositions: Position[] = [];
+  for (let r = 0; r < BOARD_SIZE; r++) {
+    for (let c = 0; c < BOARD_SIZE; c++) {
+      if (puzzle[r][c] === null) {
+        emptyPositions.push({ row: r, col: c });
+      }
+    }
+  }
+  const shuffled = shuffle(emptyPositions);
+
+  const lockedCells: LockedCell[] = [];
+  const lockedKeys = new Set<string>();
+  const workingPuzzle = cloneGrid(puzzle);
+
+  // 복합 조건 대상 수 결정
+  const compositeCount = options.allowComposite
+    ? Math.round(count * compositeRatio)
+    : 0;
+
+  for (const pos of shuffled) {
+    if (lockedCells.length >= count) break;
+
+    const isComposite = options.allowComposite
+      && lockedCells.length < compositeCount;
+
+    let conditions: LockCondition[];
+
+    if (isComposite) {
+      conditions = generateCompositeConditions(
+        workingPuzzle, pos, lockedKeys, allowedTypes, solution,
+      );
+    } else {
+      const condition = generateCondition(
+        workingPuzzle, pos, lockedKeys, allowedTypes, solution,
+      );
+      conditions = condition ? [condition] : [];
+    }
+
+    if (conditions.length === 0) continue;
+
+    // 검증: 잠금 포함 상태에서 풀이 가능한지
+    const candidateLocks = [...lockedCells, { position: pos, conditions }];
+    if (validateSolvabilityWithLocks(workingPuzzle, solution, candidateLocks)) {
+      lockedKeys.add(posKey(pos.row, pos.col));
+      lockedCells.push({ position: pos, conditions });
+    }
+  }
+
+  // 연쇄 잠금 설정
+  let finalLockedCells = lockedCells;
+  if (options.allowChain && lockedCells.length >= 2) {
+    const chainCount = Math.max(1, Math.round(lockedCells.length * chainRatio));
+    finalLockedCells = setupChainLinks(lockedCells, chainCount);
+  }
+
+  return {
+    lockedCells: finalLockedCells,
+    puzzle: workingPuzzle,
+  };
+};
+
 /**
  * @internal 테스트 전용 export — 외부에서 직접 사용 금지
- * countDigitPlacements, isNumberConditionMet, generateNumberCondition은
+ * countDigitPlacements, isNumberConditionMet, generateNumberCondition,
+ * generateCompositeConditions, setupChainLinks, findUnlockableCellsWithChain은
  * 이미 export const로 선언되어 있으므로 여기에 중복하지 않음.
  */
 export {
@@ -469,5 +800,6 @@ export {
   getAreaPositions,
   countEmptyInArea,
   createConditionDescription,
+  getNumberConditionCandidates,
   AREA_LOCK_TYPES,
 };

--- a/src/lib/sudoku/lockSystem.ts
+++ b/src/lib/sudoku/lockSystem.ts
@@ -461,16 +461,19 @@ export const placeAreaLocks = (
 // ─── 복합 조건 생성 ──────────────────────────────────
 
 /**
- * 특정 위치에 대해 복합 조건(2개)을 생성한다.
- * 서로 다른 유형의 조건 2개를 반환한다.
- * 2개를 확보할 수 없으면 1개만 반환한다.
+ * 특정 위치에 대해 복합 조건(최대 2개)을 생성한다.
+ * 서로 다른 유형(또는 같은 유형이라도 다른 target)의 조건 2개를 반환한다.
+ *
+ * 후보가 부족하면 1개만 반환할 수 있다 — 이는 의도적 동작이다.
+ * 허용 유형이 제한적이거나 영역에 빈 칸이 부족하면 2개 확보가 불가능하므로,
+ * 1개라도 유효한 조건을 반환하여 잠금 배치 자체는 진행되도록 한다.
  *
  * @param grid - 퍼즐 그리드
  * @param pos - 잠금 칸 위치
  * @param lockedKeys - 이미 잠긴 셀 키 Set
  * @param allowedTypes - 허용된 조건 유형
  * @param solution - 정답 그리드
- * @returns 조건 배열 (최대 2개) 또는 빈 배열
+ * @returns 조건 배열 (1~2개) 또는 빈 배열 (후보 없음)
  */
 export const generateCompositeConditions = (
   grid: Grid,
@@ -774,11 +777,30 @@ export const placeLocks = (
     }
   }
 
-  // 연쇄 잠금 설정
+  // 배치 부족 경고
+  if (lockedCells.length < count && process.env.NODE_ENV !== 'production') {
+    console.warn(
+      `[lockSystem] 잠금 칸 배치 부족: 요청 ${count}개, 실제 ${lockedCells.length}개. ` +
+      `빈 칸 부족 또는 풀이 검증 실패가 원인일 수 있습니다.`,
+    );
+  }
+
+  // 연쇄 잠금 설정 (잠금 수가 3개 이상일 때만 — 2개 이하에서는 체인 밀도가 과도)
   let finalLockedCells = lockedCells;
-  if (options.allowChain && lockedCells.length >= 2) {
+  if (options.allowChain && lockedCells.length >= 3) {
     const chainCount = Math.max(1, Math.round(lockedCells.length * chainRatio));
     finalLockedCells = setupChainLinks(lockedCells, chainCount);
+  }
+
+  // 최종 통합 검증: 개별 검증을 통과했더라도 전체 조합이 유효한지 확인
+  if (finalLockedCells.length > 0) {
+    if (!validateSolvabilityWithLocks(workingPuzzle, solution, finalLockedCells)) {
+      if (process.env.NODE_ENV !== 'production') {
+        console.warn('[lockSystem] 최종 통합 검증 실패 — 체인 없이 재시도합니다.');
+      }
+      // 체인 제거 후 개별 검증 통과한 원본으로 fallback
+      finalLockedCells = lockedCells;
+    }
   }
 
   return {


### PR DESCRIPTION
## Summary
- **복합 조건** (Stage 31~40): 하나의 잠금 칸에 2개 이상의 조건 부여 (모두 충족 시 해제)
  - `generateCompositeConditions`: 서로 다른 유형의 조건 2개 생성
  - `compositeRatio`로 복합 조건 비율 조절 (기본 40%)
- **연쇄 잠금** (Stage 41~50): 셀 해제 시 `chainUnlocks` 타겟도 함께 해제
  - `setupChainLinks`: 단방향 트리 구조로 체인 링크 생성 (순환 방지)
  - `findUnlockableCellsWithChain`: BFS 캐스케이드로 다단계 연쇄 해제 처리
- **통합 배치 함수 `placeLocks`**: 단순/복합/연쇄 모드를 `LockPlacementOptions`로 통합
- **`generatePuzzle` TODO 해소**: 실제 잠금 칸 배치 연동
  - `PuzzleGenerationResult`에 `lockedCells: LockedCell[]` 필드 추가
  - Stage 11+ 퍼즐에 자동으로 잠금 칸 배치

## Test plan
- [x] `lockSystem-chain.test.ts` — 16 tests (generateCompositeConditions, setupChainLinks, findUnlockableCellsWithChain)
- [x] `lockSystem-chain-placement.test.ts` — 8 tests (placeLocks 단순/복합/연쇄 통합 테스트)
- [x] `difficulty-generation.test.ts` — 기존 테스트 + 잠금 칸 연동 2개 추가
- [x] 전체 176 tests 통과 (회귀 없음)
- [x] `pnpm type-check` 통과
- [x] `pnpm lint` 통과

Closes #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)