### PR TITLE
[Frontend] feat/ui-login — 로그인 페이지 UI 구현

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useSearchParams } from "next/navigation";
+import { Suspense } from "react";
+import { Grid3X3, AlertCircle, ArrowLeft } from "lucide-react";
+import Link from "next/link";
+import OAuthButton from "@/components/auth/oauth-button";
+
+/** Auth.js 에러 코드 → 사용자 친화적 메시지 */
+const errorMessages: Record<string, string> = {
+  OAuthSignin: "OAuth 서비스 연결에 실패했습니다. 다시 시도해주세요.",
+  OAuthCallback: "로그인 처리 중 문제가 발생했습니다. 다시 시도해주세요.",
+  OAuthAccountNotLinked:
+    "이미 다른 방법으로 가입된 이메일입니다. 기존 로그인 방식을 사용해주세요.",
+  Callback: "로그인에 실패했습니다. 다시 시도해주세요.",
+  Default: "로그인에 실패했습니다. 다시 시도해주세요.",
+};
+
+const LoginContent = () => {
+  const searchParams = useSearchParams();
+  const error = searchParams.get("error");
+  const callbackUrl = searchParams.get("callbackUrl") ?? "/";
+
+  const errorMessage = error
+    ? errorMessages[error] ?? errorMessages.Default
+    : null;
+
+  return (
+    <div className="flex min-h-dvh flex-col">
+      {/* Header (56px) */}
+      <header className="flex h-14 shrink-0 items-center px-4">
+        <Link
+          href="/"
+          className="flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+          aria-label="홈으로 돌아가기"
+        >
+          <ArrowLeft className="size-5" />
+          <span className="sr-only">뒤로</span>
+        </Link>
+        <h1 className="flex-1 text-center text-sm font-medium">로그인</h1>
+        {/* 좌측 아이콘과 대칭을 위한 빈 공간 */}
+        <div className="size-5" />
+      </header>
+
+      {/* 메인 콘텐츠 — 2컬럼 반응형 */}
+      <main className="flex flex-1 items-center justify-center px-6 py-10 lg:gap-16">
+        {/* 좌측 일러스트 영역 (≥1024px만 표시) */}
+        <div className="hidden lg:flex lg:flex-col lg:items-center lg:gap-6">
+          <div className="flex size-32 items-center justify-center rounded-2xl bg-sudoku-primary/10">
+            <Grid3X3
+              className="size-20 text-sudoku-primary"
+              strokeWidth={1.5}
+            />
+          </div>
+          <div className="text-center">
+            <p className="text-2xl font-bold">스도쿠</p>
+            <p className="mt-2 text-sm text-muted-foreground">
+              언제 어디서든 즐기는 숫자 퍼즐
+            </p>
+          </div>
+        </div>
+
+        {/* 로그인 폼 영역 */}
+        <div
+          className={
+            "flex w-full flex-col items-center " +
+            /* ≥768px: 카드 UI */
+            "md:w-100 md:rounded-xl md:border md:border-border md:bg-card md:p-8 md:shadow-lg"
+          }
+        >
+          {/* 로고 & 텍스트 (PC 2컬럼에서는 숨김) */}
+          <div className="flex flex-col items-center lg:hidden">
+            <Grid3X3
+              className="size-14 text-sudoku-primary xs:size-16"
+              strokeWidth={1.5}
+            />
+            <h2 className="mt-4 text-2xl font-bold">스도쿠</h2>
+            <p className="mt-2 text-sm text-muted-foreground">
+              스도쿠에 오신 것을 환영합니다
+            </p>
+          </div>
+
+          {/* PC 2컬럼일 때 카드 내부 타이틀 */}
+          <div className="hidden lg:block lg:w-full lg:text-center">
+            <h2 className="text-xl font-bold">로그인</h2>
+            <p className="mt-1 text-sm text-muted-foreground">
+              소셜 계정으로 간편하게 시작하세요
+            </p>
+          </div>
+
+          {/* 에러 메시지 */}
+          {errorMessage && (
+            <div
+              className="mt-6 flex w-full max-w-[320px] items-start gap-2 animate-in fade-in duration-200"
+              role="alert"
+            >
+              <AlertCircle className="mt-0.5 size-4 shrink-0 text-destructive" />
+              <p className="text-[13px] text-destructive">{errorMessage}</p>
+            </div>
+          )}
+
+          {/* OAuth 버튼 */}
+          <div className="mt-10 flex w-full flex-col items-center gap-3 lg:mt-8">
+            <OAuthButton provider="google" callbackUrl={callbackUrl} />
+            <OAuthButton provider="naver" callbackUrl={callbackUrl} />
+          </div>
+
+          {/* 하단 캡션 */}
+          <p className="mt-6 text-center text-xs text-muted-foreground">
+            게임은 로그인 없이도 즐길 수 있어요
+          </p>
+        </div>
+      </main>
+    </div>
+  );
+};
+
+/** useSearchParams()는 Suspense 경계 안에서 사용해야 함 */
+const LoginPage = () => {
+  return (
+    <Suspense
+      fallback={
+        <div className="flex min-h-dvh items-center justify-center">
+          <Grid3X3
+            className="size-10 animate-pulse text-sudoku-primary"
+            strokeWidth={1.5}
+          />
+        </div>
+      }
+    >
+      <LoginContent />
+    </Suspense>
+  );
+};
+
+export default LoginPage;

