### PR TITLE
[Engine] fix/gamestore-safety — 잠금 복원·타입 안전성·렌더링 최적화

### DIFF
--- a/__tests__/sudoku/game-store.test.ts
+++ b/__tests__/sudoku/game-store.test.ts
@@ -60,10 +60,11 @@ beforeEach(() => {
   // 스토어 초기화 (persist 상태 포함)
   useGameStore.setState({
     board: [],
-    solution: [] as unknown as SolutionGrid,
+    solution: null,
     stage: 0,
     config: null,
     lockedCells: [],
+    initialLockedCells: [],
     selectedCell: null,
     isNoteMode: false,
     timer: 0,

--- a/docs/adr/300-game-store-refactor.md
+++ b/docs/adr/300-game-store-refactor.md
@@ -1,0 +1,89 @@
+# ADR-300: game-store.ts 리팩토링 — 잠금 복원, 타입 안전성, 렌더링 최적화
+
+## Status
+
+Accepted
+
+## Context
+
+PR #31에서 구현된 `game-store.ts`에 4가지 구조적 문제가 발견되었다.
+
+### 문제 1: reset 시 잠금 칸이 원래대로 복원되지 않음
+
+`reset()`이 현재 시점의 `lockedCells`를 "원래 목록"으로 사용했다.
+게임 중 잠금이 해제되면 `lockedCells`에서 빠지므로, reset 시점에는 이미 줄어든 목록을 참조하게 된다.
+
+```ts
+// Before: 이미 줄어든 목록을 원래 목록이라고 가져옴
+const result = get();
+const originalLockedCells = result.lockedCells; // 해제된 셀은 이미 빠져있음
+```
+
+### 문제 2: 불필요한 Set 생성으로 인한 성능 저하
+
+`setValue`, `clearValue`, `toggleNote`, `processUnlocks` 4곳에서 변경하지 않는 셀까지 매번 새 객체 + `new Set()`을 생성했다.
+
+```ts
+// Before: 81개 셀 전부 새 객체 생성
+return { ...c, notes: new Set(c.notes) }; // 변경 안 하는 셀도 복사
+```
+
+이는 9x9=81개 셀을 매 입력마다 전부 복사하는 비용이 발생하고, React에서 `memo`/`useMemo`로 셀 단위 리렌더링 최적화를 할 때 참조가 항상 바뀌어 최적화가 무력화된다.
+
+### 문제 3: 타입 안전성을 우회하는 EMPTY_SOLUTION
+
+```ts
+// Before: as unknown as — 타입 시스템을 완전히 우회
+const EMPTY_SOLUTION: SolutionGrid = [] as unknown as SolutionGrid;
+```
+
+`initGame` 전에 `solution`에 접근하면 빈 배열이지만 타입은 `SolutionGrid`이므로 컴파일러가 경고하지 않는다.
+
+### 문제 4: reset 내부 주석과 실제 동작 불일치
+
+주석은 "원래 목록으로 복원", "원래 solution/puzzle에서 재생성"을 논의하지만, 실제 코드는 현재 시점의 `lockedCells`를 그대로 사용했다.
+
+## Decision
+
+### 1. `initialLockedCells` 필드 추가
+
+- `GameStoreState`에 `initialLockedCells: LockedCell[]` 필드를 추가한다.
+- `initGame()`에서 최초 잠금 목록을 `initialLockedCells`에 저장한다.
+- `reset()`에서는 `initialLockedCells`를 참조하여 원래 잠금 상태를 복원한다.
+- `initialLockedCells`는 게임 진행 중 변경되지 않는다.
+
+### 2. 변경 대상 셀만 새 객체 생성
+
+- `setValue`, `clearValue`, `toggleNote`, `processUnlocks`에서 변경하지 않는 셀은 기존 참조를 그대로 반환한다 (`return c`).
+- 변경 대상 셀만 `{ ...c, ... }` + `new Set()`으로 새 객체를 생성한다.
+- 이를 통해 React에서 `React.memo` 또는 `useMemo`로 셀 단위 리렌더링 최적화가 가능해진다.
+
+### 3. `solution: SolutionGrid | null`로 변경
+
+- `solution` 타입을 `SolutionGrid | null`로 선언하고, 초기값은 `null`로 둔다.
+- `setValue`에서 `!solution` 가드를 추가하여 null일 때 입력을 차단한다.
+- `as unknown as` 캐스팅을 제거하여 타입 안전성을 확보한다.
+
+### 4. reset 주석 정리
+
+- 문제 1의 수정으로 주석과 코드의 불일치가 해소된다.
+- "원래 목록으로 복원"이 실제로 `initialLockedCells`를 참조하므로 코드가 주석의 의도와 일치한다.
+
+## Consequences
+
+### 긍정적
+
+- **reset 정확성**: 잠금 해제 후 reset해도 원래 잠금 칸이 모두 복원된다.
+- **렌더링 최적화**: 변경되지 않은 셀의 참조가 유지되어, React 셀 컴포넌트에서 `memo` 최적화가 유효하게 동작한다. 매 입력마다 81개 → 1개 셀만 새 객체가 생성된다.
+- **타입 안전성**: `initGame` 전에 `solution`에 접근하면 `null`이므로 컴파일러가 경고한다.
+- **코드 정합성**: 주석과 실제 동작이 일치한다.
+
+### 부정적
+
+- `initialLockedCells` 필드가 추가되어 persist 대상이 늘어난다 (미미한 localStorage 사용량 증가).
+- `solution`이 nullable이 되어 사용처에서 null 체크가 필요하다 (현재는 `setValue` 1곳).
+
+---
+
+**변경 파일**: `src/stores/game-store.ts`, `__tests__/sudoku/game-store.test.ts`
+**관련 PR**: PR #31 (원본), 이 리팩토링으로 수정

--- a/src/lib/sudoku/validator.ts
+++ b/src/lib/sudoku/validator.ts
@@ -90,12 +90,13 @@ export const findAllConflicts = (board: Board): Set<string> => {
 export const updateBoardErrors = (board: Board): Board => {
   const conflicts = findAllConflicts(board);
 
+  // isError가 실제로 변경되는 셀만 새 객체 생성 — 셀 참조 유지로 React memo 최적화 가능
   return board.map((row, r) =>
-    row.map((cell, c): Cell => ({
-      ...cell,
-      notes: new Set(cell.notes),
-      isError: conflicts.has(posKey(r, c)),
-    })),
+    row.map((cell, c): Cell => {
+      const shouldError = conflicts.has(posKey(r, c));
+      if (cell.isError === shouldError) return cell;
+      return { ...cell, notes: new Set(cell.notes), isError: shouldError };
+    }),
   );
 };
 

--- a/src/stores/game-store.ts
+++ b/src/stores/game-store.ts
@@ -66,14 +66,16 @@ interface GameStoreState {
   // ── 게임 데이터 ──
   /** 현재 보드 */
   board: Board;
-  /** 정답 */
-  solution: SolutionGrid;
+  /** 정답 (게임 시작 전에는 null) */
+  solution: SolutionGrid | null;
   /** 현재 스테이지 */
   stage: number;
   /** 스테이지 설정 */
   config: StageConfig | null;
-  /** 남은 잠금 칸 목록 */
+  /** 남은 잠금 칸 목록 (게임 진행 중 해제되면 줄어듦) */
   lockedCells: LockedCell[];
+  /** 최초 잠금 칸 목록 (reset 시 복원용, 게임 중 변경되지 않음) */
+  initialLockedCells: LockedCell[];
 
   // ── UI 상태 ──
   /** 선택된 셀 */
@@ -138,14 +140,14 @@ export type GameStore = GameStoreState & GameStoreActions;
 // ─── 초기 상태 ──────────────────────────────────────
 
 const EMPTY_BOARD: Board = [];
-const EMPTY_SOLUTION: SolutionGrid = [] as unknown as SolutionGrid;
 
 const initialState: GameStoreState = {
   board: EMPTY_BOARD,
-  solution: EMPTY_SOLUTION,
+  solution: null,
   stage: 0,
   config: null,
   lockedCells: [],
+  initialLockedCells: [],
   selectedCell: null,
   isNoteMode: false,
   timer: 0,
@@ -197,13 +199,13 @@ const processUnlocks = (
     unlockable.map((lc) => posKey(lc.position.row, lc.position.col)),
   );
 
-  // 보드에서 isLocked 해제
+  // 보드에서 isLocked 해제 — 변경 대상 셀만 새 객체 생성
   const newBoard = board.map((row, r) =>
     row.map((cell, c): Cell => {
       if (unlockKeys.has(posKey(r, c))) {
         return { ...cell, notes: new Set(cell.notes), isLocked: false };
       }
-      return { ...cell, notes: new Set(cell.notes) };
+      return cell;
     }),
   );
 
@@ -258,7 +260,7 @@ export const deserializeHistory = (data: { board: SerializedCell[][]; lockedCell
 
 interface PersistedState {
   board: SerializedCell[][];
-  solution: SolutionGrid;
+  solution: SolutionGrid | null;
   stage: number;
   config: StageConfig | null;
   lockedCells: LockedCell[];
@@ -286,6 +288,7 @@ export const useGameStore = create<GameStore>()(
           stage,
           config: result.config,
           lockedCells: result.lockedCells,
+          initialLockedCells: result.lockedCells,
           selectedCell: null,
           isNoteMode: false,
           timer: 0,
@@ -298,13 +301,17 @@ export const useGameStore = create<GameStore>()(
 
       // ── reset ──
       reset: () => {
-        const { stage, config } = get();
+        const { stage, config, board: currentBoard, initialLockedCells } = get();
         if (!config || stage === 0) return;
 
-        // 초기 보드를 히스토리에서 복원하지 않고, 현재 보드의 given 셀만 유지
-        const currentBoard = get().board;
-        const resetBoard: Board = currentBoard.map((row) =>
-          row.map((cell): Cell => {
+        // initialLockedCells에서 잠금 위치 키 Set 생성
+        const lockedKeys = new Set(
+          initialLockedCells.map((lc) => posKey(lc.position.row, lc.position.col)),
+        );
+
+        // given 셀 유지, 나머지 초기화, 잠금은 최초 목록 기준으로 복원
+        const resetBoard: Board = currentBoard.map((row, r) =>
+          row.map((cell, c): Cell => {
             if (cell.isGiven) {
               return { ...cell, notes: new Set(), isError: false };
             }
@@ -313,32 +320,13 @@ export const useGameStore = create<GameStore>()(
               isGiven: false,
               notes: new Set(),
               isError: false,
-              isLocked: cell.isLocked, // 원래 잠금 상태는 유지하지 않고 재계산
+              isLocked: lockedKeys.has(posKey(r, c)),
             };
           }),
         );
 
-        // 잠금 칸은 initGame 시 원래 목록으로 복원
-        // 현재 config에서 재생성하면 랜덤이 달라지므로, 원래 보드의 given을 기반으로 재구성
-        // → 심플하게: initGame과 동일한 효과를 위해 원래 solution/puzzle에서 재생성
-        const result = get();
-        const originalLockedCells = result.lockedCells;
-
-        // 잠금 칸을 원래 목록으로 복원하고, 보드에서도 잠금 표시
-        const lockedKeys = new Set(
-          originalLockedCells.map((lc) => posKey(lc.position.row, lc.position.col)),
-        );
-
-        const finalBoard: Board = resetBoard.map((row, r) =>
-          row.map((cell, c): Cell => ({
-            ...cell,
-            notes: new Set(),
-            isLocked: lockedKeys.has(posKey(r, c)) ? true : cell.isLocked,
-          })),
-        );
-
         // given 셀만으로 이미 충족되는 잠금 조건을 재검사
-        const unlockResult = processUnlocks(finalBoard, originalLockedCells);
+        const unlockResult = processUnlocks(resetBoard, initialLockedCells);
 
         set({
           board: unlockResult.board,
@@ -355,7 +343,7 @@ export const useGameStore = create<GameStore>()(
       // ── setValue ──
       setValue: (row: number, col: number, digit: Digit) => {
         const { board, solution, lockedCells, history, isComplete } = get();
-        if (isComplete) return;
+        if (isComplete || !solution) return;
 
         const cell = board[row]?.[col];
         if (!cell || cell.isGiven || cell.isLocked) return;
@@ -363,7 +351,7 @@ export const useGameStore = create<GameStore>()(
         // 히스토리 저장
         const newHistory = pushHistory(history, board, lockedCells);
 
-        // 셀 값 설정 + 메모 초기화
+        // 셀 값 설정 + 메모 초기화 — 변경 대상 셀만 새 객체 생성
         const newBoard = board.map((r, ri) =>
           r.map((c, ci): Cell => {
             if (ri === row && ci === col) {
@@ -374,7 +362,7 @@ export const useGameStore = create<GameStore>()(
                 isError: false,
               };
             }
-            return { ...c, notes: new Set(c.notes) };
+            return c;
           }),
         );
 
@@ -407,13 +395,13 @@ export const useGameStore = create<GameStore>()(
         // 히스토리 저장
         const newHistory = pushHistory(history, board, lockedCells);
 
-        // 셀 값 삭제
+        // 셀 값 삭제 — 변경 대상 셀만 새 객체 생성
         const newBoard = board.map((r, ri) =>
           r.map((c, ci): Cell => {
             if (ri === row && ci === col) {
               return { ...c, value: null, notes: new Set<Digit>(), isError: false };
             }
-            return { ...c, notes: new Set(c.notes) };
+            return c;
           }),
         );
 
@@ -439,7 +427,7 @@ export const useGameStore = create<GameStore>()(
         // 히스토리 저장
         const newHistory = pushHistory(history, board, lockedCells);
 
-        // 메모 토글
+        // 메모 토글 — 변경 대상 셀만 새 객체 생성
         const newBoard = board.map((r, ri) =>
           r.map((c, ci): Cell => {
             if (ri === row && ci === col) {
@@ -451,7 +439,7 @@ export const useGameStore = create<GameStore>()(
               }
               return { ...c, notes: newNotes };
             }
-            return { ...c, notes: new Set(c.notes) };
+            return c;
           }),
         );
 

--- a/src/stores/game-store.ts
+++ b/src/stores/game-store.ts
@@ -264,6 +264,7 @@ interface PersistedState {
   stage: number;
   config: StageConfig | null;
   lockedCells: LockedCell[];
+  initialLockedCells: LockedCell[];
   timer: number;
   history: { board: SerializedCell[][]; lockedCells: LockedCell[] }[];
   isStarted: boolean;
@@ -507,6 +508,7 @@ export const useGameStore = create<GameStore>()(
         stage: state.stage,
         config: state.config,
         lockedCells: state.lockedCells,
+        initialLockedCells: state.initialLockedCells,
         timer: state.timer,
         history: serializeHistory(state.history),
         isStarted: state.isStarted,
@@ -527,6 +529,7 @@ export const useGameStore = create<GameStore>()(
           stage: data.stage,
           config: data.config,
           lockedCells: data.lockedCells,
+          initialLockedCells: data.initialLockedCells || data.lockedCells,
           timer: data.timer,
           history: deserializeHistory(data.history || []),
           isStarted: data.isStarted,


### PR DESCRIPTION
## Summary
- **reset 잠금 복원 버그 수정**: `initialLockedCells` 필드를 추가하여, reset 시 게임 중 해제된 잠금이 아닌 최초 잠금 목록으로 정확히 복원
- **렌더링 최적화**: `setValue`/`clearValue`/`toggleNote`/`processUnlocks`에서 변경 대상 셀만 새 객체 생성 (81개→1개). React `memo` 셀 단위 최적화 가능
- **타입 안전성**: `solution: SolutionGrid | null`로 변경, `as unknown as` 캐스팅 제거
- **reset 주석/코드 불일치 정리**

## 변경 상세

### 1. `initialLockedCells` 필드 추가
| Before | After |
|--------|-------|
| `reset()`이 현재 `lockedCells`(이미 줄어든 목록) 참조 | `initGame()`에서 `initialLockedCells`에 최초 목록 저장, `reset()`에서 참조 |

### 2. 불필요한 Set 생성 제거
| Before | After |
|--------|-------|
| 변경 안 하는 셀도 `{ ...c, notes: new Set(c.notes) }` | 변경 셀만 새 객체, 나머지 `return c` |

### 3. EMPTY_SOLUTION 타입 캐스팅 제거
| Before | After |
|--------|-------|
| `[] as unknown as SolutionGrid` | `solution: SolutionGrid \| null`, 초기값 `null` |

## Test plan
- [x] TypeScript strict 타입 체크 통과
- [x] 342개 테스트 전체 통과 (회귀 없음)
- [x] ADR-300 문서화 완료

🤖 Generated with [Claude Code](https://claude.com/claude-code)