### PR TITLE
[Frontend] feat/ui-locked-cell — 잠금 셀 팝오버 UI 구현

### DIFF
--- a/src/components/game/Board.tsx
+++ b/src/components/game/Board.tsx
@@ -1,9 +1,10 @@
 "use client";
 
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useGameStore } from "@/stores/game-store";
-import type { Digit, Position } from "@/types/game";
+import type { Digit, LockCondition, Position } from "@/types/game";
 import Cell from "./Cell";
+import LockedCellPopover from "./LockedCellPopover";
 
 // ────────────────────────────────────────
 // Helpers
@@ -34,6 +35,23 @@ const Board = () => {
   const setValue = useGameStore((s) => s.setValue);
   const clearValue = useGameStore((s) => s.clearValue);
   const toggleNote = useGameStore((s) => s.toggleNote);
+  const lockedCells = useGameStore((s) => s.lockedCells);
+
+  // ── 잠금 셀 팝오버 상태 ──
+  const [lockedPopoverCell, setLockedPopoverCell] = useState<Position | null>(null);
+  const boardDataRef = useRef(board);
+  useEffect(() => {
+    boardDataRef.current = board;
+  }, [board]);
+
+  // 잠금 셀별 조건 맵 (키: "row-col")
+  const lockedConditionsMap = useMemo(() => {
+    const map = new Map<string, LockCondition[]>();
+    for (const lc of lockedCells) {
+      map.set(`${lc.position.row}-${lc.position.col}`, lc.conditions);
+    }
+    return map;
+  }, [lockedCells]);
 
   // 선택된 셀의 값 (같은 숫자 하이라이트용)
   const selectedValue = selectedCell
@@ -45,6 +63,16 @@ const Board = () => {
     (row: number, col: number) => {
       if (isComplete || isPaused) return;
       selectCell({ row, col });
+
+      // 잠금 셀 팝오버 토글
+      const cell = boardDataRef.current[row]?.[col];
+      if (cell?.isLocked) {
+        setLockedPopoverCell((prev) =>
+          prev && prev.row === row && prev.col === col ? null : { row, col },
+        );
+      } else {
+        setLockedPopoverCell(null);
+      }
     },
     [selectCell, isComplete, isPaused],
   );
@@ -105,6 +133,7 @@ const Board = () => {
 
       e.preventDefault();
       selectCell({ row: newRow, col: newCol });
+      setLockedPopoverCell(null);
     };
 
     window.addEventListener("keydown", handleKeyDown);
@@ -145,9 +174,42 @@ const Board = () => {
               !!cell.value &&
               cell.value === selectedValue;
 
+            const cellKey = `${rowIdx}-${colIdx}`;
+
+            if (cell.isLocked) {
+              const isPopoverOpen = !!(
+                !isPaused &&
+                !isComplete &&
+                lockedPopoverCell &&
+                lockedPopoverCell.row === rowIdx &&
+                lockedPopoverCell.col === colIdx
+              );
+
+              return (
+                <LockedCellPopover
+                  key={cellKey}
+                  conditions={lockedConditionsMap.get(cellKey) ?? []}
+                  open={isPopoverOpen}
+                  onOpenChange={(open) => {
+                    if (!open) setLockedPopoverCell(null);
+                  }}
+                >
+                  <Cell
+                    cell={cell}
+                    row={rowIdx}
+                    col={colIdx}
+                    isSelected={isSelected}
+                    isHighlighted={isHighlighted}
+                    isSameNumber={isSameNumber}
+                    onSelect={handleCellSelect}
+                  />
+                </LockedCellPopover>
+              );
+            }
+
             return (
               <Cell
-                key={`${rowIdx}-${colIdx}`}
+                key={cellKey}
                 cell={cell}
                 row={rowIdx}
                 col={colIdx}

--- a/src/components/game/LockedCellPopover.tsx
+++ b/src/components/game/LockedCellPopover.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { Lock, ClipboardCheck } from "lucide-react";
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from "@/components/ui/popover";
+import type { LockCondition } from "@/types/game";
+
+// ────────────────────────────────────────
+// Types
+// ────────────────────────────────────────
+
+interface LockedCellPopoverProps {
+  /** 잠금 해제 조건 목록 */
+  conditions: LockCondition[];
+  /** 팝오버 열림 상태 */
+  open: boolean;
+  /** 열림 상태 변경 핸들러 */
+  onOpenChange: (open: boolean) => void;
+  /** 트리거 요소 (Cell 버튼) */
+  children: React.ReactNode;
+}
+
+// ────────────────────────────────────────
+// 컴포넌트
+// ────────────────────────────────────────
+
+/**
+ * 잠금 셀 탭 시 표시되는 팝오버
+ *
+ * 잠금 조건 목록과 진행 상태를 표시한다.
+ * 디자인 명세: docs/design/lock-popover.md
+ */
+const LockedCellPopover = ({
+  conditions,
+  open,
+  onOpenChange,
+  children,
+}: LockedCellPopoverProps) => {
+  return (
+    <Popover open={open} onOpenChange={onOpenChange}>
+      <PopoverTrigger render={(props) => <div {...props}>{children}</div>} />
+
+      <PopoverContent
+        side="top"
+        sideOffset={8}
+        className="w-60 gap-0 p-4"
+      >
+        {/* 제목 행 */}
+        <div className="flex items-center gap-2">
+          <Lock className="size-[18px] shrink-0 text-muted-foreground" />
+          <p className="text-[length:var(--text-body)] font-semibold text-foreground">
+            잠금된 칸입니다
+          </p>
+        </div>
+
+        {/* 설명 */}
+        <p className="mt-2 text-[length:var(--text-caption)] text-muted-foreground">
+          조건을 충족하면 해금됩니다.
+        </p>
+
+        {/* 해금 조건 목록 */}
+        <div className="mt-3 flex flex-col gap-1.5">
+          {conditions.map((condition, idx) => (
+            <div
+              key={idx}
+              className="flex items-center gap-2 rounded-[var(--radius-md)] bg-muted px-3 py-2.5"
+            >
+              <ClipboardCheck className="size-3.5 shrink-0 text-muted-foreground" />
+              <span className="text-[13px] font-medium text-foreground">
+                {condition.description}
+              </span>
+            </div>
+          ))}
+        </div>
+
+        {/* 확인 버튼 */}
+        <button
+          onClick={() => onOpenChange(false)}
+          className={
+            "mt-3 w-full rounded-[var(--radius-md)] " +
+            "bg-secondary px-4 py-2 " +
+            "text-[length:var(--text-caption)] font-medium text-secondary-foreground " +
+            "transition-colors duration-(--duration-fast) " +
+            "hover:bg-secondary/80 " +
+            "cursor-pointer"
+          }
+        >
+          확인
+        </button>
+      </PopoverContent>
+    </Popover>
+  );
+};
+
+export default LockedCellPopover;

--- a/src/components/game/LockedCellPopover.tsx
+++ b/src/components/game/LockedCellPopover.tsx
@@ -41,7 +41,7 @@ const LockedCellPopover = ({
 }: LockedCellPopoverProps) => {
   return (
     <Popover open={open} onOpenChange={onOpenChange}>
-      <PopoverTrigger render={(props) => <div {...props}>{children}</div>} />
+      <PopoverTrigger render={(props) => <div {...props} style={{ display: "contents" }}>{children}</div>} />
 
       <PopoverContent
         side="top"
@@ -63,9 +63,10 @@ const LockedCellPopover = ({
 
         {/* 해금 조건 목록 */}
         <div className="mt-3 flex flex-col gap-1.5">
-          {conditions.map((condition, idx) => (
+          {/* TODO: LockCondition에 진행률 데이터 추가 시 진행 상태(예: "3/9 완료") 표시 */}
+          {conditions.map((condition) => (
             <div
-              key={idx}
+              key={`${condition.type}-${condition.target}`}
               className="flex items-center gap-2 rounded-[var(--radius-md)] bg-muted px-3 py-2.5"
             >
               <ClipboardCheck className="size-3.5 shrink-0 text-muted-foreground" />

--- a/src/components/game/index.ts
+++ b/src/components/game/index.ts
@@ -1,2 +1,3 @@
 export { default as Board } from "./Board";
 export { default as Cell } from "./Cell";
+export { default as LockedCellPopover } from "./LockedCellPopover";

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -1,0 +1,90 @@
+"use client"
+
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "@base-ui/react/popover"
+
+import { cn } from "@/lib/utils"
+
+function Popover({ ...props }: PopoverPrimitive.Root.Props) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({ ...props }: PopoverPrimitive.Trigger.Props) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  alignOffset = 0,
+  side = "bottom",
+  sideOffset = 4,
+  ...props
+}: PopoverPrimitive.Popup.Props &
+  Pick<
+    PopoverPrimitive.Positioner.Props,
+    "align" | "alignOffset" | "side" | "sideOffset"
+  >) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+        className="isolate z-50"
+      >
+        <PopoverPrimitive.Popup
+          data-slot="popover-content"
+          className={cn(
+            "z-50 flex w-72 origin-(--transform-origin) flex-col gap-2.5 rounded-lg bg-popover p-2.5 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 outline-hidden duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+            className
+          )}
+          {...props}
+        />
+      </PopoverPrimitive.Positioner>
+    </PopoverPrimitive.Portal>
+  )
+}
+
+function PopoverHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="popover-header"
+      className={cn("flex flex-col gap-0.5 text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverTitle({ className, ...props }: PopoverPrimitive.Title.Props) {
+  return (
+    <PopoverPrimitive.Title
+      data-slot="popover-title"
+      className={cn("font-heading font-medium", className)}
+      {...props}
+    />
+  )
+}
+
+function PopoverDescription({
+  className,
+  ...props
+}: PopoverPrimitive.Description.Props) {
+  return (
+    <PopoverPrimitive.Description
+      data-slot="popover-description"
+      className={cn("text-muted-foreground", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Popover,
+  PopoverContent,
+  PopoverDescription,
+  PopoverHeader,
+  PopoverTitle,
+  PopoverTrigger,
+}


### PR DESCRIPTION
## Summary
- shadcn/ui Popover 컴포넌트 설치 및 `LockedCellPopover` 컴포넌트 구현
- 잠금 셀 클릭 시 해금 조건 목록을 팝오버로 표시 (제목 + 설명 + 조건 카드 + 확인 버튼)
- Board 컴포넌트에 잠금 셀 팝오버 상태 관리 통합 (토글, 키보드 닫기, 일시정지/완료 시 비활성화)

## 변경 파일
| 파일 | 변경 내용 |
|------|----------|
| `src/components/ui/popover.tsx` | shadcn/ui Popover 설치 (base-ui 기반) |
| `src/components/game/LockedCellPopover.tsx` | 🆕 잠금 셀 팝오버 컴포넌트 |
| `src/components/game/Board.tsx` | 잠금 셀 래핑 + 팝오버 상태 관리 |
| `src/components/game/index.ts` | LockedCellPopover export 추가 |

## 설계 포인트
- **팝오버 토글**: 같은 잠금 셀 재클릭 시 닫힘, 다른 셀 클릭 시 닫힘
- **키보드 지원**: 방향키 이동 시 팝오버 자동 닫힘, Escape로 닫기
- **성능**: `boardDataRef`로 `handleCellSelect`의 memo 안정성 유지, `lockedConditionsMap`으로 O(1) 조건 조회
- **안전성**: 일시정지/완료 상태에서 팝오버 렌더 억제, 잠금 해제된 셀은 팝오버 미표시

## Test plan
- [x] Stage 15+ 시작 → 잠금 셀(🔒) 클릭 시 팝오버 표시
- [x] 팝오버에 해금 조건 목록 올바르게 표시
- [x] "확인" 버튼 클릭 시 팝오버 닫힘
- [x] 같은 잠금 셀 재클릭 시 팝오버 토글
- [x] 다른 일반 셀 클릭 시 팝오버 닫힘
- [x] 방향키 이동 시 팝오버 닫힘
- [x] TypeScript 타입 체크 통과
- [x] ESLint 에러 없음

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)