### PR TITLE
[Frontend] refactor/store-slices — game-store 슬라이스 패턴 분리

### DIFF
--- a/src/stores/game-store.ts
+++ b/src/stores/game-store.ts
@@ -1,501 +1,50 @@
 /**
  * 스도쿠 게임 상태 관리 (Zustand Store)
  *
- * @description
- * 1. 스테이지 기반 퍼즐 생성 및 초기화
- * 2. 셀 값 입력/삭제, 메모(후보 숫자) 토글
- * 3. 실시간 충돌 검증 (행/열/박스)
- * 4. 잠금 칸 조건 충족 시 자동 해제 (연쇄 포함)
- * 5. Undo (최대 50단계)
- * 6. 타이머 (초 단위)
- * 7. localStorage 자동 저장/복원 (persist)
+ * 슬라이스 패턴으로 관심사를 분리한다:
+ * - GameCoreSlice: 보드, 퍼즐, 히스토리, 게임 라이프사이클
+ * - TimerSlice: 경과 시간, 일시정지
+ * - UISlice: 셀 선택, 메모 모드, 힌트 사용 횟수
  *
  * @see GitHub Issue #3 — Epic: 스도쿠 엔진 개발
+ * @see GitHub Issue #5 — Epic: 게임 UI 개발
  */
 
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
-import type {
-  Board,
-  Cell,
-  Digit,
-  SolutionGrid,
-  Position,
-  LockedCell,
-  StageConfig,
-} from '@/types/game';
-import { generatePuzzle } from '@/lib/sudoku/difficulty';
-import { findUnlockableCellsWithChain } from '@/lib/sudoku/lockSystem';
+import { createGameCoreSlice } from './slices/game-core-slice';
+import { createTimerSlice } from './slices/timer-slice';
+import { createUISlice } from './slices/ui-slice';
 import {
-  updateBoardErrors,
-  isGameComplete,
-  boardToGrid,
-  cloneBoard,
-  createBoardFromPuzzle,
-} from '@/lib/sudoku/validator';
-import { posKey } from '@/lib/sudoku/utils';
+  serializeCell,
+  deserializeCell,
+  serializeBoard,
+  deserializeBoard,
+  serializeHistory,
+  deserializeHistory,
+} from './helpers/serialization';
+import type { GameStore, PersistedState } from './types';
 
-// ─── 상수 ────────────────────────────────────────────
+// ─── Re-exports (하위 호환: 테스트에서 기존 경로로 import) ──
 