--- a/src/components/auth/google-logo.tsx
+++ b/src/components/auth/google-logo.tsx
@@ -1,0 +1,37 @@
+interface GoogleLogoProps {
+  className?: string;
+  size?: number;
+}
+
+const GoogleLogo = ({ className, size = 20 }: GoogleLogoProps) => {
+  return (
+    <svg
+      className={className}
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <path
+        d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 0 1-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1Z"
+        fill="#4285F4"
+      />
+      <path
+        d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23Z"
+        fill="#34A853"
+      />
+      <path
+        d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18A11.96 11.96 0 0 0 1 12c0 1.94.46 3.77 1.18 4.93l3.66-2.84Z"
+        fill="#FBBC05"
+      />
+      <path
+        d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53Z"
+        fill="#EA4335"
+      />
+    </svg>
+  );
+};
+
+export default GoogleLogo;

--- a/src/components/auth/naver-logo.tsx
+++ b/src/components/auth/naver-logo.tsx
@@ -1,0 +1,25 @@
+interface NaverLogoProps {
+  className?: string;
+  size?: number;
+}
+
+const NaverLogo = ({ className, size = 20 }: NaverLogoProps) => {
+  return (
+    <svg
+      className={className}
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <path
+        d="M16.27 12.77 7.38 0H0v24h7.73V11.23L16.62 24H24V0h-7.73v12.77Z"
+        fill="currentColor"
+      />
+    </svg>
+  );
+};
+
+export default NaverLogo;

