### PR TITLE
[Engine] feat/engine-deadlock — 잠금 칸 데드락 검증 로직 구현

### DIFF
--- a/__tests__/sudoku/lockSystem-deadlock.test.ts
+++ b/__tests__/sudoku/lockSystem-deadlock.test.ts
@@ -1,0 +1,390 @@
+import { describe, it, expect } from 'vitest';
+import {
+  checkDeadlock,
+  hasChainCycle,
+} from '@/lib/sudoku/lockSystem';
+import type { Grid, SolutionGrid, Digit, LockedCell } from '@/types/game';
+
+// ─── 헬퍼 ──────────────────────────────────────────
+
+const createTestSolution = (): SolutionGrid => [
+  [5, 3, 4, 6, 7, 8, 9, 1, 2],
+  [6, 7, 2, 1, 9, 5, 3, 4, 8],
+  [1, 9, 8, 3, 4, 2, 5, 6, 7],
+  [8, 5, 9, 7, 6, 1, 4, 2, 3],
+  [4, 2, 6, 8, 5, 3, 7, 9, 1],
+  [7, 1, 3, 9, 2, 4, 8, 5, 6],
+  [9, 6, 1, 5, 3, 7, 2, 8, 4],
+  [2, 8, 7, 4, 1, 9, 6, 3, 5],
+  [3, 4, 5, 2, 8, 6, 1, 7, 9],
+];
+
+const createTestPuzzle = (
+  solution: SolutionGrid,
+  emptyPositions: [number, number][],
+): Grid => {
+  const grid: Grid = solution.map((row) => row.map((v) => v as Digit | null));
+  for (const [r, c] of emptyPositions) {
+    grid[r][c] = null;
+  }
+  return grid;
+};
+
+// ─── hasChainCycle ──────────────────────────────────
+
+describe('hasChainCycle', () => {
+  it('체인이 없으면 순환 없음', () => {
+    const cells: LockedCell[] = [
+      { position: { row: 0, col: 0 }, conditions: [] },
+      { position: { row: 1, col: 0 }, conditions: [] },
+    ];
+    expect(hasChainCycle(cells)).toBe(false);
+  });
+
+  it('단방향 체인은 순환 없음 (A→B)', () => {
+    const cells: LockedCell[] = [
+      {
+        position: { row: 0, col: 0 },
+        conditions: [],
+        chainUnlocks: [{ row: 1, col: 0 }],
+      },
+      { position: { row: 1, col: 0 }, conditions: [] },
+    ];
+    expect(hasChainCycle(cells)).toBe(false);
+  });
+
+  it('다단계 체인은 순환 없음 (A→B→C)', () => {
+    const cells: LockedCell[] = [
+      {
+        position: { row: 0, col: 0 },
+        conditions: [],
+        chainUnlocks: [{ row: 1, col: 0 }],
+      },
+      {
+        position: { row: 1, col: 0 },
+        conditions: [],
+        chainUnlocks: [{ row: 2, col: 0 }],
+      },
+      { position: { row: 2, col: 0 }, conditions: [] },
+    ];
+    expect(hasChainCycle(cells)).toBe(false);
+  });
+
+  it('양방향 체인은 순환 (A→B, B→A)', () => {
+    const cells: LockedCell[] = [
+      {
+        position: { row: 0, col: 0 },
+        conditions: [],
+        chainUnlocks: [{ row: 1, col: 0 }],
+      },
+      {
+        position: { row: 1, col: 0 },
+        conditions: [],
+        chainUnlocks: [{ row: 0, col: 0 }],
+      },
+    ];
+    expect(hasChainCycle(cells)).toBe(true);
+  });
+
+  it('간접 순환 (A→B→C→A)', () => {
+    const cells: LockedCell[] = [
+      {
+        position: { row: 0, col: 0 },
+        conditions: [],
+        chainUnlocks: [{ row: 1, col: 0 }],
+      },
+      {
+        position: { row: 1, col: 0 },
+        conditions: [],
+        chainUnlocks: [{ row: 2, col: 0 }],
+      },
+      {
+        position: { row: 2, col: 0 },
+        conditions: [],
+        chainUnlocks: [{ row: 0, col: 0 }],
+      },
+    ];
+    expect(hasChainCycle(cells)).toBe(true);
+  });
+
+  it('빈 목록은 순환 없음', () => {
+    expect(hasChainCycle([])).toBe(false);
+  });
+});
+
+// ─── checkDeadlock ──────────────────────────────────
+
+describe('checkDeadlock', () => {
+  it('잠금 칸이 없으면 데드락 없음', () => {
+    const solution = createTestSolution();
+    const puzzle = createTestPuzzle(solution, [[0, 0], [0, 1]]);
+
+    const result = checkDeadlock(puzzle, solution, []);
+    expect(result.hasDeadlock).toBe(false);
+  });
+
+  it('단순 영역 조건은 데드락 없음', () => {
+    const solution = createTestSolution();
+    // 0행에서 몇 개 비우기
+    const puzzle = createTestPuzzle(solution, [
+      [0, 0], [0, 1], [0, 2], // row 0에 빈 칸
+      [1, 0], // 잠금 대상
+    ]);
+
+    const lockedCells: LockedCell[] = [
+      {
+        position: { row: 1, col: 0 },
+        conditions: [{
+          type: 'row-complete',
+          target: 0, // 0행 완성 시 해제
+          description: '1행을 완성하세요',
+        }],
+      },
+    ];
+
+    // 플레이어가 (0,0), (0,1), (0,2)를 채우면 0행 완성 → 잠금 해제
+    const result = checkDeadlock(puzzle, solution, lockedCells);
+    expect(result.hasDeadlock).toBe(false);
+  });
+
+  it('같은 영역의 두 잠금 칸도 데드락 없음 (lockedKeys 제외)', () => {
+    const solution = createTestSolution();
+    const puzzle = createTestPuzzle(solution, [
+      [0, 0], [0, 1], [0, 2], [0, 3], [0, 4],
+    ]);
+
+    // 두 셀 모두 row 0 완성 조건
+    const lockedCells: LockedCell[] = [
+      {
+        position: { row: 0, col: 0 },
+        conditions: [{
+          type: 'row-complete',
+          target: 0,
+          description: '1행을 완성하세요',
+        }],
+      },
+      {
+        position: { row: 0, col: 1 },
+        conditions: [{
+          type: 'row-complete',
+          target: 0,
+          description: '1행을 완성하세요',
+        }],
+      },
+    ];
+
+    // (0,2), (0,3), (0,4) 채우면 → row 0의 비잠금 빈칸 모두 채워짐 → 둘 다 해제
+    const result = checkDeadlock(puzzle, solution, lockedCells);
+    expect(result.hasDeadlock).toBe(false);
+  });
+
+  it('점진적 해제: A 해제 후 B의 조건이 충족된다', () => {
+    const solution = createTestSolution();
+    // A=(0,0) row-complete(1)로 해제, B=(1,0) row-complete(0)으로 해제
+    const puzzle = createTestPuzzle(solution, [
+      [0, 0], [0, 1], [0, 2], // row 0 빈 칸
+      [1, 0], [1, 1],         // row 1 빈 칸
+    ]);
+
+    const lockedCells: LockedCell[] = [
+      {
+        position: { row: 0, col: 0 },
+        conditions: [{
+          type: 'row-complete',
+          target: 1, // row 1 완성 시 해제
+          description: '2행을 완성하세요',
+        }],
+      },
+      {
+        position: { row: 1, col: 0 },
+        conditions: [{
+          type: 'row-complete',
+          target: 0, // row 0 완성 시 해제
+          description: '1행을 완성하세요',
+        }],
+      },
+    ];
+
+    // Wave 1: row 1의 비잠금 빈칸=(1,1) 채움 → row-complete(1) 충족 → (0,0) 해제
+    // Wave 2: (0,0) 해제됨 → row 0 비잠금 빈칸=(0,1),(0,2) 채움 → row-complete(0) 충족 → (1,0) 해제
+    const result = checkDeadlock(puzzle, solution, lockedCells);
+    expect(result.hasDeadlock).toBe(false);
+  });
+
+  it('자기 숫자가 조건 대상이면 데드락 (number-complete 자기참조)', () => {
+    const solution = createTestSolution();
+    // (3,1)=5를 잠금, number-complete(5) 조건 → 카운트에서 자신 제외 → 최대 8 → 불충족
+    const puzzle = createTestPuzzle(solution, [[3, 1]]);
+
+    const lockedCells: LockedCell[] = [
+      {
+        position: { row: 3, col: 1 },
+        conditions: [{
+          type: 'number-complete',
+          target: 5,
+          description: '숫자 5을(를) 모두 배치하세요',
+        }],
+      },
+    ];
+
+    const result = checkDeadlock(puzzle, solution, lockedCells);
+    expect(result.hasDeadlock).toBe(true);
+  });
+
+  it('해제 불가능한 number-complete는 데드락', () => {
+    const solution = createTestSolution();
+    // (0,0)=5를 잠금, 조건: number-complete(5)
+    // 5가 다른 잠금 셀에도 있고 그 셀은 해제 불가 → 5가 9개 안 됨
+    const puzzle = createTestPuzzle(solution, [
+      [0, 0], // 5
+      [3, 1], // 5
+    ]);
+
+    // 두 셀 모두 number-complete(5) 조건
+    // 서로 잠겨있어서 5는 최대 7개(9-2) → 어느 쪽도 조건 충족 불가
+    const lockedCells: LockedCell[] = [
+      {
+        position: { row: 0, col: 0 },
+        conditions: [{
+          type: 'number-complete',
+          target: 5,
+          description: '숫자 5을(를) 모두 배치하세요',
+        }],
+      },
+      {
+        position: { row: 3, col: 1 },
+        conditions: [{
+          type: 'number-complete',
+          target: 5,
+          description: '숫자 5을(를) 모두 배치하세요',
+        }],
+      },
+    ];
+
+    const result = checkDeadlock(puzzle, solution, lockedCells);
+    expect(result.hasDeadlock).toBe(true);
+    expect(result.involvedCells).toHaveLength(2);
+    expect(result.reason).toContain('해제 불가능');
+  });
+
+  it('체인으로 연결되면 데드락이 해소된다', () => {
+    const solution = createTestSolution();
+    const puzzle = createTestPuzzle(solution, [
+      [0, 0], [0, 1], [0, 2], // 빈 칸
+      [3, 1], // 잠금: solution=5
+    ]);
+
+    // (0,0)은 row-complete(0)으로 해제 가능
+    // (3,1)은 number-complete(5)인데, (0,0)=5가 잠겨있어 직접 해제 불가
+    // → (0,0)이 체인으로 (3,1)을 해제
+    const lockedCells: LockedCell[] = [
+      {
+        position: { row: 0, col: 0 },
+        conditions: [{
+          type: 'row-complete',
+          target: 0,
+          description: '1행을 완성하세요',
+        }],
+        chainUnlocks: [{ row: 3, col: 1 }],
+      },
+      {
+        position: { row: 3, col: 1 },
+        conditions: [{
+          type: 'number-complete',
+          target: 5,
+          description: '숫자 5을(를) 모두 배치하세요',
+        }],
+      },
+    ];
+
+    const result = checkDeadlock(puzzle, solution, lockedCells);
+    expect(result.hasDeadlock).toBe(false);
+  });
+
+  it('순환 체인은 데드락이다', () => {
+    const solution = createTestSolution();
+    const puzzle = createTestPuzzle(solution, [[0, 0], [1, 0]]);
+
+    const lockedCells: LockedCell[] = [
+      {
+        position: { row: 0, col: 0 },
+        conditions: [{
+          type: 'number-complete',
+          target: 9, // 아마 해제 불가
+          description: '숫자 9을(를) 모두 배치하세요',
+        }],
+        chainUnlocks: [{ row: 1, col: 0 }],
+      },
+      {
+        position: { row: 1, col: 0 },
+        conditions: [{
+          type: 'number-complete',
+          target: 9,
+          description: '숫자 9을(를) 모두 배치하세요',
+        }],
+        chainUnlocks: [{ row: 0, col: 0 }],
+      },
+    ];
+
+    const result = checkDeadlock(puzzle, solution, lockedCells);
+    expect(result.hasDeadlock).toBe(true);
+    expect(result.reason).toContain('순환');
+  });
+
+  it('복합 조건 중 하나라도 충족 불가이면 데드락', () => {
+    const solution = createTestSolution();
+    // (0,0)=5 잠금, (3,1)=5 잠금
+    const puzzle = createTestPuzzle(solution, [[0, 0], [3, 1]]);
+
+    // (0,0): row-complete(0) + number-complete(5) 복합
+    // row-complete(0)은 충족 가능 (빈칸 없음)
+    // 하지만 number-complete(5)는 (3,1)도 잠겨있어 7개 뿐 → 미충족
+    // → (0,0) 해제 불가 → (3,1)도 해제 불가
+    const lockedCells: LockedCell[] = [
+      {
+        position: { row: 0, col: 0 },
+        conditions: [
+          { type: 'row-complete', target: 0, description: '1행을 완성하세요' },
+          { type: 'number-complete', target: 5, description: '숫자 5을(를) 모두 배치하세요' },
+        ],
+      },
+      {
+        position: { row: 3, col: 1 },
+        conditions: [{
+          type: 'row-complete',
+          target: 3,
+          description: '4행을 완성하세요',
+        }],
+      },
+    ];
+
+    const result = checkDeadlock(puzzle, solution, lockedCells);
+    // (0,0)은 number-complete(5) 때문에 해제 불가 (5가 7개)
+    // (3,1)은 row-complete(3)이고 row 3에 빈칸이 (3,1) 자체뿐 → 비잠금 빈칸 0 → 충족 가능
+    // → (3,1) 먼저 해제 → 5가 8개
+    // → (0,0)의 number-complete(5): 8 < 9 → 여전히 미충족
+    expect(result.hasDeadlock).toBe(true);
+    expect(result.involvedCells?.length).toBe(1);
+  });
+});
+
+// ─── checkDeadlock with generated puzzles ───────────
+
+describe('checkDeadlock — 생성 기반', () => {
+  it('placeLocks로 생성된 잠금은 데드락이 없다', async () => {
+    const { generateSolution } = await import('@/lib/sudoku/generator');
+    const { createPuzzleFromSolution } = await import('@/lib/sudoku/solver');
+    const { placeLocks } = await import('@/lib/sudoku/lockSystem');
+
+    const solution = generateSolution();
+    const puzzle = createPuzzleFromSolution(solution, 35);
+    const lockResult = placeLocks(
+      puzzle, solution, 3,
+      ['row-complete', 'col-complete', 'box-complete', 'number-complete'],
+      { allowComposite: true, allowChain: true },
+    );
+
+    const deadlock = checkDeadlock(puzzle, solution, lockResult.lockedCells);
+    expect(deadlock.hasDeadlock).toBe(false);
+  }, 15000);
+});

