### PR TITLE
[Frontend] feat/ui-game-page — 게임 플레이 페이지 통합

### DIFF
--- a/src/app/game/GameContent.tsx
+++ b/src/app/game/GameContent.tsx
@@ -1,0 +1,154 @@
+"use client";
+
+import { useEffect, useRef, useSyncExternalStore } from "react";
+import { useSearchParams, useRouter } from "next/navigation";
+import { useGameStore } from "@/stores/game-store";
+import {
+  Board,
+  GameHeader,
+  NumberPad,
+} from "@/components/game";
+import Toolbar from "@/components/game/Toolbar";
+import PauseOverlay from "@/components/game/PauseOverlay";
+
+// ────────────────────────────────────────
+// Zustand persist 하이드레이션 구독
+// ────────────────────────────────────────
+
+const subscribeToHydration = (callback: () => void) => {
+  return useGameStore.persist.onFinishHydration(callback);
+};
+const getHydrationSnapshot = () => useGameStore.persist.hasHydrated();
+const getHydrationServerSnapshot = () => false;
+
+// ────────────────────────────────────────
+// 로딩 스켈레톤
+// ────────────────────────────────────────
+
+/** 게임 로딩 중 표시되는 스켈레톤 */
+const GameSkeleton = () => (
+  <div className="flex flex-1 flex-col items-center px-4 py-4 gap-4 animate-pulse">
+    {/* 보드 스켈레톤 */}
+    <div
+      className="aspect-square w-full max-w-[376px] rounded-[var(--radius-lg)] bg-muted/40"
+      aria-hidden="true"
+    />
+    {/* 도구바 스켈레톤 */}
+    <div className="flex gap-2 w-full max-w-[376px]">
+      {Array.from({ length: 4 }, (_, i) => (
+        <div key={i} className="flex-1 h-12 rounded-[var(--radius-md)] bg-muted/30" />
+      ))}
+    </div>
+    {/* 숫자패드 스켈레톤 */}
+    <div className="grid grid-cols-5 gap-2 w-full max-w-[376px]">
+      {Array.from({ length: 10 }, (_, i) => (
+        <div key={i} className="h-12 rounded-[var(--radius-md)] bg-muted/30" />
+      ))}
+    </div>
+  </div>
+);
+
+// ────────────────────────────────────────
+// GameContent 컴포넌트
+// ────────────────────────────────────────
+
+/**
+ * 게임 플레이 페이지 콘텐츠 (클라이언트)
+ *
+ * 구성: GameHeader > (Board + Toolbar + NumberPad + PauseOverlay)
+ *
+ * ## 게임 초기화 흐름
+ *
+ * 1. Zustand persist 하이드레이션 완료 대기 (스켈레톤 표시)
+ * 2. 하이드레이션 후 스토어에 진행 중인 게임이 있으면 계속
+ * 3. 없으면 URL의 stage 파라미터로 새 게임 생성
+ * 4. 유효한 stage 없으면 홈으로 리다이렉트
+ *
+ * @see docs/design/game.md
+ */
+const GameContent = () => {
+  const searchParams = useSearchParams();
+  const router = useRouter();
+  const initDoneRef = useRef(false);
+
+  // Zustand persist 하이드레이션 상태
+  const isHydrated = useSyncExternalStore(
+    subscribeToHydration,
+    getHydrationSnapshot,
+    getHydrationServerSnapshot,
+  );
+
+  // 스토어 구독
+  const isStarted = useGameStore((s) => s.isStarted);
+  const stage = useGameStore((s) => s.stage);
+  const initGame = useGameStore((s) => s.initGame);
+
+  // ── 게임 초기화 (하이드레이션 완료 후 1회 실행) ──
+  useEffect(() => {
+    if (!isHydrated || initDoneRef.current) return;
+
+    const stageParam = searchParams.get("stage");
+    const targetStage = stageParam ? parseInt(stageParam, 10) : NaN;
+
+    // 이미 같은 스테이지 진행 중 → 계속
+    if (isStarted && stage === targetStage) {
+      initDoneRef.current = true;
+      return;
+    }
+
+    // 진행 중인 게임 존재 (URL 없이 접근 또는 stage 불일치)
+    if (isStarted && (isNaN(targetStage) || targetStage === stage)) {
+      initDoneRef.current = true;
+      return;
+    }
+
+    // 유효한 stage 파라미터 → 새 게임
+    if (targetStage >= 1 && targetStage <= 50) {
+      initGame(targetStage);
+      initDoneRef.current = true;
+      return;
+    }
+
+    // 게임 없고 유효한 stage도 없음 → 홈으로
+    router.replace("/");
+  }, [isHydrated, isStarted, stage, searchParams, initGame, router]);
+
+  // ── 하이드레이션 전: 스켈레톤 ──
+  if (!isHydrated) {
+    return (
+      <GameHeader>
+        <GameSkeleton />
+      </GameHeader>
+    );
+  }
+
+  // ── 게임 미시작 (리다이렉트 중이거나 초기화 대기) ──
+  if (!isStarted) {
+    return (
+      <GameHeader>
+        <GameSkeleton />
+      </GameHeader>
+    );
+  }
+
+  // ── 게임 진행 중 ──
+  return (
+    <GameHeader>
+      <div className="flex flex-1 flex-col items-center px-[var(--board-padding)] py-4 gap-4">
+        {/* 보드 */}
+        <Board />
+
+        {/* 도구바 + 숫자패드 (보드 최대 너비에 맞춤) */}
+        <div className="w-full max-w-[376px] flex flex-col gap-4">
+          <Toolbar />
+          <NumberPad />
+        </div>
+      </div>
+
+      {/* 일시정지 오버레이 */}
+      <PauseOverlay />
+    </GameHeader>
+  );
+};
+
+export default GameContent;

