### PR TITLE
[Frontend] feat/ui-game-header — 게임 헤더 컴포넌트 구현

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -185,6 +185,12 @@
   --memo-cell-size: 12px;
 
   /* ── 🖌 타이포그래피 스케일 ── */
+  --text-display: 32px;
+  --text-heading: 24px;
+  --text-subheading: 18px;
+  --text-body: 16px;
+  --text-caption: 14px;
+  --text-small: 12px;
   --text-cell: 24px;
   --text-cell-given: 24px;
   --text-cell-memo: 10px;

--- a/src/components/game/GameHeader.tsx
+++ b/src/components/game/GameHeader.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useCallback } from "react";
+import { Pause, Play } from "lucide-react";
+import { useGameStore } from "@/stores/game-store";
+import { STAGE_RANGES } from "@/types/game";
+import { AppLayout } from "@/components/layout";
+import Timer from "./Timer";
+
+// ────────────────────────────────────────
+// 헬퍼
+// ────────────────────────────────────────
+
+/** 스테이지 번호로 난이도 라벨 + 색상 클래스를 반환 */
+const getDifficultyInfo = (
+  stage: number,
+): { label: string; colorClass: string } => {
+  for (const range of STAGE_RANGES) {
+    if (stage >= range.startStage && stage <= range.endStage) {
+      const colorMap: Record<string, string> = {
+        입문: "text-difficulty-easy",
+        초급: "text-difficulty-easy",
+        중급: "text-difficulty-medium",
+        고급: "text-difficulty-hard",
+        마스터: "text-difficulty-expert",
+      };
+      return {
+        label: range.label,
+        colorClass: colorMap[range.label] ?? "text-muted-foreground",
+      };
+    }
+  }
+  return { label: "알 수 없음", colorClass: "text-muted-foreground" };
+};
+
+// ────────────────────────────────────────
+// Props
+// ────────────────────────────────────────
+
+interface GameHeaderProps {
+  children: React.ReactNode;
+}
+
+// ────────────────────────────────────────
+// GameHeader 컴포넌트
+// ────────────────────────────────────────
+
+/**
+ * 게임 전용 레이아웃 래퍼
+ *
+ * Header variant="game"에 난이도 라벨 + 타이머 (중앙) +
+ * 일시정지/재개 버튼 (우측)을 배치한다.
+ * BottomNav는 자동 숨김 (/game 경로).
+ *
+ * @see docs/design/game.md §2 Header (게임 전용)
+ */
+const GameHeader = ({ children }: GameHeaderProps) => {
+  const stage = useGameStore((s) => s.stage);
+  const isPaused = useGameStore((s) => s.isPaused);
+  const isComplete = useGameStore((s) => s.isComplete);
+  const isStarted = useGameStore((s) => s.isStarted);
+  const pause = useGameStore((s) => s.pause);
+  const resume = useGameStore((s) => s.resume);
+
+  const { label, colorClass } = getDifficultyInfo(stage);
+
+  const handlePauseToggle = useCallback(() => {
+    if (isPaused) {
+      resume();
+    } else {
+      pause();
+    }
+  }, [isPaused, pause, resume]);
+
+  // ── 중앙: 난이도 라벨 + 타이머 ──
+  const centerSlot = isStarted ? (
+    <div className="flex items-center gap-2">
+      <span className={`text-sm font-medium ${colorClass}`}>
+        {label}
+      </span>
+      <span className="text-muted-foreground" aria-hidden="true">·</span>
+      <Timer />
+    </div>
+  ) : null;
+
+  // ── 우측: 일시정지/재개 버튼 ──
+  const rightSlot = isStarted && !isComplete ? (
+    <button
+      type="button"
+      onClick={handlePauseToggle}
+      aria-label={isPaused ? "게임 재개" : "일시정지"}
+      className={
+        "flex items-center justify-center size-11 rounded-lg " +
+        "text-foreground " +
+        "transition-colors duration-(--duration-fast) " +
+        "hover:bg-accent"
+      }
+    >
+      {isPaused ? (
+        <Play size={20} strokeWidth={2} />
+      ) : (
+        <Pause size={20} strokeWidth={2} />
+      )}
+    </button>
+  ) : undefined;
+
+  return (
+    <AppLayout
+      headerVariant="game"
+      centerContent={centerSlot}
+      rightContent={rightSlot}
+    >
+      {children}
+    </AppLayout>
+  );
+};
+
+export default GameHeader;

--- a/src/components/game/GameHeader.tsx
+++ b/src/components/game/GameHeader.tsx
@@ -11,22 +11,24 @@ import Timer from "./Timer";
 // 헬퍼
 // ────────────────────────────────────────
 