--- a/__tests__/sudoku/lockSystem-number.test.ts
+++ b/__tests__/sudoku/lockSystem-number.test.ts
@@ -198,17 +198,16 @@ describe('generateNumberCondition', () => {
     }
   });
 
-  it('완성된 보드에서도 잠금 대상 셀의 숫자가 후보가 된다', () => {
+  it('완성된 보드에서 자기 숫자는 후보에서 제외된다 (데드락 방지)', () => {
     const solution = createTestSolution();
     // 빈 칸 없이 완성된 보드
     const grid: Grid = solution.map((row) => row.map((v) => v as Digit | null));
     const lockedKeys = new Set<string>();
 
-    // (0,0)=5를 잠금 대상으로 지정하면, 5는 잠금 칸 제외 시 8개 → 후보
+    // (0,0)=5를 잠금 대상으로 지정하면, 5는 자기 숫자이므로 제외
+    // 다른 모든 숫자는 9개로 완성 → 후보 없음 → null
     const condition = generateNumberCondition(grid, { row: 0, col: 0 }, solution, lockedKeys);
-    expect(condition).not.toBeNull();
-    // 잠금 대상 셀의 숫자(5)만 후보가 됨 (다른 숫자는 여전히 9개)
-    expect(condition!.target).toBe(5);
+    expect(condition).toBeNull();
   });
 
   it('모든 셀이 이미 잠금 처리되면 null을 반환한다', () => {

--- a/src/lib/sudoku/lockSystem.ts
+++ b/src/lib/sudoku/lockSystem.ts
@@ -22,6 +22,7 @@ import type {
   LockConditionType,
   CellValue,
   Digit,
+  DeadlockCheckResult,
 } from '@/types/game';
 import { BOARD_SIZE, BOX_SIZE, DIGITS, cloneGrid, shuffle, posKey, getBoxIndex } from '@/lib/sudoku/utils';
 import { hasUniqueSolution } from '@/lib/sudoku/solver';
@@ -166,16 +167,22 @@ export const isNumberConditionMet = (
  * 보드에 아예 없는 숫자(0개)는 제외 — 완전히 빈 숫자를 조건으로 쓰면
  * 플레이어가 해당 숫자를 처음부터 전부 채워야 하므로 난이도 조절상 제외한다.
  *
+ * 잠금 셀 자체의 정답 숫자는 제외한다 — 자기 숫자가 조건 대상이 되면
+ * 카운트에서 자신이 제외되어 조건 충족이 불가능하다 (데드락 원인).
+ *
  * @param grid - 퍼즐 그리드
  * @param lockedKeys - 잠금 칸 키 Set (해당 셀 포함)
+ * @param excludeDigit - 제외할 숫자 (잠금 셀 자체의 정답 숫자)
  * @returns 후보 숫자 배열
  */
 const getNumberConditionCandidates = (
   grid: Grid,
   lockedKeys: Set<string>,
+  excludeDigit?: Digit,
 ): Digit[] => {
   const candidates: Digit[] = [];
   for (const d of DIGITS) {
+    if (d === excludeDigit) continue; // 자기 숫자 제외 (데드락 방지)
     const placed = countDigitPlacements(grid, d, lockedKeys);
     if (placed >= 1 && placed < BOARD_SIZE) {
       candidates.push(d);
@@ -203,7 +210,8 @@ export const generateNumberCondition = (
   const updatedLockedKeys = new Set(lockedKeys);
   updatedLockedKeys.add(posKey(pos.row, pos.col));
 
-  const candidates = getNumberConditionCandidates(grid, updatedLockedKeys);
+  const selfDigit = solution[pos.row][pos.col] as Digit;
+  const candidates = getNumberConditionCandidates(grid, updatedLockedKeys, selfDigit);
   if (candidates.length === 0) return null;
 
   const digit = candidates[Math.floor(Math.random() * candidates.length)];
@@ -313,7 +321,8 @@ export const generateCondition = (
         console.warn('[lockSystem] number-complete 조건 생성에는 solution 파라미터가 필요합니다.');
       }
     } else {
-      const numberCandidates = getNumberConditionCandidates(grid, updatedLockedKeys);
+      const selfDigit = solution[pos.row][pos.col] as Digit;
+      const numberCandidates = getNumberConditionCandidates(grid, updatedLockedKeys, selfDigit);
       for (const d of numberCandidates) {
         candidates.push({
           type: 'number-complete',
@@ -514,7 +523,8 @@ export const generateCompositeConditions = (
 
   // 숫자 조건 후보
   if (allowedTypes.includes('number-complete') && solution) {
-    const numberCandidates = getNumberConditionCandidates(grid, updatedLockedKeys);
+    const selfDigit = solution[pos.row][pos.col] as Digit;
+    const numberCandidates = getNumberConditionCandidates(grid, updatedLockedKeys, selfDigit);
     for (const d of numberCandidates) {
       allCandidates.push({
         type: 'number-complete',
@@ -792,14 +802,24 @@ export const placeLocks = (
     finalLockedCells = setupChainLinks(lockedCells, chainCount);
   }
 
-  // 최종 통합 검증: 개별 검증을 통과했더라도 전체 조합이 유효한지 확인
+  // 최종 통합 검증: 풀이 가능성 + 데드락 검사
   if (finalLockedCells.length > 0) {
-    if (!validateSolvabilityWithLocks(workingPuzzle, solution, finalLockedCells)) {
+    const solvable = validateSolvabilityWithLocks(workingPuzzle, solution, finalLockedCells);
+    const deadlockResult = checkDeadlock(workingPuzzle, solution, finalLockedCells);
+
+    if (!solvable || deadlockResult.hasDeadlock) {
       if (process.env.NODE_ENV !== 'production') {
-        console.warn('[lockSystem] 최종 통합 검증 실패 — 체인 없이 재시도합니다.');
+        const reason = !solvable ? '풀이 불가' : `데드락: ${deadlockResult.reason}`;
+        console.warn(`[lockSystem] 최종 검증 실패 (${reason}) — 체인 없이 재시도합니다.`);
       }
       // 체인 제거 후 개별 검증 통과한 원본으로 fallback
       finalLockedCells = lockedCells;
+
+      // fallback에서도 데드락 검사
+      const fallbackCheck = checkDeadlock(workingPuzzle, solution, finalLockedCells);
+      if (fallbackCheck.hasDeadlock && process.env.NODE_ENV !== 'production') {
+        console.warn(`[lockSystem] fallback에서도 데드락 감지: ${fallbackCheck.reason}`);
+      }
     }
   }
 
@@ -809,11 +829,177 @@ export const placeLocks = (
   };
 };
 
+// ─── 데드락 검증 ────────────────────────────────────
+
+/**
+ * 체인 관계에 순환이 있는지 검사한다 (DFS 기반).
+ *
+ * @param lockedCells - 잠금 칸 목록
+ * @returns 순환이 있으면 true
+ */
+export const hasChainCycle = (lockedCells: LockedCell[]): boolean => {
+  // 인접 리스트 구축
+  const adj = new Map<string, string[]>();
+  for (const lc of lockedCells) {
+    const key = posKey(lc.position.row, lc.position.col);
+    if (lc.chainUnlocks && lc.chainUnlocks.length > 0) {
+      adj.set(key, lc.chainUnlocks.map((p) => posKey(p.row, p.col)));
+    }
+  }
+
+  // DFS 순환 탐지: 0=미방문, 1=진행중, 2=완료
+  const state = new Map<string, number>();
+  for (const lc of lockedCells) {
+    state.set(posKey(lc.position.row, lc.position.col), 0);
+  }
+
+  const dfs = (key: string): boolean => {
+    if (state.get(key) === 1) return true;  // 순환 발견
+    if (state.get(key) === 2) return false; // 이미 검사 완료
+
+    state.set(key, 1); // 진행중
+    const neighbors = adj.get(key) || [];
+    for (const next of neighbors) {
+      if (dfs(next)) return true;
+    }
+    state.set(key, 2); // 완료
+    return false;
+  };
+
+  for (const lc of lockedCells) {
+    const key = posKey(lc.position.row, lc.position.col);
+    if (state.get(key) === 0) {
+      if (dfs(key)) return true;
+    }
+  }
+
+  return false;
+};
+
+/**
+ * 잠금 칸 조합의 데드락 여부를 검증한다.
+ *
+ * 시뮬레이션 방식:
+ * 1. 모든 비잠금 빈 칸을 정답값으로 채운 그리드를 만든다.
+ * 2. 잠금 칸은 null로 유지한다.
+ * 3. 반복적으로 조건 충족된 잠금 칸 + 체인 캐스케이드를 해제한다.
+ * 4. 해제된 셀의 정답값을 그리드에 반영하고, 다시 조건을 검사한다.
+ * 5. 더 이상 해제할 셀이 없는데 잠금 셀이 남아있으면 데드락이다.
+ *
+ * @param puzzle - 퍼즐 그리드
+ * @param solution - 정답 그리드
+ * @param lockedCells - 잠금 칸 목록
+ * @returns 데드락 검증 결과
+ *
+ * @example
+ * ```ts
+ * const result = checkDeadlock(puzzle, solution, lockedCells);
+ * if (result.hasDeadlock) {
+ *   console.log(result.reason);          // "2개의 잠금 칸이 해제 불가능합니다"
+ *   console.log(result.involvedCells);   // [{row: 0, col: 3}, {row: 2, col: 5}]
+ * }
+ * ```
+ */
+export const checkDeadlock = (
+  puzzle: Grid,
+  solution: SolutionGrid,
+  lockedCells: LockedCell[],
+): DeadlockCheckResult => {
+  if (lockedCells.length === 0) {
+    return { hasDeadlock: false };
+  }
+
+  // 1. 순환 체인 검사
+  if (hasChainCycle(lockedCells)) {
+    return {
+      hasDeadlock: true,
+      reason: '체인 관계에 순환이 존재합니다',
+      involvedCells: lockedCells.map((lc) => lc.position),
+    };
+  }
+
+  // 2. 시뮬레이션 그리드: 비잠금 빈 칸을 정답으로 채움
+  const simGrid = cloneGrid(puzzle);
+  const lockedKeySet = new Set(
+    lockedCells.map((lc) => posKey(lc.position.row, lc.position.col)),
+  );
+  for (let r = 0; r < BOARD_SIZE; r++) {
+    for (let c = 0; c < BOARD_SIZE; c++) {
+      if (simGrid[r][c] === null && !lockedKeySet.has(posKey(r, c))) {
+        simGrid[r][c] = solution[r][c] as CellValue;
+      }
+    }
+  }
+
+  // 3. 점진적 해제 시뮬레이션
+  let remaining = [...lockedCells];
+  let changed = true;
+
+  while (changed && remaining.length > 0) {
+    changed = false;
+    const currentLockedKeys = new Set(
+      remaining.map((lc) => posKey(lc.position.row, lc.position.col)),
+    );
+
+    // 조건 충족된 셀 찾기
+    const directUnlockKeys = new Set<string>();
+    for (const lc of remaining) {
+      if (lc.conditions.every((cond) => isAreaConditionMet(simGrid, cond, currentLockedKeys))) {
+        directUnlockKeys.add(posKey(lc.position.row, lc.position.col));
+      }
+    }
+
+    // 체인 캐스케이드 (BFS)
+    const allUnlockKeys = new Set(directUnlockKeys);
+    const queue = [...directUnlockKeys];
+    // 빠른 조회를 위한 맵
+    const remainingMap = new Map(
+      remaining.map((lc) => [posKey(lc.position.row, lc.position.col), lc]),
+    );
+
+    while (queue.length > 0) {
+      const key = queue.shift()!;
+      const cell = remainingMap.get(key);
+      if (!cell?.chainUnlocks) continue;
+
+      for (const target of cell.chainUnlocks) {
+        const targetKey = posKey(target.row, target.col);
+        if (!allUnlockKeys.has(targetKey) && currentLockedKeys.has(targetKey)) {
+          allUnlockKeys.add(targetKey);
+          queue.push(targetKey);
+        }
+      }
+    }
+
+    // 해제: 정답값 반영
+    if (allUnlockKeys.size > 0) {
+      for (const lc of remaining) {
+        const key = posKey(lc.position.row, lc.position.col);
+        if (allUnlockKeys.has(key)) {
+          simGrid[lc.position.row][lc.position.col] = solution[lc.position.row][lc.position.col] as CellValue;
+        }
+      }
+      remaining = remaining.filter(
+        (lc) => !allUnlockKeys.has(posKey(lc.position.row, lc.position.col)),
+      );
+      changed = true;
+    }
+  }
+
+  // 4. 결과 판정
+  if (remaining.length === 0) {
+    return { hasDeadlock: false };
+  }
+
+  return {
+    hasDeadlock: true,
+    reason: `${remaining.length}개의 잠금 칸이 해제 불가능합니다`,
+    involvedCells: remaining.map((lc) => lc.position),
+  };
+};
+
 /**
  * @internal 테스트 전용 export — 외부에서 직접 사용 금지
- * countDigitPlacements, isNumberConditionMet, generateNumberCondition,
- * generateCompositeConditions, setupChainLinks, findUnlockableCellsWithChain은
- * 이미 export const로 선언되어 있으므로 여기에 중복하지 않음.
  */
 export {
   getRowPositions,

--- a/src/lib/sudoku/lockSystem.ts
+++ b/src/lib/sudoku/lockSystem.ts
@@ -815,10 +815,19 @@ export const placeLocks = (
       // 체인 제거 후 개별 검증 통과한 원본으로 fallback
       finalLockedCells = lockedCells;
 
-      // fallback에서도 데드락 검사
+      // fallback에서도 데드락 검사 → 원인 셀 제거
       const fallbackCheck = checkDeadlock(workingPuzzle, solution, finalLockedCells);
-      if (fallbackCheck.hasDeadlock && process.env.NODE_ENV !== 'production') {
-        console.warn(`[lockSystem] fallback에서도 데드락 감지: ${fallbackCheck.reason}`);
+      if (fallbackCheck.hasDeadlock) {
+        if (process.env.NODE_ENV !== 'production') {
+          console.warn(`[lockSystem] fallback에서도 데드락 감지: ${fallbackCheck.reason} — 원인 셀을 제거합니다.`);
+        }
+        // 데드락 원인 셀을 제거하여 안전한 잠금 목록만 유지
+        const involvedKeys = new Set(
+          (fallbackCheck.involvedCells || []).map((p) => posKey(p.row, p.col)),
+        );
+        finalLockedCells = finalLockedCells.filter(
+          (lc) => !involvedKeys.has(posKey(lc.position.row, lc.position.col)),
+        );
       }
     }
   }


### PR DESCRIPTION
## Summary
- **`checkDeadlock`**: 시뮬레이션 기반 점진적 해제 검증
  - 비잠금 셀을 정답값으로 채운 후, 반복적으로 조건 충족 셀 + 체인 캐스케이드를 해제
  - 더 이상 해제 불가능한데 잠금 셀이 남아있으면 데드락 판정
  - `DeadlockCheckResult` 반환 (reason, involvedCells 포함)
- **`hasChainCycle`**: DFS 기반 순환 체인 탐지 (cycle이 있으면 즉시 데드락)
- **number-complete 자기참조 데드락 방지**
  - `getNumberConditionCandidates`에 `excludeDigit` 파라미터 추가
  - 잠금 셀의 정답 숫자를 조건 후보에서 제외 (자기 숫자 → 카운트에서 제외 → 조건 충족 불가)
  - `generateNumberCondition`, `generateCondition`, `generateCompositeConditions` 모두 반영
- **`placeLocks` 통합 검증 강화**: 데드락 감지 시 체인 제거 fallback

## 데드락 시나리오 & 대응
| 시나리오 | 대응 |
|---------|------|
| 순환 체인 (A→B→A) | `hasChainCycle` DFS 탐지 |
| number-complete 자기참조 | 후보 생성 시 자기 숫자 제외 |
| 상호 number-complete 교착 | `checkDeadlock` 시뮬레이션에서 탐지 |
| 점진적 해제 불가 | `checkDeadlock`의 반복 해제 시뮬레이션 |

## Test plan
- [x] `lockSystem-deadlock.test.ts` — 16 tests
  - hasChainCycle: 순환/비순환/빈 목록 6개
  - checkDeadlock: 영역/점진적/자기참조/상호참조/체인해소/순환/복합/생성기반 10개
- [x] `lockSystem-number.test.ts` — 기존 테스트 수정 (자기 숫자 제외 반영)
- [x] 전체 192 tests 통과 (회귀 없음)
- [x] `pnpm type-check` 통과
- [x] `pnpm lint` 통과

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)