### PR TITLE
[Frontend] feat/ui-auth-state — 인증 상태 관리 훅 구현

### DIFF
--- a/docs/adr/101-auth-state-hook.md
+++ b/docs/adr/101-auth-state-hook.md
@@ -1,0 +1,72 @@
+# ADR-101: 클라이언트 인증 상태 관리 훅 설계
+
+## 상태
+승인됨 (Accepted)
+
+## 날짜
+2026-03-31
+
+## 컨텍스트
+
+Auth.js v5 설정(ADR-202)과 로그인 UI(PR #35)가 완성된 상태에서,
+클라이언트 컴포넌트들이 인증 상태를 일관되게 소비할 수 있는 인터페이스가 필요하다.
+
+### 고려 사항
+1. `next-auth/react`의 `useSession`은 범용적이라 반환 타입이 느슨함
+2. 여러 컴포넌트(AuthButton, 헤더, 향후 랭킹 페이지 등)에서 인증 상태를 반복 소비함
+3. 로그인/로그아웃 액션이 컴포넌트마다 개별 구현되어 있음
+4. 보호 페이지(랭킹 기록 등)에서 미인증 리다이렉트 패턴이 반복될 예정
+5. 세션에 커스텀 필드(`nickname`)가 이미 추가되어 있어 타입 보장이 필요
+
+### 선택지
+- **A) useSession 직접 사용** — 래핑 없이 각 컴포넌트에서 직접 호출
+- **B) useAuth 커스텀 훅** — useSession을 래핑하여 타입 안전한 인터페이스 제공
+- **C) Zustand 인증 스토어** — 별도 전역 스토어로 인증 상태 관리
+
+## 결정
+
+**선택지 B — `useAuth` + `useAuthGuard` 커스텀 훅**
+
+### 이유
+1. useSession의 느슨한 타입을 `AuthUser` 인터페이스로 좁혀서 타입 안전성 확보
+2. `login()` / `logout()` 액션을 훅에 캡슐화하여 중복 제거
+3. `useAuthGuard`로 보호 페이지 리다이렉트 패턴을 재사용 가능하게 추출
+4. SessionProvider가 이미 인증 상태를 관리하므로 Zustand 스토어는 불필요한 중복
+5. React Query는 서버 데이터(랭킹 등)에만 사용하고, 세션은 Auth.js 전용 캐시 활용
+
+## 구현 상세
+
+### 파일 구조
+```
+src/hooks/
+├── useAuth.ts         # 인증 상태 + 액션 훅
+├── useAuthGuard.ts    # 보호 페이지 가드 훅
+└── index.ts           # 배럴 export
+```
+
+### useAuth 반환값
+```ts
+{
+  user: AuthUser | null;    // { id, name, email, image, nickname }
+  status: AuthStatus;       // "authenticated" | "loading" | "unauthenticated"
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  login(callbackUrl?): void;
+  logout(callbackUrl?): Promise<void>;
+}
+```
+
+### useAuthGuard 반환값
+```ts
+{
+  isReady: boolean;          // 로딩 완료 + 인증됨
+  isLoading: boolean;
+  isAuthenticated: boolean;
+}
+```
+
+## 영향
+
+- `AuthButton` — `useSession` → `useAuth`로 교체, 로그아웃 드롭다운 메뉴 추가
+- `LoginPage` — 이미 인증된 상태면 홈으로 리다이렉트 로직 추가
+- 향후 보호 페이지 — `useAuthGuard` 적용으로 보일러플레이트 최소화

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useSearchParams } from "next/navigation";
-import { Suspense } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import { Suspense, useEffect } from "react";
 import { Grid3X3, AlertCircle } from "lucide-react";
 import OAuthButton from "@/components/auth/oauth-button";
 import { AppLayout } from "@/components/layout";
