### PR TITLE
[Frontend] feat/ui-timer — 타이머 컴포넌트 구현

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -189,6 +189,7 @@
   --text-cell-given: 24px;
   --text-cell-memo: 10px;
   --text-numpad: 24px;
+  --text-timer: 20px;
 
   /* ── 🖌 그림자 (Light) ── */
   --shadow-board: 0 2px 8px oklch(0 0 0 / 0.08), 0 0 0 3px oklch(0.25 0 0);

--- a/src/components/game/Timer.tsx
+++ b/src/components/game/Timer.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useEffect } from "react";
+import { useGameStore } from "@/stores/game-store";
+
+// ────────────────────────────────────────
+// 헬퍼
+// ────────────────────────────────────────
+
+/**
+ * 초(seconds)를 타이머 포맷 문자열로 변환
+ *
+ * | 경과 시간 | 포맷        | 예시     |
+ * |----------|------------|---------|
+ * | < 1시간  | MM:SS      | 03:24   |
+ * | ≥ 1시간  | H:MM:SS    | 1:03:24 |
+ *
+ * @see docs/design/game.md §2.1 타이머 포맷
+ */
+export const formatTime = (seconds: number): string => {
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  const s = seconds % 60;
+
+  const mm = String(m).padStart(2, "0");
+  const ss = String(s).padStart(2, "0");
+
+  if (h > 0) {
+    return `${h}:${mm}:${ss}`;
+  }
+  return `${mm}:${ss}`;
+};
+
+// ────────────────────────────────────────
+// Props
+// ────────────────────────────────────────
+
+interface TimerProps {
+  /** 외부에서 추가 className을 전달할 때 사용 */
+  className?: string;
+}
+
+// ────────────────────────────────────────
+// Timer 컴포넌트
+// ────────────────────────────────────────
+
+/**
+ * 게임 경과 시간 표시 + 자동 틱
+ *
+ * - 1초 간격으로 store의 tick() 호출
+ * - isPaused / isComplete / !isStarted 상태에서 자동 정지
+ * - 디자인: Geist Mono, 20px, weight 500
+ *
+ * @see docs/design/game.md §2 Header — 타이머
+ */
+const Timer = ({ className = "" }: TimerProps) => {
+  const timer = useGameStore((s) => s.timer);
+  const isPaused = useGameStore((s) => s.isPaused);
+  const isComplete = useGameStore((s) => s.isComplete);
+  const isStarted = useGameStore((s) => s.isStarted);
+  const tick = useGameStore((s) => s.tick);
+
+  // ── 1초 인터벌 ──
+  useEffect(() => {
+    if (!isStarted || isPaused || isComplete) return;
+
+    const intervalId = setInterval(() => {
+      tick();
+    }, 1000);
+
+    return () => clearInterval(intervalId);
+  }, [isStarted, isPaused, isComplete, tick]);
+
+  return (
+    <time
+      aria-label={`경과 시간 ${formatTime(timer)}`}
+      aria-live="off"
+      className={`font-mono text-(length:--text-timer) font-medium tabular-nums ${className}`}
+    >
+      {formatTime(timer)}
+    </time>
+  );
+};
+
+export default Timer;

--- a/src/components/game/Timer.tsx
+++ b/src/components/game/Timer.tsx
@@ -18,9 +18,10 @@ import { useGameStore } from "@/stores/game-store";
  * @see docs/design/game.md §2.1 타이머 포맷
  */
 export const formatTime = (seconds: number): string => {
-  const h = Math.floor(seconds / 3600);
-  const m = Math.floor((seconds % 3600) / 60);
-  const s = seconds % 60;
+  const safe = Math.max(0, seconds);
+  const h = Math.floor(safe / 3600);
+  const m = Math.floor((safe % 3600) / 60);
+  const s = safe % 60;
 
   const mm = String(m).padStart(2, "0");
   const ss = String(s).padStart(2, "0");
@@ -71,13 +72,15 @@ const Timer = ({ className = "" }: TimerProps) => {
     return () => clearInterval(intervalId);
   }, [isStarted, isPaused, isComplete, tick]);
 
+  const display = formatTime(timer);
+
   return (
     <time
-      aria-label={`경과 시간 ${formatTime(timer)}`}
+      aria-label={`경과 시간 ${display}`}
       aria-live="off"
       className={`font-mono text-(length:--text-timer) font-medium tabular-nums ${className}`}
     >
-      {formatTime(timer)}
+      {display}
     </time>
   );
 };

--- a/src/components/game/index.ts
+++ b/src/components/game/index.ts
@@ -2,3 +2,5 @@ export { default as Board } from "./Board";
 export { default as Cell } from "./Cell";
 export { default as LockedCellPopover } from "./LockedCellPopover";
 export { default as NumberPad } from "./NumberPad";
+export { default as Timer } from "./Timer";
+export { formatTime } from "./Timer";


### PR DESCRIPTION
## Summary

- **Timer.tsx** 컴포넌트 신규 생성 — 게임 경과 시간 표시 + 자동 틱
- **formatTime** 유틸 함수 — 초 단위를 `MM:SS` / `H:MM:SS` 포맷으로 변환
- 1초 인터벌로 store `tick()` 호출, `isPaused` / `isComplete` / `!isStarted` 상태에서 자동 정지
- `globals.css`에 `--text-timer: 20px` 타이포그래피 변수 추가

## 구현 상세

| 파일 | 변경 |
|------|------|
| `src/components/game/Timer.tsx` | 신규 — Timer 컴포넌트 + formatTime 유틸 |
| `src/components/game/index.ts` | Timer, formatTime export 추가 |
| `src/app/globals.css` | `--text-timer` CSS 변수 추가 |

## 디자인 명세 일치 확인

- [x] 폰트: Geist Mono (`font-mono`) — `game.md §2`
- [x] 크기: 20px (`--text-timer`) — `game.md §2`
- [x] 두께: weight 500 (`font-medium`) — `game.md §2`
- [x] 포맷: < 1시간 `MM:SS`, ≥ 1시간 `H:MM:SS` — `game.md §2.1`
- [x] 정지 조건: 일시정지 / 게임 완료 / 미시작 — `ux-flow.md §3.2`
- [x] `tabular-nums`로 숫자 폭 고정 (깜빡임 방지)
- [x] Tailwind v4 신문법 사용 `text-(length:--text-timer)`

## 접근성

- [x] `<time>` 시맨틱 HTML 태그 사용
- [x] `aria-label`에 포맷된 시간 포함
- [x] `aria-live="off"` — 매초 읽어주지 않도록 설정

## 관련 이슈

Epic #5 `feat/ui-timer` 작업

## Test Plan

- [ ] 게임 시작 후 타이머 1초 간격 증가 확인
- [ ] 일시정지 → 타이머 정지 확인
- [ ] 재개 → 타이머 재시작 확인
- [ ] 게임 완료 → 타이머 정지 확인
- [ ] 59:59 → 1:00:00 포맷 전환 확인 (formatTime 단위 테스트 권장)

🤖 Generated with [Claude Code](https://claude.com/claude-code)