### PR TITLE
[Frontend] feat/ui-layout — 공통 레이아웃 컴포넌트 구현

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -2,9 +2,9 @@
 
 import { useSearchParams } from "next/navigation";
 import { Suspense } from "react";
-import { Grid3X3, AlertCircle, ArrowLeft } from "lucide-react";
-import Link from "next/link";
+import { Grid3X3, AlertCircle } from "lucide-react";
 import OAuthButton from "@/components/auth/oauth-button";
+import { AppLayout } from "@/components/layout";
 
 /** Auth.js 에러 코드 → 사용자 친화적 메시지 */
 const errorMessages: Record<string, string> = {
@@ -26,24 +26,9 @@ const LoginContent = () => {
     : null;
 
   return (
-    <div className="flex min-h-dvh flex-col">
-      {/* Header (56px) */}
-      <header className="flex h-14 shrink-0 items-center px-4">
-        <Link
-          href="/"
-          className="flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
-          aria-label="홈으로 돌아가기"
-        >
-          <ArrowLeft className="size-5" />
-          <span className="sr-only">뒤로</span>
-        </Link>
-        <h1 className="flex-1 text-center text-sm font-medium">로그인</h1>
-        {/* 좌측 아이콘과 대칭을 위한 빈 공간 */}
-        <div className="size-5" />
-      </header>
-
+    <AppLayout headerVariant="login">
       {/* 메인 콘텐츠 — 2컬럼 반응형 */}
-      <main className="flex flex-1 items-center justify-center px-6 py-10 lg:gap-16">
+      <div className="flex flex-1 items-center justify-center px-6 py-10 lg:gap-16">
         {/* 좌측 일러스트 영역 (≥1024px만 표시) */}
         <div className="hidden lg:flex lg:flex-col lg:items-center lg:gap-6">
           <div className="flex size-32 items-center justify-center rounded-2xl bg-sudoku-primary/10">
@@ -110,8 +95,8 @@ const LoginContent = () => {
             게임은 로그인 없이도 즐길 수 있어요
           </p>
         </div>
-      </main>
-    </div>
+      </div>
+    </AppLayout>
   );
 };
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,15 @@
-export default function Home() {
+"use client";
+
+import { AppLayout } from "@/components/layout";
+
+const HomePage = () => {
   return (
-    <div className="flex flex-1 items-center justify-center">
-      <h1 className="text-4xl font-bold">Sudoku</h1>
-    </div>
+    <AppLayout headerVariant="home">
+      <div className="flex flex-1 items-center justify-center">
+        <h1 className="text-4xl font-bold">Sudoku</h1>
+      </div>
+    </AppLayout>
   );
-}
+};
+
+export default HomePage;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { AppLayout } from "@/components/layout";
 
 const HomePage = () => {

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -3,6 +3,7 @@
 import { usePathname } from "next/navigation";
 import Header, { type HeaderVariant } from "./Header";
 import BottomNav from "./BottomNav";
+import { BOTTOM_NAV_HIDDEN_PATHS } from "./nav-items";
 
 // ────────────────────────────────────────
 // Types
@@ -32,12 +33,12 @@ const inferVariant = (pathname: string): HeaderVariant => {
   return "home";
 };
 
-/** BottomNav가 표시되는 페이지인지 확인 */
+/** BottomNav가 표시되는 페이지인지 확인 — nav-items.ts의 HIDDEN_PATHS를 단일 진실 원천으로 사용 */
 const hasBottomNav = (pathname: string, forceHide?: boolean): boolean => {
   if (forceHide) return false;
-  if (pathname.startsWith("/game")) return false;
-  if (pathname.startsWith("/login")) return false;
-  return true;
+  return !BOTTOM_NAV_HIDDEN_PATHS.some(
+    (path) => pathname === path || pathname.startsWith(`${path}/`),
+  );
 };
 
 // ────────────────────────────────────────
@@ -75,7 +76,7 @@ const AppLayout = ({
         {children}
       </main>
 
-      <BottomNav />
+      {showNav && <BottomNav />}
     </div>
   );
 };

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import Header, { type HeaderVariant } from "./Header";
+import BottomNav from "./BottomNav";
+
+// ────────────────────────────────────────
+// Types
+// ────────────────────────────────────────
+
+interface AppLayoutProps {
+  children: React.ReactNode;
+  /** Header 변형 (명시하지 않으면 경로에서 자동 추론) */
+  headerVariant?: HeaderVariant;
+  /** 게임 Header 중앙 커스텀 콘텐츠 */
+  centerContent?: React.ReactNode;
+  /** 게임 Header 우측 커스텀 콘텐츠 */
+  rightContent?: React.ReactNode;
+  /** BottomNav 강제 숨김 */
+  hideBottomNav?: boolean;
+}
+
+// ────────────────────────────────────────
+// Helpers
+// ────────────────────────────────────────
+
+/** 경로에서 Header variant 자동 추론 */
+const inferVariant = (pathname: string): HeaderVariant => {
+  if (pathname.startsWith("/game")) return "game";
+  if (pathname.startsWith("/ranking")) return "ranking";
+  if (pathname.startsWith("/login")) return "login";
+  return "home";
+};
+
+/** BottomNav가 표시되는 페이지인지 확인 */
+const hasBottomNav = (pathname: string, forceHide?: boolean): boolean => {
+  if (forceHide) return false;
+  if (pathname.startsWith("/game")) return false;
+  if (pathname.startsWith("/login")) return false;
+  return true;
+};
+
+// ────────────────────────────────────────
+// Component
+// ────────────────────────────────────────
+
+const AppLayout = ({
+  children,
+  headerVariant,
+  centerContent,
+  rightContent,
+  hideBottomNav,
+}: AppLayoutProps) => {
+  const pathname = usePathname();
+  const variant = headerVariant ?? inferVariant(pathname);
+  const showNav = hasBottomNav(pathname, hideBottomNav);
+
+  return (
+    <div className="flex min-h-dvh flex-col">
+      <Header
+        variant={variant}
+        centerContent={centerContent}
+        rightContent={rightContent}
+      />
+
+      {/* 콘텐츠 영역 */}
+      <main
+        className={
+          "flex flex-1 flex-col " +
+          (showNav
+            ? "pb-[calc(64px+env(safe-area-inset-bottom))] md:pb-0"
+            : "pb-[env(safe-area-inset-bottom)]")
+        }
+      >
+        {children}
+      </main>
+
+      <BottomNav />
+    </div>
+  );
+};
+
+export default AppLayout;

--- a/src/components/layout/AppLogo.tsx
+++ b/src/components/layout/AppLogo.tsx
@@ -1,0 +1,14 @@
+import Link from "next/link";
+
+/** 텍스트 로고 — 클릭 시 홈으로 이동 */
+const AppLogo = () => (
+  <Link
+    href="/"
+    className="flex h-11 items-center text-lg font-bold text-foreground"
+    aria-label="스도쿠 홈"
+  >
+    SUDOKU
+  </Link>
+);
+
+export default AppLogo;

--- a/src/components/layout/AuthButton.tsx
+++ b/src/components/layout/AuthButton.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import Link from "next/link";
+import { useSession } from "next-auth/react";
+import { User } from "lucide-react";
+
+/** 로그인/프로필 아이콘 버튼 — 세션 상태에 따라 변형 */
+const AuthButton = () => {
+  const { data: session } = useSession();
+
+  if (session?.user) {
+    const img = session.user.image;
+    const name = session.user.name ?? "";
+
+    return (
+      <Link href="/login" className="flex size-11 items-center justify-center">
+        {img ? (
+          /* eslint-disable-next-line @next/next/no-img-element */
+          <img
+            src={img}
+            alt={name}
+            className="size-8 rounded-full border border-border object-cover"
+          />
+        ) : (
+          <span className="flex size-8 items-center justify-center rounded-full bg-muted text-sm font-bold">
+            {name.charAt(0).toUpperCase()}
+          </span>
+        )}
+      </Link>
+    );
+  }
+
+  return (
+    <Link
+      href="/login"
+      className="flex size-11 items-center justify-center text-muted-foreground transition-colors duration-100 hover:text-foreground"
+      aria-label="로그인"
+    >
+      <User className="size-6" />
+    </Link>
+  );
+};
+
+export default AuthButton;

--- a/src/components/layout/AuthButton.tsx
+++ b/src/components/layout/AuthButton.tsx
@@ -12,8 +12,13 @@ const AuthButton = () => {
     const img = session.user.image;
     const name = session.user.name ?? "";
 
+    // TODO: 추후 /mypage 또는 /profile 경로로 변경 예정 (v2 프로필 드롭다운)
     return (
-      <Link href="/login" className="flex size-11 items-center justify-center">
+      <Link
+        href="/login"
+        className="flex size-11 items-center justify-center"
+        aria-label={`${name || "사용자"} 프로필`}
+      >
         {img ? (
           /* eslint-disable-next-line @next/next/no-img-element */
           <img

--- a/src/components/layout/BackButton.tsx
+++ b/src/components/layout/BackButton.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { ChevronLeft } from "lucide-react";
+
+/** 뒤로가기 버튼 — router.back() 호출 */
+const BackButton = () => {
+  const router = useRouter();
+
+  return (
+    <button
+      type="button"
+      onClick={() => router.back()}
+      className="flex size-11 items-center justify-center rounded-md text-foreground transition-colors duration-100 hover:bg-accent"
+      aria-label="뒤로 가기"
+    >
+      <ChevronLeft className="size-6" />
+    </button>
+  );
+};
+
+export default BackButton;

--- a/src/components/layout/BottomNav.tsx
+++ b/src/components/layout/BottomNav.tsx
@@ -2,19 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Home, Trophy } from "lucide-react";
-
-// ────────────────────────────────────────
-// Config
-// ────────────────────────────────────────
-
-const navItems = [
-  { href: "/", label: "홈", icon: Home, ariaLabel: "홈으로 이동" },
-  { href: "/ranking", label: "랭킹", icon: Trophy, ariaLabel: "랭킹으로 이동" },
-] as const;
-
-/** BottomNav를 숨기는 경로 — 게임, 로그인 */
-const HIDDEN_PATHS = ["/game", "/login"];
+import { navItems } from "./nav-items";
 
 // ────────────────────────────────────────
 // Component
@@ -22,13 +10,6 @@ const HIDDEN_PATHS = ["/game", "/login"];
 
 const BottomNav = () => {
   const pathname = usePathname();
-
-  // 게임·로그인 페이지 또는 태블릿 이상(md)에서는 숨김
-  const isHidden = HIDDEN_PATHS.some(
-    (path) => pathname === path || pathname.startsWith(`${path}/`),
-  );
-
-  if (isHidden) return null;
 
   return (
     <nav

--- a/src/components/layout/BottomNav.tsx
+++ b/src/components/layout/BottomNav.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Home, Trophy } from "lucide-react";
+
+// ────────────────────────────────────────
+// Config
+// ────────────────────────────────────────
+
+const navItems = [
+  { href: "/", label: "홈", icon: Home, ariaLabel: "홈으로 이동" },
+  { href: "/ranking", label: "랭킹", icon: Trophy, ariaLabel: "랭킹으로 이동" },
+] as const;
+
+/** BottomNav를 숨기는 경로 — 게임, 로그인 */
+const HIDDEN_PATHS = ["/game", "/login"];
+
+// ────────────────────────────────────────
+// Component
+// ────────────────────────────────────────
+
+const BottomNav = () => {
+  const pathname = usePathname();
+
+  // 게임·로그인 페이지 또는 태블릿 이상(md)에서는 숨김
+  const isHidden = HIDDEN_PATHS.some(
+    (path) => pathname === path || pathname.startsWith(`${path}/`),
+  );
+
+  if (isHidden) return null;
+
+  return (
+    <nav
+      className={
+        "fixed bottom-0 left-0 right-0 z-[var(--z-bottom-nav)] " +
+        "border-t border-border bg-background " +
+        "pb-[env(safe-area-inset-bottom)] " +
+        "md:hidden"
+      }
+      aria-label="메인 내비게이션"
+    >
+      <div className="flex h-16 items-center">
+        {navItems.map(({ href, label, icon: Icon, ariaLabel }) => {
+          const isActive = pathname === href;
+
+          return (
+            <Link
+              key={href}
+              href={href}
+              className={
+                "flex flex-1 flex-col items-center justify-center gap-0.5 " +
+                "h-16 min-h-[44px] " +
+                "transition-colors duration-100 active:scale-95 " +
+                (isActive
+                  ? "text-sudoku-primary"
+                  : "text-muted-foreground")
+              }
+              aria-label={ariaLabel}
+              aria-current={isActive ? "page" : undefined}
+            >
+              <Icon className="size-6" />
+              <span className="text-[11px] font-medium max-[374px]:hidden">
+                {label}
+              </span>
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+};
+
+export default BottomNav;

--- a/src/components/layout/DesktopNav.tsx
+++ b/src/components/layout/DesktopNav.tsx
@@ -2,12 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Home, Trophy } from "lucide-react";
-
-const navItems = [
-  { href: "/", label: "홈", icon: Home },
-  { href: "/ranking", label: "랭킹", icon: Trophy },
-] as const;
+import { navItems } from "./nav-items";
 
 /** 데스크톱 네비게이션 링크 (≥768px) — BottomNav 숨김 시 대체 */
 const DesktopNav = () => {

--- a/src/components/layout/DesktopNav.tsx
+++ b/src/components/layout/DesktopNav.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Home, Trophy } from "lucide-react";
+
+const navItems = [
+  { href: "/", label: "홈", icon: Home },
+  { href: "/ranking", label: "랭킹", icon: Trophy },
+] as const;
+
+/** 데스크톱 네비게이션 링크 (≥768px) — BottomNav 숨김 시 대체 */
+const DesktopNav = () => {
+  const pathname = usePathname();
+
+  return (
+    <nav
+      className="hidden items-center gap-1 md:flex"
+      aria-label="메인 내비게이션"
+    >
+      {navItems.map(({ href, label, icon: Icon }) => {
+        const isActive = pathname === href;
+
+        return (
+          <Link
+            key={href}
+            href={href}
+            className={
+              "flex h-9 items-center gap-1.5 rounded-md px-3 text-sm font-medium transition-colors " +
+              (isActive
+                ? "bg-accent text-foreground"
+                : "text-muted-foreground hover:bg-accent hover:text-foreground")
+            }
+            aria-current={isActive ? "page" : undefined}
+          >
+            <Icon className="size-4" />
+            {label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+};
+
+export default DesktopNav;

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import AppLogo from "./AppLogo";
+import BackButton from "./BackButton";
+import AuthButton from "./AuthButton";
+import DesktopNav from "./DesktopNav";
+
+// ────────────────────────────────────────
+// Types
+// ────────────────────────────────────────
+
+/** Header 변형 — 페이지별로 다른 레이아웃 */
+export type HeaderVariant = "home" | "game" | "ranking" | "login";
+
+interface HeaderProps {
+  /** 현재 페이지에 맞는 Header 변형 */
+  variant: HeaderVariant;
+  /** 게임 Header 중앙 커스텀 콘텐츠 (난이도 + 타이머) */
+  centerContent?: React.ReactNode;
+  /** 게임 Header 우측 커스텀 콘텐츠 (일시정지 등) */
+  rightContent?: React.ReactNode;
+}
+
+// ────────────────────────────────────────
+// Variant resolver
+// ────────────────────────────────────────
+
+const resolveSlots = (
+  variant: HeaderVariant,
+  centerContent?: React.ReactNode,
+  rightContent?: React.ReactNode,
+) => {
+  switch (variant) {
+    case "home":
+      return {
+        left: (
+          <div className="flex items-center gap-2">
+            <AppLogo />
+            <DesktopNav />
+          </div>
+        ),
+        center: null,
+        right: <AuthButton />,
+      };
+
+    case "game":
+      return {
+        left: <BackButton />,
+        center: centerContent ?? null,
+        right: rightContent ?? <div className="size-11" />,
+      };
+
+    case "ranking":
+      return {
+        left: (
+          <div className="flex items-center gap-2">
+            <AppLogo />
+            <DesktopNav />
+          </div>
+        ),
+        center: (
+          <span className="text-base font-semibold text-foreground md:hidden">
+            랭킹
+          </span>
+        ),
+        right: <AuthButton />,
+      };
+
+    case "login":
+      return {
+        left: <BackButton />,
+        center: (
+          <span className="text-base font-semibold text-foreground">
+            로그인
+          </span>
+        ),
+        right: <div className="size-11" />,
+      };
+  }
+};
+
+// ────────────────────────────────────────
+// Component
+// ────────────────────────────────────────
+
+const Header = ({ variant, centerContent, rightContent }: HeaderProps) => {
+  const { left, center, right } = resolveSlots(
+    variant,
+    centerContent,
+    rightContent,
+  );
+
+  return (
+    <header
+      className={
+        "sticky top-0 z-[var(--z-header)] border-b border-border bg-background " +
+        "h-14 md:h-16 " +
+        "pt-[env(safe-area-inset-top)]"
+      }
+      role="banner"
+    >
+      <div className="mx-auto flex h-full max-w-5xl items-center justify-between px-4 md:px-6">
+        {/* 좌측 — flex-1, start 정렬 */}
+        <div className="flex min-w-0 flex-1 items-center justify-start">
+          {left}
+        </div>
+
+        {/* 중앙 — flex-shrink-0, center 정렬, 최대 50% */}
+        {center && (
+          <div className="flex max-w-[50%] shrink-0 items-center justify-center">
+            {center}
+          </div>
+        )}
+
+        {/* 우측 — flex-1, end 정렬 */}
+        <div className="flex min-w-0 flex-1 items-center justify-end">
+          {right}
+        </div>
+      </div>
+    </header>
+  );
+};
+
+export default Header;

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -6,3 +6,5 @@ export { default as BackButton } from "./BackButton";
 export { default as AuthButton } from "./AuthButton";
 export { default as DesktopNav } from "./DesktopNav";
 export type { HeaderVariant } from "./Header";
+export { navItems, BOTTOM_NAV_HIDDEN_PATHS } from "./nav-items";
+export type { NavItem } from "./nav-items";

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -1,0 +1,8 @@
+export { default as AppLayout } from "./AppLayout";
+export { default as Header } from "./Header";
+export { default as BottomNav } from "./BottomNav";
+export { default as AppLogo } from "./AppLogo";
+export { default as BackButton } from "./BackButton";
+export { default as AuthButton } from "./AuthButton";
+export { default as DesktopNav } from "./DesktopNav";
+export type { HeaderVariant } from "./Header";

--- a/src/components/layout/nav-items.ts
+++ b/src/components/layout/nav-items.ts
@@ -1,0 +1,18 @@
+import { Home, Trophy } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+export interface NavItem {
+  href: string;
+  label: string;
+  icon: LucideIcon;
+  ariaLabel: string;
+}
+
+/** BottomNav + DesktopNav 공통 네비게이션 항목 */
+export const navItems: readonly NavItem[] = [
+  { href: "/", label: "홈", icon: Home, ariaLabel: "홈으로 이동" },
+  { href: "/ranking", label: "랭킹", icon: Trophy, ariaLabel: "랭킹으로 이동" },
+] as const;
+
+/** BottomNav를 숨기는 경로 */
+export const BOTTOM_NAV_HIDDEN_PATHS = ["/game", "/login"];


### PR DESCRIPTION
## Summary
- 디자인 문서(`docs/design/layout.md`) 기반 공통 레이아웃 시스템 구축
- 컴포넌트를 개별 파일로 분리하여 재사용성·유지보수성 확보
- 홈/로그인 페이지에 AppLayout 적용, 기존 인라인 Header 제거

## 구현 목록

### 신규 컴포넌트 (`src/components/layout/`)
| 파일 | 설명 |
|------|------|
| `AppLogo.tsx` | 텍스트 로고 "SUDOKU", 홈 링크 |
| `BackButton.tsx` | 뒤로가기 버튼 (`router.back()`) |
| `AuthButton.tsx` | 세션 상태별 로그인/프로필 아이콘 |
| `DesktopNav.tsx` | 데스크톱 네비게이션 (≥768px), 경로 기반 활성 표시 |
| `Header.tsx` | 4가지 변형 (home/game/ranking/login), 3분할 슬롯 |
| `BottomNav.tsx` | 하단 탭바, 게임/로그인 자동 숨김, md 이상 숨김 |
| `AppLayout.tsx` | Header + children + BottomNav 조합, variant 자동 추론 |
| `index.ts` | barrel export |

### 수정된 페이지
| 파일 | 변경 |
|------|------|
| `src/app/page.tsx` | AppLayout 적용 |
| `src/app/login/page.tsx` | 인라인 Header 제거 → AppLayout(login) 적용 |

### 디자인 명세 일치 확인
- [x] Header 56px (모바일) / 64px (태블릿+)
- [x] BottomNav 64px, fixed bottom, safe-area 대응
- [x] 3분할 Header (좌측/중앙/우측)
- [x] 페이지별 Header 변형 (home/game/ranking/login)
- [x] BottomNav 표시 조건 (홈✅, 게임❌, 랭킹✅, 로그인❌)
- [x] 데스크톱(≥768px) BottomNav 숨김 → Header 네비게이션
- [x] 활성 탭 `aria-current="page"` 접근성
- [x] 터치 타겟 44px 이상
- [x] < 375px 라벨 숨김

## 관련 이슈
- Epic #5 게임 UI 개발

## Test plan
- [x] `next build` 성공 확인
- [x] 홈 페이지 Header + BottomNav 렌더링 확인
- [x] 로그인 페이지 Header(login 변형) + BottomNav 숨김 확인
- [x] 모바일/태블릿/데스크톱 반응형 확인
- [ ] BottomNav 활성 탭 경로 연동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)