--- a/src/components/auth/oauth-button.tsx
+++ b/src/components/auth/oauth-button.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { signIn } from "next-auth/react";
+import { useState } from "react";
+import { Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+import GoogleLogo from "./google-logo";
+import NaverLogo from "./naver-logo";
+
+interface OAuthButtonProps {
+  provider: "google" | "naver";
+  callbackUrl?: string;
+  className?: string;
+}
+
+const providerConfig = {
+  google: {
+    label: "Google로 계속하기",
+    loadingLabel: "로그인 중...",
+    Logo: GoogleLogo,
+    className: cn(
+      /* Light */
+      "bg-[oklch(0.98_0_0)] border border-border text-[oklch(0.30_0_0)]",
+      "shadow-sm",
+      "hover:bg-[oklch(0.96_0_0)]",
+      "active:bg-[oklch(0.94_0_0)] active:scale-[0.98]",
+      /* Dark */
+      "dark:bg-[oklch(0.25_0_0)] dark:border-[oklch(1_0_0/15%)] dark:text-[oklch(0.92_0_0)]",
+      "dark:hover:bg-[oklch(0.28_0_0)]",
+      "dark:active:bg-[oklch(0.22_0_0)]"
+    ),
+  },
+  naver: {
+    label: "네이버로 계속하기",
+    loadingLabel: "로그인 중...",
+    Logo: NaverLogo,
+    className: cn(
+      /* Light & Dark (브랜드 색상 유지) */
+      "bg-[oklch(0.62_0.17_145)] border-transparent text-white",
+      "hover:bg-[oklch(0.58_0.17_145)]",
+      "active:bg-[oklch(0.55_0.17_145)] active:scale-[0.98]"
+    ),
+  },
+} as const;
+
+const OAuthButton = ({
+  provider,
+  callbackUrl = "/",
+  className,
+}: OAuthButtonProps) => {
+  const [isLoading, setIsLoading] = useState(false);
+  const config = providerConfig[provider];
+  const { Logo } = config;
+
+  const handleClick = async () => {
+    setIsLoading(true);
+    try {
+      await signIn(provider, { callbackUrl });
+    } catch {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      disabled={isLoading}
+      aria-label={isLoading ? config.loadingLabel : config.label}
+      className={cn(
+        /* 공통 스타일 */
+        "flex w-full max-w-[320px] items-center justify-center gap-3",
+        "h-12 rounded-[var(--radius-md)] px-4",
+        "text-base font-medium",
+        "transition-all duration-[var(--duration-fast)]",
+        "cursor-pointer",
+        "disabled:cursor-not-allowed disabled:opacity-70",
+        /* 프로바이더별 스타일 */
+        config.className,
+        className
+      )}
+    >
+      {isLoading ? (
+        <Loader2 className="size-5 animate-spin" />
+      ) : (
+        <Logo size={20} />
+      )}
+      <span>{isLoading ? config.loadingLabel : config.label}</span>
+    </button>
+  );
+};
+
+export default OAuthButton;

--- a/src/components/auth/oauth-button.tsx
+++ b/src/components/auth/oauth-button.tsx
@@ -2,7 +2,7 @@
 
 import { signIn } from "next-auth/react";
 import { useState } from "react";
-import { Loader2 } from "lucide-react";
+import { AlertCircle, Loader2 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import GoogleLogo from "./google-logo";
 import NaverLogo from "./naver-logo";
@@ -49,43 +49,57 @@ const OAuthButton = ({
   className,
 }: OAuthButtonProps) => {
   const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
   const config = providerConfig[provider];
   const { Logo } = config;
 
   const handleClick = async () => {
     setIsLoading(true);
+    setError(null);
     try {
       await signIn(provider, { callbackUrl });
     } catch {
       setIsLoading(false);
+      setError("네트워크 오류가 발생했습니다. 다시 시도해주세요.");
     }
   };
 
   return (
-    <button
-      onClick={handleClick}
-      disabled={isLoading}
-      aria-label={isLoading ? config.loadingLabel : config.label}
-      className={cn(
-        /* 공통 스타일 */
-        "flex w-full max-w-[320px] items-center justify-center gap-3",
-        "h-12 rounded-[var(--radius-md)] px-4",
-        "text-base font-medium",
-        "transition-all duration-[var(--duration-fast)]",
-        "cursor-pointer",
-        "disabled:cursor-not-allowed disabled:opacity-70",
-        /* 프로바이더별 스타일 */
-        config.className,
-        className
+    <div className="flex w-full max-w-[320px] flex-col items-center">
+      <button
+        onClick={handleClick}
+        disabled={isLoading}
+        aria-label={isLoading ? config.loadingLabel : config.label}
+        className={cn(
+          /* 공통 스타일 */
+          "flex w-full items-center justify-center gap-3",
+          "h-12 rounded-md px-4",
+          "text-base font-medium",
+          "transition-all duration-(--duration-fast)",
+          "cursor-pointer",
+          "disabled:cursor-not-allowed disabled:opacity-70",
+          /* 프로바이더별 스타일 */
+          config.className,
+          className
+        )}
+      >
+        {isLoading ? (
+          <Loader2 className="size-5 animate-spin" />
+        ) : (
+          <Logo size={20} />
+        )}
+        <span>{isLoading ? config.loadingLabel : config.label}</span>
+      </button>
+      {error && (
+        <div
+          className="mt-2 flex items-center gap-1.5 animate-in fade-in duration-200"
+          role="alert"
+        >
+          <AlertCircle className="size-3.5 shrink-0 text-destructive" />
+          <p className="text-[13px] text-destructive">{error}</p>
+        </div>
       )}
-    >
-      {isLoading ? (
-        <Loader2 className="size-5 animate-spin" />
-      ) : (
-        <Logo size={20} />
-      )}
-      <span>{isLoading ? config.loadingLabel : config.label}</span>
-    </button>
+    </div>
   );
 };
 

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { SessionProvider } from "next-auth/react";
 import { useState } from "react";
 
 const Providers = ({ children }: { children: React.ReactNode }) => {
@@ -17,7 +18,9 @@ const Providers = ({ children }: { children: React.ReactNode }) => {
   );
 
   return (
-    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    <SessionProvider>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    </SessionProvider>
   );
 };
 


### PR DESCRIPTION
## Summary
- Google / Naver OAuth 소셜 로그인 페이지 구현 (디자인 명세 `docs/design/login.md` 기반)
- OAuth 버튼 컴포넌트 (`OAuthButton`) — 로딩/에러 상태, 다크모드, hover/active 효과
- Google / Naver 로고 SVG 컴포넌트
- `SessionProvider` 추가 (`providers.tsx`)

## 구현 목록
| 파일 | 설명 |
|------|------|
| `src/app/login/page.tsx` | 로그인 페이지 — 반응형 3단계 (모바일→카드→2컬럼) |
| `src/components/auth/oauth-button.tsx` | OAuth 버튼 — Google/Naver 공통, signIn 연동 |
| `src/components/auth/google-logo.tsx` | Google 멀티컬러 로고 SVG |
| `src/components/auth/naver-logo.tsx` | Naver N 로고 SVG |
| `src/components/providers.tsx` | SessionProvider 래핑 추가 |

## 디자인 명세 반영
- ✅ 반응형: `<768px` 모바일 / `≥768px` 카드 UI / `≥1024px` 2컬럼
- ✅ Google 버튼: 흰색 배경 + border + 그림자 (다크모드 변형)
- ✅ Naver 버튼: #03C75A 녹색 (브랜드색 유지)
- ✅ 에러 처리: URL `?error=` → 인라인 에러 메시지 + fadeIn
- ✅ 로딩 상태: 스피너 + "로그인 중..." + disabled
- ✅ 접근성: aria-label, role="alert", sr-only, 터치 타겟 48px
- ✅ 다크모드 대응

## 관련 이슈
- Closes 하위 작업: Epic #4 — `feat/ui-login`

## Test plan
- [x] `pnpm dev` 로컬 서버 정상 기동
- [x] `/login` 페이지 200 응답 확인
- [x] TypeScript 타입 에러 0건 확인
- [x] 브라우저에서 Google OAuth 로그인 흐름 테스트
- [x] 브라우저에서 Naver OAuth 로그인 흐름 테스트
- [x] `?error=OAuthSignin` 파라미터로 에러 표시 확인
- [x] 다크모드 전환 시 버튼 스타일 확인
- [x] 768px / 1024px 브레이크포인트 반응형 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)