--- a/src/app/game/page.tsx
+++ b/src/app/game/page.tsx
@@ -1,0 +1,20 @@
+import { Suspense } from "react";
+import GameContent from "./GameContent";
+
+/**
+ * 게임 플레이 페이지
+ *
+ * URL: /game?stage={1~50}
+ *
+ * - Suspense: useSearchParams()를 사용하는 GameContent를 감싸 스트리밍
+ * - GameContent가 Zustand persist 하이드레이션 + 게임 초기화 담당
+ *
+ * @see docs/design/game.md
+ */
+const GamePage = () => (
+  <Suspense>
+    <GameContent />
+  </Suspense>
+);
+
+export default GamePage;

--- a/src/components/game/LockedCellPopover.tsx
+++ b/src/components/game/LockedCellPopover.tsx
@@ -41,7 +41,7 @@ const LockedCellPopover = ({
 }: LockedCellPopoverProps) => {
   return (
     <Popover open={open} onOpenChange={onOpenChange}>
-      <PopoverTrigger render={(props) => <div {...props} style={{ display: "contents" }}>{children}</div>} />
+      <PopoverTrigger nativeButton={false} render={(props) => <div {...props} style={{ display: "contents" }}>{children}</div>} />
 
       <PopoverContent
         side="top"

--- a/src/components/game/PauseOverlay.tsx
+++ b/src/components/game/PauseOverlay.tsx
@@ -45,7 +45,7 @@ const PauseOverlay = () => {
       className={
         "fixed inset-0 z-[var(--z-modal-overlay)] " +
         "flex flex-col items-center justify-center " +
-        "bg-background/80 backdrop-blur-sm " +
+        "bg-background/80 backdrop-blur " +
         "animate-in fade-in duration-[var(--duration-slow)]"
       }
       role="dialog"

--- a/src/components/game/PauseOverlay.tsx
+++ b/src/components/game/PauseOverlay.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { useCallback } from "react";
+import { useRouter } from "next/navigation";
+import { Pause, Play, Home } from "lucide-react";
+import { useGameStore } from "@/stores/game-store";
+import { Button } from "@/components/ui/button";
+
+// ────────────────────────────────────────
+// PauseOverlay 컴포넌트
+// ────────────────────────────────────────
+
+/**
+ * 일시정지 오버레이
+ *
+ * isPaused === true일 때 게임 화면 위에 표시.
+ * Board는 blur(12px) 처리 (Board 자체에서 담당).
+ *
+ * - 배경: background/80% + backdrop-blur 8px
+ * - "계속하기" (Primary) + "홈으로" (Ghost)
+ * - fade-in 300ms 애니메이션
+ *
+ * @see docs/design/game.md §6 일시정지 오버레이
+ */
+const PauseOverlay = () => {
+  const router = useRouter();
+
+  const isPaused = useGameStore((s) => s.isPaused);
+  const isComplete = useGameStore((s) => s.isComplete);
+  const resume = useGameStore((s) => s.resume);
+
+  const handleResume = useCallback(() => {
+    resume();
+  }, [resume]);
+
+  const handleGoHome = useCallback(() => {
+    router.push("/");
+  }, [router]);
+
+  // 일시정지 상태가 아니거나 완료 상태면 표시 안 함
+  if (!isPaused || isComplete) return null;
+
+  return (
+    <div
+      className={
+        "fixed inset-0 z-[var(--z-modal-overlay)] " +
+        "flex flex-col items-center justify-center " +
+        "bg-background/80 backdrop-blur-sm " +
+        "animate-in fade-in duration-[var(--duration-slow)]"
+      }
+      role="dialog"
+      aria-label="일시정지"
+      aria-modal="true"
+    >
+      {/* 아이콘 + 제목 */}
+      <Pause
+        size={48}
+        strokeWidth={1.5}
+        className="text-muted-foreground mb-4"
+        aria-hidden="true"
+      />
+      <h2 className="text-(length:--text-heading) font-semibold text-foreground mb-8">
+        일시정지
+      </h2>
+
+      {/* 액션 버튼 */}
+      <div className="flex flex-col gap-3 w-full max-w-[200px]">
+        <Button
+          variant="default"
+          className="h-12 w-full gap-2 text-base bg-sudoku-primary hover:bg-sudoku-primary/90"
+          onClick={handleResume}
+        >
+          <Play size={20} />
+          계속하기
+        </Button>
+        <Button
+          variant="ghost"
+          className="h-12 w-full gap-2 text-base"
+          onClick={handleGoHome}
+        >
+          <Home size={20} />
+          홈으로
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default PauseOverlay;

--- a/src/components/game/Toolbar.tsx
+++ b/src/components/game/Toolbar.tsx
@@ -1,0 +1,146 @@
+"use client";
+
+import { memo, useCallback, useMemo } from "react";
+import { Undo2, Eraser, PenLine, Lightbulb } from "lucide-react";
+import { useGameStore } from "@/stores/game-store";
+
+// ────────────────────────────────────────
+// ToolButton 서브 컴포넌트
+// ────────────────────────────────────────
+
+interface ToolButtonProps {
+  icon: React.ReactNode;
+  label: string;
+  /** 활성 상태 (메모 ON 등) */
+  active?: boolean;
+  disabled?: boolean;
+  onClick: () => void;
+}
+
+/**
+ * 도구바 개별 버튼
+ *
+ * - 기본: transparent 배경, muted-foreground 텍스트
+ * - 활성: sudoku-primary 색상 + 10% 배경
+ * - 비활성: opacity 0.4
+ *
+ * @see docs/design/game.md §4.2
+ */
+const ToolButton = memo(
+  ({ icon, label, active = false, disabled = false, onClick }: ToolButtonProps) => (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={label}
+      aria-pressed={active ? "true" : undefined}
+      className={
+        "flex flex-1 flex-col items-center justify-center gap-0.5 " +
+        "h-12 rounded-[var(--radius-md)] " +
+        "transition-colors duration-[var(--duration-fast)] " +
+        (disabled
+          ? "opacity-40 pointer-events-none text-muted-foreground "
+          : active
+            ? "bg-sudoku-primary/10 text-sudoku-primary "
+            : "text-muted-foreground hover:bg-accent ")
+      }
+    >
+      {icon}
+      <span className="text-[11px] font-normal leading-none">{label}</span>
+    </button>
+  ),
+);
+ToolButton.displayName = "ToolButton";
+
+// ────────────────────────────────────────
+// Toolbar 컴포넌트
+// ────────────────────────────────────────
+
+interface ToolbarProps {
+  className?: string;
+}
+
+/**
+ * 게임 도구바
+ *
+ * 되돌리기 | 지우기 | 메모 | 힌트(N)
+ *
+ * - flex 4등분, gap 8px, 48px 높이
+ * - 아이콘 20px, 라벨 11px
+ *
+ * @see docs/design/game.md §4 도구바
+ */
+const Toolbar = ({ className = "" }: ToolbarProps) => {
+  const selectedCell = useGameStore((s) => s.selectedCell);
+  const board = useGameStore((s) => s.board);
+  const isNoteMode = useGameStore((s) => s.isNoteMode);
+  const isComplete = useGameStore((s) => s.isComplete);
+  const isPaused = useGameStore((s) => s.isPaused);
+  const history = useGameStore((s) => s.history);
+  const undo = useGameStore((s) => s.undo);
+  const clearValue = useGameStore((s) => s.clearValue);
+  const toggleNoteMode = useGameStore((s) => s.toggleNoteMode);
+
+  // ── 되돌리기 가능 여부 ──
+  const canUndo = history.length > 0 && !isComplete && !isPaused;
+
+  // ── 지우기 가능 여부 ──
+  const canErase = useMemo(() => {
+    if (!selectedCell || isComplete || isPaused) return false;
+    const cell = board[selectedCell.row]?.[selectedCell.col];
+    return !!cell && !cell.isGiven && !cell.isLocked && cell.value !== null;
+  }, [selectedCell, board, isComplete, isPaused]);
+
+  // ── 핸들러 ──
+  const handleUndo = useCallback(() => {
+    undo();
+  }, [undo]);
+
+  const handleErase = useCallback(() => {
+    if (!selectedCell) return;
+    clearValue(selectedCell.row, selectedCell.col);
+  }, [selectedCell, clearValue]);
+
+  const handleToggleMemo = useCallback(() => {
+    toggleNoteMode();
+  }, [toggleNoteMode]);
+
+  // 보드가 비어있으면 렌더링하지 않음
+  if (board.length === 0) return null;
+
+  return (
+    <div
+      className={`flex gap-2 w-full ${className}`}
+      role="toolbar"
+      aria-label="게임 도구"
+    >
+      <ToolButton
+        icon={<Undo2 size={20} />}
+        label="되돌리기"
+        disabled={!canUndo}
+        onClick={handleUndo}
+      />
+      <ToolButton
+        icon={<Eraser size={20} />}
+        label="지우기"
+        disabled={!canErase}
+        onClick={handleErase}
+      />
+      <ToolButton
+        icon={<PenLine size={20} />}
+        label="메모"
+        active={isNoteMode}
+        disabled={isComplete || isPaused}
+        onClick={handleToggleMemo}
+      />
+      <ToolButton
+        icon={<Lightbulb size={20} />}
+        label="힌트(3)"
+        disabled={true} // TODO: 힌트 시스템 구현 후 활성화
+        onClick={() => {}} // TODO: 힌트 액션 연결
+      />
+    </div>
+  );
+};
+
+export default Toolbar;

--- a/src/components/game/index.ts
+++ b/src/components/game/index.ts
@@ -3,5 +3,7 @@ export { default as Cell } from "./Cell";
 export { default as GameHeader } from "./GameHeader";
 export { default as LockedCellPopover } from "./LockedCellPopover";
 export { default as NumberPad } from "./NumberPad";
+export { default as PauseOverlay } from "./PauseOverlay";
 export { default as Timer } from "./Timer";
+export { default as Toolbar } from "./Toolbar";
 export { formatTime } from "./Timer";


### PR DESCRIPTION
## Summary
- 게임 플레이 페이지 `/game?stage=N` 구현
- 기존 컴포넌트(Board, NumberPad, GameHeader, Timer) 통합
- 새 컴포넌트: Toolbar (도구바), PauseOverlay (일시정지)
- Zustand persist 하이드레이션 대기 + Skeleton UI

## 구현 목록
- [x] `src/app/game/page.tsx` — 서버 컴포넌트, Suspense 래핑
- [x] `src/app/game/GameContent.tsx` — 클라이언트 컴포넌트
  - Zustand persist 하이드레이션 감지 (useSyncExternalStore)
  - URL stage 파라미터 기반 게임 초기화 흐름
  - Skeleton UI (하이드레이션/초기화 대기 중)
  - Board + Toolbar + NumberPad + PauseOverlay 통합 레이아웃
- [x] `src/components/game/Toolbar.tsx` — 게임 도구바
  - 되돌리기 (Undo2): 히스토리 비어있으면 비활성
  - 지우기 (Eraser): 선택 셀이 빈 셀/given/locked이면 비활성
  - 메모 (PenLine): 토글, 활성 시 sudoku-primary 색상
  - 힌트 (Lightbulb): TODO — 힌트 시스템 구현 후 활성화
  - memo 최적화된 ToolButton 서브 컴포넌트
- [x] `src/components/game/PauseOverlay.tsx` — 일시정지 오버레이
  - 배경: background/80% + backdrop-blur
  - "계속하기" (Primary) + "홈으로" (Ghost) 버튼
  - fade-in 애니메이션
  - shadcn/ui Button 컴포넌트 사용
- [x] `src/components/game/index.ts` — barrel export 업데이트

## 디자인 명세 대조
| 항목 | 명세 (game.md) | 구현 |
|------|---------------|------|
| 도구바 레이아웃 | flex 4등분, gap 8px | `flex gap-2, flex-1` |
| 도구 버튼 높이 | 48px | `h-12` |
| 도구 아이콘 | 20px | `size={20}` |
| 도구 라벨 | 11px, weight 400 | `text-[11px] font-normal` |
| 메모 활성 | sudoku-primary + 10% bg | `bg-sudoku-primary/10 text-sudoku-primary` |
| 비활성 | opacity 0.4 | `opacity-40 pointer-events-none` |
| 오버레이 배경 | background/80%, blur 8px | `bg-background/80 backdrop-blur-sm` |
| 오버레이 z-index | 60 | `z-[var(--z-modal-overlay)]` |
| 일시정지 아이콘 | 48px | `size={48}` |
| 계속하기 버튼 | Primary, 48px, max-w 200px | `h-12 max-w-[200px]` |

## 게임 초기화 흐름
```
1. 하이드레이션 대기 (Skeleton)
2. persist 복원 완료
3. URL stage와 스토어 비교
   ├─ 일치 → 게임 계속
   ├─ 불일치 + 유효 stage → initGame(stage)
   └─ 유효하지 않음 → 홈 리다이렉트
```

## Known Issues / TODO
- 힌트 시스템 미구현 (힌트 버튼 항상 비활성)
- ~~ContinueBanner 뒤로가기 배너 유지~~ — /game 라우트 생성으로 자연 해결됨

## Test plan
- [x] TypeScript 타입 체크 통과
- [x] ESLint 통과
- [x] Next.js 빌드 성공 (`/game` 라우트 생성 확인)
- [x] 수동 확인: 홈 → 난이도 클릭 → /game 이동 + 보드 렌더링
- [x] 수동 확인: 숫자패드 입력 → 셀 값 변경
- [x] 수동 확인: 도구바 — 되돌리기, 지우기, 메모 토글
- [x] 수동 확인: 일시정지 → 오버레이 표시, 보드 블러
- [x] 수동 확인: 계속하기 → 오버레이 닫힘, 타이머 재개
- [x] 수동 확인: 홈으로 → / 이동

Closes 일부 #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)