+/** 난이도 라벨 → Tailwind 색상 클래스 매핑 (모듈 상수) */
+const DIFFICULTY_COLOR_MAP: Record<string, string> = {
+  입문: "text-difficulty-easy",
+  초급: "text-difficulty-easy",
+  중급: "text-difficulty-medium",
+  고급: "text-difficulty-hard",
+  마스터: "text-difficulty-expert",
+};
+
 /** 스테이지 번호로 난이도 라벨 + 색상 클래스를 반환 */
 const getDifficultyInfo = (
   stage: number,
 ): { label: string; colorClass: string } => {
   for (const range of STAGE_RANGES) {
     if (stage >= range.startStage && stage <= range.endStage) {
-      const colorMap: Record<string, string> = {
-        입문: "text-difficulty-easy",
-        초급: "text-difficulty-easy",
-        중급: "text-difficulty-medium",
-        고급: "text-difficulty-hard",
-        마스터: "text-difficulty-expert",
-      };
       return {
         label: range.label,
-        colorClass: colorMap[range.label] ?? "text-muted-foreground",
+        colorClass: DIFFICULTY_COLOR_MAP[range.label] ?? "text-muted-foreground",
       };
     }
   }
@@ -75,7 +77,7 @@ const GameHeader = ({ children }: GameHeaderProps) => {
   // ── 중앙: 난이도 라벨 + 타이머 ──
   const centerSlot = isStarted ? (
     <div className="flex items-center gap-2">
-      <span className={`text-sm font-medium ${colorClass}`}>
+      <span className={`text-(length:--text-caption) font-medium ${colorClass}`}>
         {label}
       </span>
       <span className="text-muted-foreground" aria-hidden="true">·</span>

--- a/src/components/game/index.ts
+++ b/src/components/game/index.ts
@@ -1,5 +1,6 @@
 export { default as Board } from "./Board";
 export { default as Cell } from "./Cell";
+export { default as GameHeader } from "./GameHeader";
 export { default as LockedCellPopover } from "./LockedCellPopover";
 export { default as NumberPad } from "./NumberPad";
 export { default as Timer } from "./Timer";


### PR DESCRIPTION
## Summary

- **GameHeader.tsx** 컴포넌트 신규 생성 — 게임 전용 레이아웃 래퍼
- 기존 `AppLayout` + `Header(variant="game")`의 슬롯에 게임 UI를 배치
- 중앙: 난이도 라벨 (`STAGE_RANGES` 기반 색상 매핑) + `Timer` 컴포넌트
- 우측: 일시정지/재개 토글 버튼 (`Pause`/`Play` Lucide 아이콘)

## 구현 상세

| 파일 | 변경 |
|------|------|
| `src/components/game/GameHeader.tsx` | 신규 — GameHeader + getDifficultyInfo 헬퍼 |
| `src/components/game/index.ts` | GameHeader export 추가 |

## 디자인 명세 일치 확인

- [x] 좌측: ← 뒤로가기 (`BackButton`, 44×44px 터치 영역) — `game.md §2`
- [x] 중앙: 난이도 라벨 14px + 타이머 20px Geist Mono — `game.md §2`
- [x] 우측: ⏸ 일시정지 20px, 44×44px 터치 영역 — `game.md §2`
- [x] 난이도 색상: 입문/초급=`--difficulty-easy`, 중급=`--difficulty-medium`, 고급=`--difficulty-hard`, 마스터=`--difficulty-expert` — `game.md §2`
- [x] 일시정지 시 ▶ Play 아이콘으로 전환 — `game.md §6`
- [x] 게임 완료 시 일시정지 버튼 숨김
- [x] BottomNav 자동 숨김 (`/game` 경로)

## 접근성

- [x] 일시정지 버튼 `aria-label` 상태별 변경 ("일시정지" / "게임 재개")
- [x] 뒤로가기 버튼 `aria-label="뒤로 가기"` (기존 BackButton)

## 수동 테스트 결과

- [x] Header 좌측 ← 뒤로 버튼 표시
- [x] Header 중앙 난이도 라벨 + 타이머 표시
- [x] Stage 1/11/21/31/41 전환 시 난이도 색상 변화
- [x] Header 우측 ⏸ 일시정지 버튼 표시
- [x] 일시정지 클릭 → ▶ 전환 + 타이머 정지 + 보드 블러
- [x] 재개 클릭 → ⏸ 복원 + 타이머 재시작
- [x] BottomNav 숨김 확인

## 관련 이슈

Epic #5 `feat/ui-game-header` 작업

## Test Plan

- [x] 수동 테스트 완료 (위 체크리스트 참조)

🤖 Generated with [Claude Code](https://claude.com/claude-code)