+import { useAuth } from "@/hooks";
 
 /** Auth.js 에러 코드 → 사용자 친화적 메시지 */
 const errorMessages: Record<string, string> = {
@@ -18,8 +19,17 @@ const errorMessages: Record<string, string> = {
 
 const LoginContent = () => {
   const searchParams = useSearchParams();
+  const router = useRouter();
+  const { isAuthenticated, isLoading } = useAuth();
   const error = searchParams.get("error");
   const callbackUrl = searchParams.get("callbackUrl") ?? "/";
+
+  // 이미 로그인된 상태면 callbackUrl 또는 홈으로 리다이렉트
+  useEffect(() => {
+    if (!isLoading && isAuthenticated && !error) {
+      router.replace(callbackUrl);
+    }
+  }, [isLoading, isAuthenticated, error, callbackUrl, router]);
 
   const errorMessage = error
     ? errorMessages[error] ?? errorMessages.Default

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -35,6 +35,18 @@ const LoginContent = () => {
     ? errorMessages[error] ?? errorMessages.Default
     : null;
 
+  // 로딩 중이거나 인증된 상태면 로그인 폼을 숨겨서 깜빡임 방지
+  if (isLoading || (isAuthenticated && !error)) {
+    return (
+      <div className="flex min-h-dvh items-center justify-center">
+        <Grid3X3
+          className="size-10 animate-pulse text-sudoku-primary"
+          strokeWidth={1.5}
+        />
+      </div>
+    );
+  }
+
   return (
     <AppLayout headerVariant="login">
       {/* 메인 콘텐츠 — 2컬럼 반응형 */}

--- a/src/components/layout/AuthButton.tsx
+++ b/src/components/layout/AuthButton.tsx
@@ -1,54 +1,29 @@
 "use client";
 
-import { useState, useRef, useEffect } from "react";
 import Link from "next/link";
 import { User, LogOut } from "lucide-react";
 import { useAuth } from "@/hooks";
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+} from "@/components/ui/dropdown-menu";
 
 /** 로그인/프로필 아이콘 버튼 — 세션 상태에 따라 변형 */
 const AuthButton = () => {
   const { user, isAuthenticated, logout } = useAuth();
-  const [isMenuOpen, setIsMenuOpen] = useState(false);
-  const menuRef = useRef<HTMLDivElement>(null);
-
-  // 외부 클릭 시 메뉴 닫기
-  useEffect(() => {
-    if (!isMenuOpen) return;
-
-    const handleClickOutside = (e: MouseEvent) => {
-      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
-        setIsMenuOpen(false);
-      }
-    };
-
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, [isMenuOpen]);
-
-  // ESC 키로 메뉴 닫기
-  useEffect(() => {
-    if (!isMenuOpen) return;
-
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setIsMenuOpen(false);
-    };
-
-    document.addEventListener("keydown", handleEscape);
-    return () => document.removeEventListener("keydown", handleEscape);
-  }, [isMenuOpen]);
 
   if (isAuthenticated && user) {
     const name = user.nickname ?? user.name ?? "";
     const displayName = name || "사용자";
 
     return (
-      <div ref={menuRef} className="relative">
-        <button
-          onClick={() => setIsMenuOpen((prev) => !prev)}
-          className="flex size-11 items-center justify-center"
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          className="flex size-11 cursor-pointer items-center justify-center outline-none"
           aria-label={`${displayName} 메뉴`}
-          aria-expanded={isMenuOpen}
-          aria-haspopup="menu"
         >
           {user.image ? (
             /* eslint-disable-next-line @next/next/no-img-element */
@@ -62,48 +37,33 @@ const AuthButton = () => {
               {name.charAt(0).toUpperCase() || "U"}
             </span>
           )}
-        </button>
+        </DropdownMenuTrigger>
 
-        {isMenuOpen && (
-          <div
-            role="menu"
-            className={
-              "absolute right-0 top-full z-50 mt-1 w-48 " +
-              "rounded-lg border border-border bg-popover p-1 shadow-lg " +
-              "animate-in fade-in zoom-in-95 duration-100"
-            }
-          >
-            {/* 사용자 정보 */}
-            <div className="border-b border-border px-3 py-2.5">
-              <p className="truncate text-sm font-medium">{displayName}</p>
-              {user.email && (
-                <p className="truncate text-xs text-muted-foreground">
-                  {user.email}
-                </p>
-              )}
-            </div>
-
-            {/* 로그아웃 */}
-            <button
-              role="menuitem"
-              onClick={async () => {
-                setIsMenuOpen(false);
-                await logout();
-              }}
-              className={
-                "mt-1 flex w-full items-center gap-2 rounded-md px-3 py-2 " +
-                "text-sm text-muted-foreground " +
-                "transition-colors duration-100 " +
-                "hover:bg-accent hover:text-foreground " +
-                "cursor-pointer"
-              }
-            >
-              <LogOut className="size-4" />
-              로그아웃
-            </button>
+        <DropdownMenuContent align="end" sideOffset={4} className="w-48">
+          {/* 사용자 정보 */}
+          <div className="px-3 py-2.5">
+            <p className="truncate text-sm font-medium">{displayName}</p>
+            {user.email && (
+              <p className="truncate text-xs text-muted-foreground">
+                {user.email}
+              </p>
+            )}
           </div>
-        )}
-      </div>
+
+          <DropdownMenuSeparator />
+
+          {/* 로그아웃 */}
+          <DropdownMenuItem
+            onSelect={async () => {
+              await logout();
+            }}
+            className="cursor-pointer gap-2"
+          >
+            <LogOut className="size-4" />
+            로그아웃
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
     );
   }
 

--- a/src/components/layout/AuthButton.tsx
+++ b/src/components/layout/AuthButton.tsx
@@ -1,37 +1,109 @@
 "use client";
 
+import { useState, useRef, useEffect } from "react";
 import Link from "next/link";
-import { useSession } from "next-auth/react";
-import { User } from "lucide-react";
+import { User, LogOut } from "lucide-react";
+import { useAuth } from "@/hooks";
 
 /** 로그인/프로필 아이콘 버튼 — 세션 상태에 따라 변형 */
 const AuthButton = () => {
-  const { data: session } = useSession();
+  const { user, isAuthenticated, logout } = useAuth();
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement>(null);
 
-  if (session?.user) {
-    const img = session.user.image;
-    const name = session.user.name ?? "";
+  // 외부 클릭 시 메뉴 닫기
+  useEffect(() => {
+    if (!isMenuOpen) return;
 
-    // TODO: 추후 /mypage 또는 /profile 경로로 변경 예정 (v2 프로필 드롭다운)
+    const handleClickOutside = (e: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setIsMenuOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [isMenuOpen]);
+
+  // ESC 키로 메뉴 닫기
+  useEffect(() => {
+    if (!isMenuOpen) return;
+
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setIsMenuOpen(false);
+    };
+
+    document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
+  }, [isMenuOpen]);
+
+  if (isAuthenticated && user) {
+    const name = user.nickname ?? user.name ?? "";
+    const displayName = name || "사용자";
+
     return (
-      <Link
-        href="/login"
-        className="flex size-11 items-center justify-center"
-        aria-label={`${name || "사용자"} 프로필`}
-      >
-        {img ? (
-          /* eslint-disable-next-line @next/next/no-img-element */
-          <img
-            src={img}
-            alt={name}
-            className="size-8 rounded-full border border-border object-cover"
-          />
-        ) : (
-          <span className="flex size-8 items-center justify-center rounded-full bg-muted text-sm font-bold">
-            {name.charAt(0).toUpperCase()}
-          </span>
+      <div ref={menuRef} className="relative">
+        <button
+          onClick={() => setIsMenuOpen((prev) => !prev)}
+          className="flex size-11 items-center justify-center"
+          aria-label={`${displayName} 메뉴`}
+          aria-expanded={isMenuOpen}
+          aria-haspopup="menu"
+        >
+          {user.image ? (
+            /* eslint-disable-next-line @next/next/no-img-element */
+            <img
+              src={user.image}
+              alt={displayName}
+              className="size-8 rounded-full border border-border object-cover"
+            />
+          ) : (
+            <span className="flex size-8 items-center justify-center rounded-full bg-muted text-sm font-bold">
+              {name.charAt(0).toUpperCase() || "U"}
+            </span>
+          )}
+        </button>
+
+        {isMenuOpen && (
+          <div
+            role="menu"
+            className={
+              "absolute right-0 top-full z-50 mt-1 w-48 " +
+              "rounded-lg border border-border bg-popover p-1 shadow-lg " +
+              "animate-in fade-in zoom-in-95 duration-100"
+            }
+          >
+            {/* 사용자 정보 */}
+            <div className="border-b border-border px-3 py-2.5">
+              <p className="truncate text-sm font-medium">{displayName}</p>
+              {user.email && (
+                <p className="truncate text-xs text-muted-foreground">
+                  {user.email}
+                </p>
+              )}
+            </div>
+
+            {/* 로그아웃 */}
+            <button
+              role="menuitem"
+              onClick={async () => {
+                setIsMenuOpen(false);
+                await logout();
+              }}
+              className={
+                "mt-1 flex w-full items-center gap-2 rounded-md px-3 py-2 " +
+                "text-sm text-muted-foreground " +
+                "transition-colors duration-100 " +
+                "hover:bg-accent hover:text-foreground " +
+                "cursor-pointer"
+              }
+            >
+              <LogOut className="size-4" />
+              로그아웃
+            </button>
+          </div>
         )}
-      </Link>
+      </div>
     );
   }
 

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,268 @@
+"use client"
+
+import * as React from "react"
+import { Menu as MenuPrimitive } from "@base-ui/react/menu"
+
+import { cn } from "@/lib/utils"
+import { ChevronRightIcon, CheckIcon } from "lucide-react"
+
+function DropdownMenu({ ...props }: MenuPrimitive.Root.Props) {
+  return <MenuPrimitive.Root data-slot="dropdown-menu" {...props} />
+}
+
+function DropdownMenuPortal({ ...props }: MenuPrimitive.Portal.Props) {
+  return <MenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+}
+
+function DropdownMenuTrigger({ ...props }: MenuPrimitive.Trigger.Props) {
+  return <MenuPrimitive.Trigger data-slot="dropdown-menu-trigger" {...props} />
+}
+
+function DropdownMenuContent({
+  align = "start",
+  alignOffset = 0,
+  side = "bottom",
+  sideOffset = 4,
+  className,
+  ...props
+}: MenuPrimitive.Popup.Props &
+  Pick<
+    MenuPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <MenuPrimitive.Portal>
+      <MenuPrimitive.Positioner
+        className="isolate z-50 outline-none"
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+      >
+        <MenuPrimitive.Popup
+          data-slot="dropdown-menu-content"
+          className={cn("z-50 max-h-(--available-height) w-(--anchor-width) min-w-32 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:overflow-hidden data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          {...props}
+        />
+      </MenuPrimitive.Positioner>
+    </MenuPrimitive.Portal>
+  )
+}
+
+function DropdownMenuGroup({ ...props }: MenuPrimitive.Group.Props) {
+  return <MenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+}
+
+function DropdownMenuLabel({
+  className,
+  inset,
+  ...props
+}: MenuPrimitive.GroupLabel.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.GroupLabel
+      data-slot="dropdown-menu-label"
+      data-inset={inset}
+      className={cn(
+        "px-1.5 py-1 text-xs font-medium text-muted-foreground data-inset:pl-7",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuItem({
+  className,
+  inset,
+  variant = "default",
+  ...props
+}: MenuPrimitive.Item.Props & {
+  inset?: boolean
+  variant?: "default" | "destructive"
+}) {
+  return (
+    <MenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      data-inset={inset}
+      data-variant={variant}
+      className={cn(
+        "group/dropdown-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuSub({ ...props }: MenuPrimitive.SubmenuRoot.Props) {
+  return <MenuPrimitive.SubmenuRoot data-slot="dropdown-menu-sub" {...props} />
+}
+
+function DropdownMenuSubTrigger({
+  className,
+  inset,
+  children,
+  ...props
+}: MenuPrimitive.SubmenuTrigger.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.SubmenuTrigger
+      data-slot="dropdown-menu-sub-trigger"
+      data-inset={inset}
+      className={cn(
+        "flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-popup-open:bg-accent data-popup-open:text-accent-foreground data-open:bg-accent data-open:text-accent-foreground [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <ChevronRightIcon className="ml-auto" />
+    </MenuPrimitive.SubmenuTrigger>
+  )
+}
+
+function DropdownMenuSubContent({
+  align = "start",
+  alignOffset = -3,
+  side = "right",
+  sideOffset = 0,
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuContent>) {
+  return (
+    <DropdownMenuContent
+      data-slot="dropdown-menu-sub-content"
+      className={cn("w-auto min-w-[96px] rounded-lg bg-popover p-1 text-popover-foreground shadow-lg ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+      align={align}
+      alignOffset={alignOffset}
+      side={side}
+      sideOffset={sideOffset}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuCheckboxItem({
+  className,
+  children,
+  checked,
+  inset,
+  ...props
+}: MenuPrimitive.CheckboxItem.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.CheckboxItem
+      data-slot="dropdown-menu-checkbox-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-checkbox-item-indicator"
+      >
+        <MenuPrimitive.CheckboxItemIndicator>
+          <CheckIcon
+          />
+        </MenuPrimitive.CheckboxItemIndicator>
+      </span>
+      {children}
+    </MenuPrimitive.CheckboxItem>
+  )
+}
+
+function DropdownMenuRadioGroup({ ...props }: MenuPrimitive.RadioGroup.Props) {
+  return (
+    <MenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  inset,
+  ...props
+}: MenuPrimitive.RadioItem.Props & {
+  inset?: boolean
+}) {
+  return (
+    <MenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      data-inset={inset}
+      className={cn(
+        "relative flex cursor-default items-center gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground focus:**:text-accent-foreground data-inset:pl-7 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span
+        className="pointer-events-none absolute right-2 flex items-center justify-center"
+        data-slot="dropdown-menu-radio-item-indicator"
+      >
+        <MenuPrimitive.RadioItemIndicator>
+          <CheckIcon
+          />
+        </MenuPrimitive.RadioItemIndicator>
+      </span>
+      {children}
+    </MenuPrimitive.RadioItem>
+  )
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: MenuPrimitive.Separator.Props) {
+  return (
+    <MenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn("-mx-1 my-1 h-px bg-border", className)}
+      {...props}
+    />
+  )
+}
+
+function DropdownMenuShortcut({
+  className,
+  ...props
+}: React.ComponentProps<"span">) {
+  return (
+    <span
+      data-slot="dropdown-menu-shortcut"
+      className={cn(
+        "ml-auto text-xs tracking-widest text-muted-foreground group-focus/dropdown-menu-item:text-accent-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuPortal,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuLabel,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubTrigger,
+  DropdownMenuSubContent,
+}

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,0 +1,4 @@
+export { default as useAuth } from "./useAuth";
+export { default as useAuthGuard } from "./useAuthGuard";
+
+export type { AuthUser, AuthStatus, UseAuthReturn } from "./useAuth";

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,94 @@
+"use client";
+
+import { useSession, signIn, signOut } from "next-auth/react";
+import { useCallback, useMemo } from "react";
+
+// ────────────────────────────────────────
+// Types
+// ────────────────────────────────────────
+
+/** 세션에서 추출한 사용자 정보 */
+export interface AuthUser {
+  id: string;
+  name: string | null;
+  email: string | null;
+  image: string | null;
+  nickname: string | null;
+}
+
+/** 인증 상태 */
+export type AuthStatus = "authenticated" | "loading" | "unauthenticated";
+
+/** useAuth 반환 타입 */
+export interface UseAuthReturn {
+  /** 현재 사용자 정보 (미인증 시 null) */
+  user: AuthUser | null;
+  /** 인증 상태 */
+  status: AuthStatus;
+  /** 로그인 여부 */
+  isAuthenticated: boolean;
+  /** 세션 로딩 중 여부 */
+  isLoading: boolean;
+  /** 로그인 페이지로 이동 */
+  login: (callbackUrl?: string) => void;
+  /** 로그아웃 처리 */
+  logout: (callbackUrl?: string) => Promise<void>;
+}
+
+// ────────────────────────────────────────
+// Hook
+// ────────────────────────────────────────
+
+/**
+ * 인증 상태를 관리하는 커스텀 훅
+ *
+ * next-auth/react의 useSession을 래핑하여
+ * 타입 안전한 사용자 정보와 인증 액션을 제공한다.
+ *
+ * @example
+ * ```tsx
+ * const { user, isAuthenticated, login, logout } = useAuth();
+ *
+ * if (isAuthenticated) {
+ *   return <p>{user.name}님 환영합니다</p>;
+ * }
+ * return <button onClick={() => login()}>로그인</button>;
+ * ```
+ */
+const useAuth = (): UseAuthReturn => {
+  const { data: session, status } = useSession();
+
+  const user = useMemo<AuthUser | null>(() => {
+    if (status !== "authenticated" || !session?.user) return null;
+
+    return {
+      id: session.user.id,
+      name: session.user.name ?? null,
+      email: session.user.email ?? null,
+      image: session.user.image ?? null,
+      nickname: session.user.nickname ?? null,
+    };
+  }, [session, status]);
+
+  const isAuthenticated = status === "authenticated";
+  const isLoading = status === "loading";
+
+  const login = useCallback((callbackUrl?: string) => {
+    signIn(undefined, { callbackUrl: callbackUrl ?? window.location.href });
+  }, []);
+
+  const logout = useCallback(async (callbackUrl: string = "/") => {
+    await signOut({ callbackUrl });
+  }, []);
+
+  return {
+    user,
+    status,
+    isAuthenticated,
+    isLoading,
+    login,
+    logout,
+  };
+};
+
+export default useAuth;

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -2,6 +2,7 @@
 
 import { useSession, signIn, signOut } from "next-auth/react";
 import { useCallback, useMemo } from "react";
+import { usePathname } from "next/navigation";
 
 // ────────────────────────────────────────
 // Types
@@ -57,6 +58,7 @@ export interface UseAuthReturn {
  */
 const useAuth = (): UseAuthReturn => {
   const { data: session, status } = useSession();
+  const pathname = usePathname();
 
   const user = useMemo<AuthUser | null>(() => {
     if (status !== "authenticated" || !session?.user) return null;
@@ -74,8 +76,8 @@ const useAuth = (): UseAuthReturn => {
   const isLoading = status === "loading";
 
   const login = useCallback((callbackUrl?: string) => {
-    signIn(undefined, { callbackUrl: callbackUrl ?? window.location.href });
-  }, []);
+    signIn(undefined, { callbackUrl: callbackUrl ?? pathname });
+  }, [pathname]);
 
   const logout = useCallback(async (callbackUrl: string = "/") => {
     await signOut({ callbackUrl });

--- a/src/hooks/useAuthGuard.ts
+++ b/src/hooks/useAuthGuard.ts
@@ -1,0 +1,69 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import useAuth from "./useAuth";
+
+// ────────────────────────────────────────
+// Types
+// ────────────────────────────────────────
+
+interface UseAuthGuardOptions {
+  /** 미인증 시 리다이렉트할 경로 (기본: "/login") */
+  redirectTo?: string;
+  /** 리다이렉트 비활성화 — 상태만 반환 */
+  redirect?: boolean;
+}
+
+interface UseAuthGuardReturn {
+  /** 인증 확인 완료 여부 (로딩 끝 + 인증됨) */
+  isReady: boolean;
+  /** 세션 로딩 중 여부 */
+  isLoading: boolean;
+  /** 인증 여부 */
+  isAuthenticated: boolean;
+}
+
+// ────────────────────────────────────────
+// Hook
+// ────────────────────────────────────────
+
+/**
+ * 인증이 필요한 페이지에서 사용하는 가드 훅
+ *
+ * 미인증 상태가 확인되면 로그인 페이지로 리다이렉트한다.
+ * 인증 확인이 완료될 때까지 isReady는 false이다.
+ *
+ * @example
+ * ```tsx
+ * const MyProtectedPage = () => {
+ *   const { isReady } = useAuthGuard();
+ *
+ *   if (!isReady) {
+ *     return <LoadingSpinner />;
+ *   }
+ *
+ *   return <div>보호된 콘텐츠</div>;
+ * };
+ * ```
+ */
+const useAuthGuard = (options: UseAuthGuardOptions = {}): UseAuthGuardReturn => {
+  const { redirectTo = "/login", redirect = true } = options;
+  const { isAuthenticated, isLoading } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isLoading && !isAuthenticated && redirect) {
+      const callbackUrl = encodeURIComponent(window.location.pathname);
+      router.replace(`${redirectTo}?callbackUrl=${callbackUrl}`);
+    }
+  }, [isLoading, isAuthenticated, redirect, redirectTo, router]);
+
+  return {
+    isReady: !isLoading && isAuthenticated,
+    isLoading,
+    isAuthenticated,
+  };
+};
+
+export default useAuthGuard;

--- a/src/hooks/useAuthGuard.ts
+++ b/src/hooks/useAuthGuard.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect } from "react";
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname, useSearchParams } from "next/navigation";
 import useAuth from "./useAuth";
 
 // ────────────────────────────────────────
@@ -51,13 +51,17 @@ const useAuthGuard = (options: UseAuthGuardOptions = {}): UseAuthGuardReturn => 
   const { redirectTo = "/login", redirect = true } = options;
   const { isAuthenticated, isLoading } = useAuth();
   const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
 
   useEffect(() => {
     if (!isLoading && !isAuthenticated && redirect) {
-      const callbackUrl = encodeURIComponent(window.location.pathname);
+      const search = searchParams.toString();
+      const currentUrl = search ? `${pathname}?${search}` : pathname;
+      const callbackUrl = encodeURIComponent(currentUrl);
       router.replace(`${redirectTo}?callbackUrl=${callbackUrl}`);
     }
-  }, [isLoading, isAuthenticated, redirect, redirectTo, router]);
+  }, [isLoading, isAuthenticated, redirect, redirectTo, router, pathname, searchParams]);
 
   return {
     isReady: !isLoading && isAuthenticated,


### PR DESCRIPTION
## Summary
- **useAuth 훅**: `useSession` 래핑 → 타입 안전한 `AuthUser` 인터페이스 + `login()`/`logout()` 액션 캡슐화
- **useAuthGuard 훅**: 보호 페이지에서 미인증 사용자 자동 리다이렉트 (callbackUrl 포함)
- **AuthButton 리팩터링**: `useSession` → `useAuth` 교체 + 로그아웃 드롭다운 메뉴 (프로필 사진, 이름, 이메일 표시)
- **LoginPage 개선**: 이미 로그인 상태에서 /login 접근 시 홈으로 리다이렉트

## 구현 목록
| 파일 | 변경 내용 |
|------|-----------|
| `src/hooks/useAuth.ts` | 🆕 핵심 인증 상태 훅 (AuthUser 타입, login/logout 액션) |
| `src/hooks/useAuthGuard.ts` | 🆕 보호 페이지 가드 훅 (리다이렉트 + isReady 상태) |
| `src/hooks/index.ts` | 🆕 배럴 export |
| `src/components/layout/AuthButton.tsx` | ♻️ useAuth 적용 + 로그아웃 드롭다운 메뉴 |
| `src/app/login/page.tsx` | ♻️ 인증 상태 리다이렉트 로직 추가 |
| `docs/adr/101-auth-state-hook.md` | 🆕 ADR: 클라이언트 인증 상태 관리 설계 결정 |

## 관련 이슈
- Closes 하위 작업: Epic #4 `feat/ui-auth-state`

## 설계 결정 (ADR-101)
- **useSession 직접 사용** vs **커스텀 훅 래핑** vs **Zustand 스토어** 중 커스텀 훅 선택
- SessionProvider가 이미 캐시를 관리하므로 Zustand 중복 불필요
- React Query는 서버 데이터(랭킹 등)에만 사용, 세션은 Auth.js 전용 캐시 활용

## Test plan
- [x] TypeScript 타입 체크 통과 (`pnpm type-check`)
- [x] ESLint 통과 (`pnpm lint`)
- [x] 미인증 상태에서 AuthButton → 로그인 아이콘 + /login 링크 표시 확인
- [x] 인증 상태에서 AuthButton → 프로필 사진 클릭 시 드롭다운 메뉴 표시 확인
- [x] 드롭다운 메뉴에서 로그아웃 클릭 시 세션 제거 + 홈 리다이렉트 확인
- [x] 인증 상태에서 /login 접근 시 홈으로 리다이렉트 확인
- [x] ESC 키 / 외부 클릭으로 드롭다운 닫힘 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)