-/** Undo 히스토리 최대 크기 */
-const MAX_HISTORY = 50;
-
-// ─── 히스토리 엔트리 ────────────────────────────────
-
-/** Undo용 스냅샷 */
-interface HistoryEntry {
-  board: Board;
-  lockedCells: LockedCell[];
-}
-
-// ─── 직렬화 타입 ────────────────────────────────────
-
-/** JSON 직렬화 가능한 Cell (notes: Digit[]) */
-interface SerializedCell {
-  value: Digit | null;
-  isGiven: boolean;
-  notes: Digit[];
-  isError: boolean;
-  isLocked: boolean;
-}
-
-// ─── 스토어 타입 ─────────────────────────────────────
-
-/** 게임 스토어 상태 */
-interface GameStoreState {
-  // ── 게임 데이터 ──
-  /** 현재 보드 */
-  board: Board;
-  /** 정답 (게임 시작 전에는 null) */
-  solution: SolutionGrid | null;
-  /** 현재 스테이지 */
-  stage: number;
-  /** 스테이지 설정 */
-  config: StageConfig | null;
-  /** 남은 잠금 칸 목록 (게임 진행 중 해제되면 줄어듦) */
-  lockedCells: LockedCell[];
-  /** 최초 잠금 칸 목록 (reset 시 복원용, 게임 중 변경되지 않음) */
-  initialLockedCells: LockedCell[];
-
-  // ── UI 상태 ──
-  /** 선택된 셀 */
-  selectedCell: Position | null;
-  /** 메모 모드 */
-  isNoteMode: boolean;
-
-  // ── 타이머 ──
-  /** 경과 시간 (초) */
-  timer: number;
-  /** 일시정지 여부 */
-  isPaused: boolean;
-
-  // ── 히스토리 ──
-  /** Undo 스택 */
-  history: HistoryEntry[];
-
-  // ── 게임 상태 ──
-  /** 게임 시작 여부 */
-  isStarted: boolean;
-  /** 게임 완료 여부 */
-  isComplete: boolean;
-}
-
-/** 게임 스토어 액션 */
-interface GameStoreActions {
-  // ── 게임 라이프사이클 ──
-  /** 스테이지로 새 게임 시작 */
-  initGame: (stage: number) => void;
-  /** 현재 퍼즐을 초기 상태로 리셋 */
-  reset: () => void;
-
-  // ── 셀 액션 ──
-  /** 셀에 숫자 입력 */
-  setValue: (row: number, col: number, digit: Digit) => void;
-  /** 셀 값 삭제 */
-  clearValue: (row: number, col: number) => void;
-  /** 메모 숫자 토글 */
-  toggleNote: (row: number, col: number, digit: Digit) => void;
-
-  // ── Undo ──
-  /** 마지막 동작 되돌리기 */
-  undo: () => void;
-
-  // ── 타이머 ──
-  /** 1초 증가 */
-  tick: () => void;
-  /** 일시정지 */
-  pause: () => void;
-  /** 재개 */
-  resume: () => void;
-
-  // ── 선택 ──
-  /** 셀 선택 */
-  selectCell: (position: Position | null) => void;
-  /** 메모 모드 토글 */
-  toggleNoteMode: () => void;
-}
-
-export type GameStore = GameStoreState & GameStoreActions;
-
-// ─── 초기 상태 ──────────────────────────────────────
-
-const EMPTY_BOARD: Board = [];
-
-const initialState: GameStoreState = {
-  board: EMPTY_BOARD,
-  solution: null,
-  stage: 0,
-  config: null,
-  lockedCells: [],
-  initialLockedCells: [],
-  selectedCell: null,
-  isNoteMode: false,
-  timer: 0,
-  isPaused: false,
-  history: [],
-  isStarted: false,
-  isComplete: false,
+export type { GameStore } from './types';
+export {
+  serializeCell,
+  deserializeCell,
+  serializeBoard,
+  deserializeBoard,
+  serializeHistory,
+  deserializeHistory,
 };
-
-// ─── 내부 헬퍼 ──────────────────────────────────────
-
-/**
- * 히스토리에 현재 상태를 스냅샷으로 저장한다.
- * MAX_HISTORY를 초과하면 가장 오래된 항목을 제거.
- */
-const pushHistory = (
-  history: HistoryEntry[],
-  board: Board,
-  lockedCells: LockedCell[],
-): HistoryEntry[] => {
-  const entry: HistoryEntry = {
-    board: cloneBoard(board),
-    lockedCells: lockedCells.map((lc) => ({ ...lc, conditions: [...lc.conditions] })),
-  };
-  const newHistory = [...history, entry];
-  if (newHistory.length > MAX_HISTORY) {
-    return newHistory.slice(newHistory.length - MAX_HISTORY);
-  }
-  return newHistory;
-};
-
-/**
- * 잠금 해제를 수행한다.
- * 현재 보드 상태를 Grid로 변환 → findUnlockableCellsWithChain → 보드 갱신.
- */
-const processUnlocks = (
-  board: Board,
-  lockedCells: LockedCell[],
-): { board: Board; lockedCells: LockedCell[] } => {
-  if (lockedCells.length === 0) return { board, lockedCells };
-
-  const grid = boardToGrid(board);
-  const unlockable = findUnlockableCellsWithChain(grid, lockedCells);
-
-  if (unlockable.length === 0) return { board, lockedCells };
-
-  // 해제 가능한 셀 키 Set
-  const unlockKeys = new Set(
-    unlockable.map((lc) => posKey(lc.position.row, lc.position.col)),
-  );
-
-  // 보드에서 isLocked 해제 — 변경 대상 셀만 새 객체 생성
-  const newBoard = board.map((row, r) =>
-    row.map((cell, c): Cell => {
-      if (unlockKeys.has(posKey(r, c))) {
-        return { ...cell, notes: new Set(cell.notes), isLocked: false };
-      }
-      return cell;
-    }),
-  );
-
-  // lockedCells에서 해제된 셀 제거
-  const newLockedCells = lockedCells.filter(
-    (lc) => !unlockKeys.has(posKey(lc.position.row, lc.position.col)),
-  );
-
-  return { board: newBoard, lockedCells: newLockedCells };
-};
-
-// ─── Board 직렬화 (persist용) ───────────────────────
-
-/** @internal 테스트 전용 — 외부에서 직접 사용 금지 */
-export const serializeCell = (cell: Cell): SerializedCell => ({
-  value: cell.value,
-  isGiven: cell.isGiven,
-  notes: Array.from(cell.notes),
-  isError: cell.isError,
-  isLocked: cell.isLocked,
-});
-
-/** @internal 테스트 전용 — 외부에서 직접 사용 금지 */
-export const deserializeCell = (data: SerializedCell): Cell => ({
-  ...data,
-  notes: new Set(data.notes),
-});
-
-/** @internal 테스트 전용 — 외부에서 직접 사용 금지 */
-export const serializeBoard = (board: Board): SerializedCell[][] =>
-  board.map((row) => row.map(serializeCell));
-
-/** @internal 테스트 전용 — 외부에서 직접 사용 금지 */
-export const deserializeBoard = (data: SerializedCell[][]): Board =>
-  data.map((row) => row.map(deserializeCell));
-
-/** @internal 테스트 전용 — 외부에서 직접 사용 금지 */
-export const serializeHistory = (history: HistoryEntry[]): { board: SerializedCell[][]; lockedCells: LockedCell[] }[] =>
-  history.map((entry) => ({
-    board: serializeBoard(entry.board),
-    lockedCells: entry.lockedCells,
-  }));
-
-/** @internal 테스트 전용 — 외부에서 직접 사용 금지 */
-export const deserializeHistory = (data: { board: SerializedCell[][]; lockedCells: LockedCell[] }[]): HistoryEntry[] =>
-  data.map((entry) => ({
-    board: deserializeBoard(entry.board),
-    lockedCells: entry.lockedCells,
-  }));
-
-// ─── persist 직렬화 타입 ────────────────────────────
-
-interface PersistedState {
-  board: SerializedCell[][];
-  solution: SolutionGrid | null;
-  stage: number;
-  config: StageConfig | null;
-  lockedCells: LockedCell[];
-  initialLockedCells: LockedCell[];
-  timer: number;
-  history: { board: SerializedCell[][]; lockedCells: LockedCell[] }[];
-  isStarted: boolean;
-  isComplete: boolean;
-}
 
 // ─── 스토어 생성 ────────────────────────────────────
 
 export const useGameStore = create<GameStore>()(
   persist(
-    (set, get) => ({
-      ...initialState,
-
-      // ── initGame ──
-      initGame: (stage: number) => {
-        const result = generatePuzzle(stage);
-        const board = createBoardFromPuzzle(result.puzzle, result.lockedCells);
-
-        set({
-          board,
-          solution: result.solution,
-          stage,
-          config: result.config,
-          lockedCells: result.lockedCells,
-          initialLockedCells: result.lockedCells,
-          selectedCell: null,
-          isNoteMode: false,
-          timer: 0,
-          isPaused: false,
-          history: [],
-          isStarted: true,
-          isComplete: false,
-        });
-      },
-
-      // ── reset ──
-      reset: () => {
-        const { stage, config, board: currentBoard, initialLockedCells } = get();
-        if (!config || stage === 0) return;
-
-        // initialLockedCells에서 잠금 위치 키 Set 생성
-        const lockedKeys = new Set(
-          initialLockedCells.map((lc) => posKey(lc.position.row, lc.position.col)),
-        );
-
-        // given 셀 유지, 나머지 초기화, 잠금은 최초 목록 기준으로 복원
-        const resetBoard: Board = currentBoard.map((row, r) =>
-          row.map((cell, c): Cell => {
-            if (cell.isGiven) {
-              return { ...cell, notes: new Set(), isError: false };
-            }
-            return {
-              value: null,
-              isGiven: false,
-              notes: new Set(),
-              isError: false,
-              isLocked: lockedKeys.has(posKey(r, c)),
-            };
-          }),
-        );
-
-        // given 셀만으로 이미 충족되는 잠금 조건을 재검사
-        const unlockResult = processUnlocks(resetBoard, initialLockedCells);
-
-        set({
-          board: unlockResult.board,
-          lockedCells: unlockResult.lockedCells,
-          selectedCell: null,
-          isNoteMode: false,
-          timer: 0,
-          isPaused: false,
-          history: [],
-          isComplete: false,
-        });
-      },
-
-      // ── setValue ──
-      setValue: (row: number, col: number, digit: Digit) => {
-        const { board, solution, lockedCells, history, isComplete } = get();
-        if (isComplete || !solution) return;
-
-        const cell = board[row]?.[col];
-        if (!cell || cell.isGiven || cell.isLocked) return;
-
-        // 히스토리 저장
-        const newHistory = pushHistory(history, board, lockedCells);
-
-        // 셀 값 설정 + 메모 초기화 — 변경 대상 셀만 새 객체 생성
-        const newBoard = board.map((r, ri) =>
-          r.map((c, ci): Cell => {
-            if (ri === row && ci === col) {
-              return {
-                ...c,
-                value: digit,
-                notes: new Set<Digit>(),
-                isError: false,
-              };
-            }
-            return c;
-          }),
-        );
-
-        // 충돌 검증
-        const validatedBoard = updateBoardErrors(newBoard);
-
-        // 잠금 해제 검사
-        const unlockResult = processUnlocks(validatedBoard, lockedCells);
-
-        // 완료 검사
-        const complete = isGameComplete(unlockResult.board, solution);
-
-        set({
-          board: unlockResult.board,
-          lockedCells: unlockResult.lockedCells,
-          history: newHistory,
-          isComplete: complete,
-          isPaused: complete ? true : get().isPaused,
-        });
-      },
-
-      // ── clearValue ──
-      clearValue: (row: number, col: number) => {
-        const { board, lockedCells, history, isComplete } = get();
-        if (isComplete) return;
-
-        const cell = board[row]?.[col];
-        if (!cell || cell.isGiven || cell.isLocked || cell.value === null) return;
-
-        // 히스토리 저장
-        const newHistory = pushHistory(history, board, lockedCells);
-
-        // 셀 값 삭제 — 변경 대상 셀만 새 객체 생성
-        const newBoard = board.map((r, ri) =>
-          r.map((c, ci): Cell => {
-            if (ri === row && ci === col) {
-              return { ...c, value: null, notes: new Set<Digit>(), isError: false };
-            }
-            return c;
-          }),
-        );
-
-        // 충돌 검증 (다른 셀의 에러가 해소될 수 있음)
-        const validatedBoard = updateBoardErrors(newBoard);
-
-        // 잠금은 단방향(해제만 가능) — clearValue로 조건이 미충족되어도 재잠금하지 않음
-        set({
-          board: validatedBoard,
-          history: newHistory,
-          isComplete: false,
-        });
-      },
-
-      // ── toggleNote ──
-      toggleNote: (row: number, col: number, digit: Digit) => {
-        const { board, lockedCells, history, isComplete } = get();
-        if (isComplete) return;
-
-        const cell = board[row]?.[col];
-        if (!cell || cell.isGiven || cell.isLocked || cell.value !== null) return;
-
-        // 히스토리 저장
-        const newHistory = pushHistory(history, board, lockedCells);
-
-        // 메모 토글 — 변경 대상 셀만 새 객체 생성
-        const newBoard = board.map((r, ri) =>
-          r.map((c, ci): Cell => {
-            if (ri === row && ci === col) {
-              const newNotes = new Set(c.notes);
-              if (newNotes.has(digit)) {
-                newNotes.delete(digit);
-              } else {
-                newNotes.add(digit);
-              }
-              return { ...c, notes: newNotes };
-            }
-            return c;
-          }),
-        );
-
-        set({
-          board: newBoard,
-          history: newHistory,
-        });
-      },
-
-      // ── undo ──
-      undo: () => {
-        const { history, isComplete } = get();
-        if (isComplete || history.length === 0) return;
-
-        const newHistory = [...history];
-        const lastEntry = newHistory.pop()!;
-
-        // 복원된 보드에서 잠금 해제 조건 재검사
-        const unlockResult = processUnlocks(lastEntry.board, lastEntry.lockedCells);
-
-        set({
-          board: unlockResult.board,
-          lockedCells: unlockResult.lockedCells,
-          history: newHistory,
-        });
-      },
-
-      // ── tick ──
-      tick: () => {
-        const { isPaused, isComplete, isStarted } = get();
-        if (isPaused || isComplete || !isStarted) return;
-        set((state) => ({ timer: state.timer + 1 }));
-      },
-
-      // ── pause ──
-      pause: () => {
-        set({ isPaused: true });
-      },
-
-      // ── resume ──
-      resume: () => {
-        const { isComplete } = get();
-        if (isComplete) return;
-        set({ isPaused: false });
-      },
-
-      // ── selectCell ──
-      selectCell: (position: Position | null) => {
-        set({ selectedCell: position });
-      },
-
-      // ── toggleNoteMode ──
-      toggleNoteMode: () => {
-        set((state) => ({ isNoteMode: !state.isNoteMode }));
-      },
+    (...a) => ({
+      ...createGameCoreSlice(...a),
+      ...createTimerSlice(...a),
+      ...createUISlice(...a),
     }),
     {
       name: 'sudoku-game',
@@ -510,6 +59,7 @@ export const useGameStore = create<GameStore>()(
         lockedCells: state.lockedCells,
         initialLockedCells: state.initialLockedCells,
         timer: state.timer,
+        hintsUsed: state.hintsUsed,
         history: serializeHistory(state.history),
         isStarted: state.isStarted,
         isComplete: state.isComplete,
@@ -531,6 +81,7 @@ export const useGameStore = create<GameStore>()(
           lockedCells: data.lockedCells,
           initialLockedCells: data.initialLockedCells || data.lockedCells,
           timer: data.timer,
+          hintsUsed: data.hintsUsed ?? 0,
           history: deserializeHistory(data.history || []),
           isStarted: data.isStarted,
           isComplete: data.isComplete,

--- a/src/stores/helpers/serialization.ts
+++ b/src/stores/helpers/serialization.ts
@@ -1,0 +1,52 @@
+/**
+ * 게임 스토어 직렬화/역직렬화 헬퍼
+ *
+ * Zustand persist에서 Board(Set 포함)를 JSON으로 변환하기 위해 사용.
+ * Set<Digit> <-> Digit[] 변환이 핵심.
+ *
+ * @internal persist 내부 및 테스트 전용
+ */
+
+import type { Board, Cell, LockedCell } from '@/types/game';
+import type { SerializedCell, HistoryEntry } from '../types';
+
+/** Cell -> SerializedCell (Set -> Array) */
+export const serializeCell = (cell: Cell): SerializedCell => ({
+  value: cell.value,
+  isGiven: cell.isGiven,
+  notes: Array.from(cell.notes),
+  isError: cell.isError,
+  isLocked: cell.isLocked,
+});
+
+/** SerializedCell -> Cell (Array -> Set) */
+export const deserializeCell = (data: SerializedCell): Cell => ({
+  ...data,
+  notes: new Set(data.notes),
+});
+
+/** Board -> SerializedCell[][] */
+export const serializeBoard = (board: Board): SerializedCell[][] =>
+  board.map((row) => row.map(serializeCell));
+
+/** SerializedCell[][] -> Board */
+export const deserializeBoard = (data: SerializedCell[][]): Board =>
+  data.map((row) => row.map(deserializeCell));
+
+/** HistoryEntry[] -> 직렬화된 히스토리 */
+export const serializeHistory = (
+  history: HistoryEntry[],
+): { board: SerializedCell[][]; lockedCells: LockedCell[] }[] =>
+  history.map((entry) => ({
+    board: serializeBoard(entry.board),
+    lockedCells: entry.lockedCells,
+  }));
+
+/** 직렬화된 히스토리 -> HistoryEntry[] */
+export const deserializeHistory = (
+  data: { board: SerializedCell[][]; lockedCells: LockedCell[] }[],
+): HistoryEntry[] =>
+  data.map((entry) => ({
+    board: deserializeBoard(entry.board),
+    lockedCells: entry.lockedCells,
+  }));

--- a/src/stores/slices/game-core-slice.ts
+++ b/src/stores/slices/game-core-slice.ts
@@ -1,0 +1,300 @@
+/**
+ * 게임 코어 슬라이스 -- 보드, 퍼즐, 히스토리, 게임 라이프사이클
+ *
+ * setValue, clearValue, toggleNote, undo 등 핵심 게임 액션을 포함한다.
+ * 이 액션들은 board, lockedCells, history를 원자적으로 수정하므로
+ * 하나의 슬라이스에 응집시킨다.
+ *
+ * initGame/reset은 타이머·UI 슬라이스 상태도 함께 초기화한다
+ * (Zustand slice 패턴에서 set()은 전체 스토어에 접근 가능).
+ */
+
+import type { Board, Cell, Digit, LockedCell } from '@/types/game';
+import type { SliceCreator, GameCoreSlice, HistoryEntry } from '../types';
+import { generatePuzzle } from '@/lib/sudoku/difficulty';
+import { findUnlockableCellsWithChain } from '@/lib/sudoku/lockSystem';
+import {
+  updateBoardErrors,
+  isGameComplete,
+  boardToGrid,
+  cloneBoard,
+  createBoardFromPuzzle,
+} from '@/lib/sudoku/validator';
+import { posKey } from '@/lib/sudoku/utils';
+
+// ─── 상수 ────────────────────────────────────────────
+
+/** Undo 히스토리 최대 크기 */
+const MAX_HISTORY = 50;
+
+// ─── 내부 헬퍼 ──────────────────────────────────────
+
+/**
+ * 히스토리에 현재 상태를 스냅샷으로 저장한다.
+ * MAX_HISTORY를 초과하면 가장 오래된 항목을 제거.
+ */
+const pushHistory = (
+  history: HistoryEntry[],
+  board: Board,
+  lockedCells: LockedCell[],
+): HistoryEntry[] => {
+  const entry: HistoryEntry = {
+    board: cloneBoard(board),
+    lockedCells: lockedCells.map((lc) => ({ ...lc, conditions: [...lc.conditions] })),
+  };
+  const newHistory = [...history, entry];
+  if (newHistory.length > MAX_HISTORY) {
+    return newHistory.slice(newHistory.length - MAX_HISTORY);
+  }
+  return newHistory;
+};
+
+/**
+ * 잠금 해제를 수행한다.
+ * 현재 보드 상태를 Grid로 변환 -> findUnlockableCellsWithChain -> 보드 갱신.
+ */
+const processUnlocks = (
+  board: Board,
+  lockedCells: LockedCell[],
+): { board: Board; lockedCells: LockedCell[] } => {
+  if (lockedCells.length === 0) return { board, lockedCells };
+
+  const grid = boardToGrid(board);
+  const unlockable = findUnlockableCellsWithChain(grid, lockedCells);
+
+  if (unlockable.length === 0) return { board, lockedCells };
+
+  // 해제 가능한 셀 키 Set
+  const unlockKeys = new Set(
+    unlockable.map((lc) => posKey(lc.position.row, lc.position.col)),
+  );
+
+  // 보드에서 isLocked 해제 -- 변경 대상 셀만 새 객체 생성
+  const newBoard = board.map((row, r) =>
+    row.map((cell, c): Cell => {
+      if (unlockKeys.has(posKey(r, c))) {
+        return { ...cell, notes: new Set(cell.notes), isLocked: false };
+      }
+      return cell;
+    }),
+  );
+
+  // lockedCells에서 해제된 셀 제거
+  const newLockedCells = lockedCells.filter(
+    (lc) => !unlockKeys.has(posKey(lc.position.row, lc.position.col)),
+  );
+
+  return { board: newBoard, lockedCells: newLockedCells };
+};
+
+// ─── 슬라이스 생성 ───────────────────────────────────
+
+export const createGameCoreSlice: SliceCreator<GameCoreSlice> = (set, get) => ({
+  board: [],
+  solution: null,
+  stage: 0,
+  config: null,
+  lockedCells: [],
+  initialLockedCells: [],
+  history: [],
+  isStarted: false,
+  isComplete: false,
+
+  // ── initGame ──
+  initGame: (stage: number) => {
+    const result = generatePuzzle(stage);
+    const board = createBoardFromPuzzle(result.puzzle, result.lockedCells);
+
+    set({
+      // Game core
+      board,
+      solution: result.solution,
+      stage,
+      config: result.config,
+      lockedCells: result.lockedCells,
+      initialLockedCells: result.lockedCells,
+      history: [],
+      isStarted: true,
+      isComplete: false,
+      // Timer reset
+      timer: 0,
+      isPaused: false,
+      // UI reset
+      selectedCell: null,
+      isNoteMode: false,
+      hintsUsed: 0,
+    });
+  },
+
+  // ── reset ──
+  reset: () => {
+    const { stage, config, board: currentBoard, initialLockedCells } = get();
+    if (!config || stage === 0) return;
+
+    // initialLockedCells에서 잠금 위치 키 Set 생성
+    const lockedKeys = new Set(
+      initialLockedCells.map((lc) => posKey(lc.position.row, lc.position.col)),
+    );
+
+    // given 셀 유지, 나머지 초기화, 잠금은 최초 목록 기준으로 복원
+    const resetBoard: Board = currentBoard.map((row, r) =>
+      row.map((cell, c): Cell => {
+        if (cell.isGiven) {
+          return { ...cell, notes: new Set(), isError: false };
+        }
+        return {
+          value: null,
+          isGiven: false,
+          notes: new Set(),
+          isError: false,
+          isLocked: lockedKeys.has(posKey(r, c)),
+        };
+      }),
+    );
+
+    // given 셀만으로 이미 충족되는 잠금 조건을 재검사
+    const unlockResult = processUnlocks(resetBoard, initialLockedCells);
+
+    set({
+      // Game core
+      board: unlockResult.board,
+      lockedCells: unlockResult.lockedCells,
+      history: [],
+      isComplete: false,
+      // Timer reset
+      timer: 0,
+      isPaused: false,
+      // UI reset
+      selectedCell: null,
+      isNoteMode: false,
+      hintsUsed: 0,
+    });
+  },
+
+  // ── setValue ──
+  setValue: (row: number, col: number, digit: Digit) => {
+    const { board, solution, lockedCells, history, isComplete } = get();
+    if (isComplete || !solution) return;
+
+    const cell = board[row]?.[col];
+    if (!cell || cell.isGiven || cell.isLocked) return;
+
+    // 히스토리 저장
+    const newHistory = pushHistory(history, board, lockedCells);
+
+    // 셀 값 설정 + 메모 초기화 -- 변경 대상 셀만 새 객체 생성
+    const newBoard = board.map((r, ri) =>
+      r.map((c, ci): Cell => {
+        if (ri === row && ci === col) {
+          return {
+            ...c,
+            value: digit,
+            notes: new Set<Digit>(),
+            isError: false,
+          };
+        }
+        return c;
+      }),
+    );
+
+    // 충돌 검증
+    const validatedBoard = updateBoardErrors(newBoard);
+
+    // 잠금 해제 검사
+    const unlockResult = processUnlocks(validatedBoard, lockedCells);
+
+    // 완료 검사
+    const complete = isGameComplete(unlockResult.board, solution);
+
+    set({
+      board: unlockResult.board,
+      lockedCells: unlockResult.lockedCells,
+      history: newHistory,
+      isComplete: complete,
+      isPaused: complete ? true : get().isPaused,
+    });
+  },
+
+  // ── clearValue ──
+  clearValue: (row: number, col: number) => {
+    const { board, lockedCells, history, isComplete } = get();
+    if (isComplete) return;
+
+    const cell = board[row]?.[col];
+    if (!cell || cell.isGiven || cell.isLocked || cell.value === null) return;
+
+    // 히스토리 저장
+    const newHistory = pushHistory(history, board, lockedCells);
+
+    // 셀 값 삭제 -- 변경 대상 셀만 새 객체 생성
+    const newBoard = board.map((r, ri) =>
+      r.map((c, ci): Cell => {
+        if (ri === row && ci === col) {
+          return { ...c, value: null, notes: new Set<Digit>(), isError: false };
+        }
+        return c;
+      }),
+    );
+
+    // 충돌 검증 (다른 셀의 에러가 해소될 수 있음)
+    const validatedBoard = updateBoardErrors(newBoard);
+
+    // 잠금은 단방향(해제만 가능) -- clearValue로 조건이 미충족되어도 재잠금하지 않음
+    set({
+      board: validatedBoard,
+      history: newHistory,
+      isComplete: false,
+    });
+  },
+
+  // ── toggleNote ──
+  toggleNote: (row: number, col: number, digit: Digit) => {
+    const { board, lockedCells, history, isComplete } = get();
+    if (isComplete) return;
+
+    const cell = board[row]?.[col];
+    if (!cell || cell.isGiven || cell.isLocked || cell.value !== null) return;
+
+    // 히스토리 저장
+    const newHistory = pushHistory(history, board, lockedCells);
+
+    // 메모 토글 -- 변경 대상 셀만 새 객체 생성
+    const newBoard = board.map((r, ri) =>
+      r.map((c, ci): Cell => {
+        if (ri === row && ci === col) {
+          const newNotes = new Set(c.notes);
+          if (newNotes.has(digit)) {
+            newNotes.delete(digit);
+          } else {
+            newNotes.add(digit);
+          }
+          return { ...c, notes: newNotes };
+        }
+        return c;
+      }),
+    );
+
+    set({
+      board: newBoard,
+      history: newHistory,
+    });
+  },
+
+  // ── undo ──
+  undo: () => {
+    const { history, isComplete } = get();
+    if (isComplete || history.length === 0) return;
+
+    const newHistory = [...history];
+    const lastEntry = newHistory.pop()!;
+
+    // 복원된 보드에서 잠금 해제 조건 재검사
+    const unlockResult = processUnlocks(lastEntry.board, lastEntry.lockedCells);
+
+    set({
+      board: unlockResult.board,
+      lockedCells: unlockResult.lockedCells,
+      history: newHistory,
+    });
+  },
+});

--- a/src/stores/slices/timer-slice.ts
+++ b/src/stores/slices/timer-slice.ts
@@ -1,0 +1,30 @@
+/**
+ * 타이머 슬라이스 -- 경과 시간, 일시정지
+ *
+ * tick은 isPaused/isComplete/isStarted를 게임 코어 슬라이스에서 참조한다.
+ * resume은 isComplete 상태에서 재개를 차단한다.
+ * setValue가 게임 완료 시 isPaused를 true로 설정한다 (크로스 슬라이스 쓰기).
+ */
+
+import type { SliceCreator, TimerSlice } from '../types';
+
+export const createTimerSlice: SliceCreator<TimerSlice> = (set, get) => ({
+  timer: 0,
+  isPaused: false,
+
+  tick: () => {
+    const { isPaused, isComplete, isStarted } = get();
+    if (isPaused || isComplete || !isStarted) return;
+    set((state) => ({ timer: state.timer + 1 }));
+  },
+
+  pause: () => {
+    set({ isPaused: true });
+  },
+
+  resume: () => {
+    const { isComplete } = get();
+    if (isComplete) return;
+    set({ isPaused: false });
+  },
+});

--- a/src/stores/slices/ui-slice.ts
+++ b/src/stores/slices/ui-slice.ts
@@ -1,0 +1,22 @@
+/**
+ * UI 슬라이스 -- 셀 선택, 메모 모드, 힌트 사용 횟수
+ *
+ * 게임 로직과 독립된 순수 UI 상태만 관리한다.
+ * initGame/reset 시 game-core-slice에서 직접 초기화한다.
+ */
+
+import type { SliceCreator, UISlice } from '../types';
+
+export const createUISlice: SliceCreator<UISlice> = (set) => ({
+  selectedCell: null,
+  isNoteMode: false,
+  hintsUsed: 0,
+
+  selectCell: (position) => {
+    set({ selectedCell: position });
+  },
+
+  toggleNoteMode: () => {
+    set((state) => ({ isNoteMode: !state.isNoteMode }));
+  },
+});

--- a/src/stores/types.ts
+++ b/src/stores/types.ts
@@ -1,0 +1,125 @@
+/**
+ * 게임 스토어 타입 정의
+ *
+ * 모든 슬라이스 인터페이스와 공유 타입을 중앙 집중 관리한다.
+ * 순환 의존성 방지를 위해 구현(slices)과 분리.
+ *
+ * @see GitHub Issue #5 — Epic: 게임 UI 개발
+ */
+
+import type { StateCreator } from 'zustand';
+import type {
+  Board,
+  Digit,
+  SolutionGrid,
+  Position,
+  LockedCell,
+  StageConfig,
+} from '@/types/game';
+
+// ─── 공유 타입 ─────────────────────────────────────
+
+/** Undo용 스냅샷 */
+export interface HistoryEntry {
+  board: Board;
+  lockedCells: LockedCell[];
+}
+
+/** JSON 직렬화 가능한 Cell (notes: Digit[]) */
+export interface SerializedCell {
+  value: Digit | null;
+  isGiven: boolean;
+  notes: Digit[];
+  isError: boolean;
+  isLocked: boolean;
+}
+
+/** persist 직렬화 타입 */
+export interface PersistedState {
+  board: SerializedCell[][];
+  solution: SolutionGrid | null;
+  stage: number;
+  config: StageConfig | null;
+  lockedCells: LockedCell[];
+  initialLockedCells: LockedCell[];
+  timer: number;
+  hintsUsed: number;
+  history: { board: SerializedCell[][]; lockedCells: LockedCell[] }[];
+  isStarted: boolean;
+  isComplete: boolean;
+}
+
+// ─── 슬라이스 인터페이스 ──────────────────────────────
+
+/** 게임 코어 슬라이스: 보드, 퍼즐, 히스토리, 게임 라이프사이클 */
+export interface GameCoreSlice {
+  // ── 상태 ──
+  /** 현재 보드 */
+  board: Board;
+  /** 정답 (게임 시작 전에는 null) */
+  solution: SolutionGrid | null;
+  /** 현재 스테이지 */
+  stage: number;
+  /** 스테이지 설정 */
+  config: StageConfig | null;
+  /** 남은 잠금 칸 목록 (게임 진행 중 해제되면 줄어듦) */
+  lockedCells: LockedCell[];
+  /** 최초 잠금 칸 목록 (reset 시 복원용, 게임 중 변경되지 않음) */
+  initialLockedCells: LockedCell[];
+  /** Undo 스택 */
+  history: HistoryEntry[];
+  /** 게임 시작 여부 */
+  isStarted: boolean;
+  /** 게임 완료 여부 */
+  isComplete: boolean;
+
+  // ── 액션 ──
+  /** 스테이지로 새 게임 시작 */
+  initGame: (stage: number) => void;
+  /** 현재 퍼즐을 초기 상태로 리셋 */
+  reset: () => void;
+  /** 셀에 숫자 입력 */
+  setValue: (row: number, col: number, digit: Digit) => void;
+  /** 셀 값 삭제 */
+  clearValue: (row: number, col: number) => void;
+  /** 메모 숫자 토글 */
+  toggleNote: (row: number, col: number, digit: Digit) => void;
+  /** 마지막 동작 되돌리기 */
+  undo: () => void;
+}
+
+/** 타이머 슬라이스 */
+export interface TimerSlice {
+  /** 경과 시간 (초) */
+  timer: number;
+  /** 일시정지 여부 */
+  isPaused: boolean;
+  /** 1초 증가 */
+  tick: () => void;
+  /** 일시정지 */
+  pause: () => void;
+  /** 재개 */
+  resume: () => void;
+}
+
+/** UI 슬라이스: 선택, 메모 모드, 힌트 사용 횟수 */
+export interface UISlice {
+  /** 선택된 셀 */
+  selectedCell: Position | null;
+  /** 메모 모드 */
+  isNoteMode: boolean;
+  /** 사용한 힌트 횟수 */
+  hintsUsed: number;
+  /** 셀 선택 */
+  selectCell: (position: Position | null) => void;
+  /** 메모 모드 토글 */
+  toggleNoteMode: () => void;
+}
+
+// ─── 전체 스토어 타입 ────────────────────────────────
+
+/** 게임 스토어 전체 (슬라이스 합집합) */
+export type GameStore = GameCoreSlice & TimerSlice & UISlice;
+
+/** 슬라이스 생성자 타입 헬퍼 */
+export type SliceCreator<T> = StateCreator<GameStore, [], [], T>;


### PR DESCRIPTION
## Summary
- 542줄 단일 `game-store.ts`를 Zustand 슬라이스 패턴으로 분리
- **GameCoreSlice**: 보드/퍼즐/히스토리/게임 라이프사이클 (setValue, clearValue, toggleNote, undo 등)
- **TimerSlice**: 경과 시간/일시정지 (tick, pause, resume)
- **UISlice**: 셀 선택/메모 모드 + `hintsUsed` 필드 신규 추가
- 직렬화 헬퍼를 `helpers/serialization.ts`로 분리
- 외부 API (`useGameStore`, `serialize*`) 변경 없음 → 기존 컴포넌트 수정 불필요

## 변경 파일 구조
```
src/stores/
├── game-store.ts          ← 진입점 (슬라이스 조합 + persist)
├── types.ts               ← 공유 타입 + SliceCreator 헬퍼
├── slices/
│   ├── game-core-slice.ts ← 보드/퍼즐/히스토리/게임 액션
│   ├── timer-slice.ts     ← 타이머
│   └── ui-slice.ts        ← UI 상태 + hintsUsed
└── helpers/
    └── serialization.ts   ← 직렬화/역직렬화
```

## 왜 필요한가
- `feat/ui-clear-modal` 작업에서 `hintsUsed` 필드가 필요
- 기존 542줄 단일 파일은 유지보수와 협업에 불리
- 슬라이스 분리로 각 관심사를 독립적으로 확장 가능

## Test plan
- [x] TypeScript `tsc --noEmit` 0 에러
- [x] 342개 기존 테스트 전체 통과 (vitest)
- [x] Next.js 빌드 성공
- [x] `useGameStore` 외부 API 동일 → 기존 컴포넌트 영향 없음
- [x] persist 하위 호환 (`hintsUsed ?? 0` 폴백)

Closes 관련: Epic #5 게임 UI 선행 작업

🤖 Generated with [Claude Code](https://claude.com/claude-code)