### PR TITLE
[Frontend] feat/ui-clear-modal — 클리어 결과 모달 구현

### DIFF
--- a/docs/adr/104-clear-modal.md
+++ b/docs/adr/104-clear-modal.md
@@ -1,0 +1,88 @@
+# ADR-104: 클리어 결과 모달 설계
+
+## 상태
+승인됨 (Accepted)
+
+## 날짜
+2026-04-01
+
+## 컨텍스트
+
+퍼즐 완성 시 결과를 보여주는 클리어 모달을 구현해야 한다.
+디자인 명세(`docs/design/clear-modal.md`)가 상세한 레이아웃, 애니메이션 타임라인,
+접근성 요구사항을 정의하고 있다.
+
+### 고려 사항
+1. 기존 `@base-ui/react` Dialog 컴포넌트를 래핑할지, 커스텀 구현할지
+2. ~1.7초에 걸친 스태거(stagger) 애니메이션 제어 방식
+3. 배경 클릭으로 닫히지 않는 강제 확인 UX
+4. 포커스 트랩 + ESC 키 처리
+5. 인증 상태에 따른 랭킹 버튼 분기
+
+### 선택지
+- **A) base-ui Dialog 래핑**: `DialogContent`/`DialogOverlay` 활용
+- **B) 커스텀 fixed 오버레이**: PauseOverlay 패턴과 동일하게 직접 구현
+
+## 결정
+
+**선택지 B — 커스텀 fixed 오버레이**
+
+### 이유
+1. 디자인 명세의 스태거 애니메이션 타임라인(7단계, 각기 다른 딜레이)을 정밀 제어 필요
+2. 배경 클릭 무시(결과 확인 강제)는 Dialog의 기본 닫기 동작과 충돌
+3. 배경색(`oklch(0 0 0 / 0.5)`)과 blur(4px)가 기존 Dialog 오버레이와 다름
+4. PauseOverlay와 동일한 `fixed inset-0` 패턴으로 코드베이스 일관성 유지
+
+## 구현 상세
+
+### 파일 구조
+```
+src/components/game/ClearModal.tsx  — 메인 컴포넌트
+src/app/globals.css                 — 키프레임 추가 (bounce-in, star-scale-in 등)
+src/app/game/GameContent.tsx        — 통합 (PauseOverlay 다음에 배치)
+```
+
+### 애니메이션 전략
+CSS `animation` 속성에 `fill-mode: both`와 개별 `animation-delay`를 인라인 스타일로 지정.
+Tailwind 클래스 대신 인라인을 사용하는 이유: 7개 요소에 각기 다른 딜레이(300~1500ms)를
+적용해야 하므로 유틸리티 클래스로는 표현이 불가능.
+
+### 키프레임 (globals.css에 추가)
+| 키프레임 | 용도 | 시간 |
+|----------|------|------|
+| `clear-fade-in` | 범용 opacity 0→1 | 200~300ms |
+| `bounce-in` | 축하 아이콘 scale 0→1.2→1 | 500ms |
+| `star-scale-in` | 별 순차 등장 scale 0→1 | 200ms |
+| `slide-down-fade` | 해금 배너 등장 | 300ms |
+| `modal-enter` | 모달 컨테이너 (기존) | 300ms |
+
+### 별점 로직
+| 별점 | 조건 |
+|------|------|
+| 3별 | hintsUsed === 0 AND 기준 시간 이내 |
+| 2별 | hintsUsed 1~2 OR 시간 초과 |
+| 1별 | hintsUsed >= 3 |
+
+### 해금 배너
+스테이지 구간의 마지막 스테이지(10, 20, 30, 40) 클리어 시
+다음 난이도 해금 알림을 표시.
+
+### 접근성
+- `role="dialog"`, `aria-modal="true"`, `aria-label`
+- Tab 포커스 트랩 (모달 내부 순환)
+- ESC 키 → 홈으로 이동
+- 초기 포커스: "다음 스테이지" 버튼 (애니메이션 완료 후)
+- `aria-live="polite"` on 결과 카드
+
+### 반응형
+| 브레이크포인트 | 동작 |
+|---------------|------|
+| < 375px | 너비 `100vw - 32px`, 패딩 축소 |
+| 375~767px | 기본 (max-width 360px) |
+| >= 768px | max-width 420px, 패딩 확대 |
+
+## 의존성
+- `useGameStore`: isComplete, timer, stage, hintsUsed, initGame
+- `useAuth`: isAuthenticated (랭킹 버튼 분기)
+- `formatTime` (Timer.tsx 재사용)
+- `STAGE_RANGES` (game.ts)

--- a/src/app/game/GameContent.tsx
+++ b/src/app/game/GameContent.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/game";
 import Toolbar from "@/components/game/Toolbar";
 import PauseOverlay from "@/components/game/PauseOverlay";
+import ClearModal from "@/components/game/ClearModal";
 
 // ────────────────────────────────────────
 // Zustand persist 하이드레이션 구독
@@ -55,7 +56,7 @@ const GameSkeleton = () => (
 /**
  * 게임 플레이 페이지 콘텐츠 (클라이언트)
  *
- * 구성: GameHeader > (Board + Toolbar + NumberPad + PauseOverlay)
+ * 구성: GameHeader > (Board + Toolbar + NumberPad + PauseOverlay + ClearModal)
  *
  * ## 게임 초기화 흐름
  *
@@ -147,6 +148,9 @@ const GameContent = () => {
 
       {/* 일시정지 오버레이 */}
       <PauseOverlay />
+
+      {/* 클리어 결과 모달 */}
+      <ClearModal />
     </GameHeader>
   );
 };

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -201,6 +201,7 @@
   --shadow-board: 0 2px 8px oklch(0 0 0 / 0.08), 0 0 0 3px oklch(0.25 0 0);
   --shadow-cell-selected: inset 0 0 0 2px oklch(0.55 0.18 250);
   --shadow-numpad: 0 2px 4px oklch(0 0 0 / 0.06);
+  --shadow-xl: 0 20px 25px oklch(0 0 0 / 0.10), 0 8px 10px oklch(0 0 0 / 0.04);
 
   /* ── 🖌 애니메이션 duration ── */
   --duration-fast: 100ms;
@@ -295,6 +296,7 @@
   --shadow-board: 0 2px 8px oklch(0 0 0 / 0.3), 0 0 0 3px oklch(0.80 0 0);
   --shadow-cell-selected: inset 0 0 0 2px oklch(0.68 0.16 250);
   --shadow-numpad: 0 2px 4px oklch(0 0 0 / 0.2);
+  --shadow-xl: 0 20px 25px oklch(0 0 0 / 0.30), 0 8px 10px oklch(0 0 0 / 0.15);
 }
 
 @layer base {
@@ -386,6 +388,51 @@
   100% {
     opacity: 0;
     transform: translateY(10px) scale(0.98);
+  }
+}
+
+/* ── 🖌 클리어 모달 키프레임 ── */
+
+@keyframes clear-fade-in {
+  0% {
+    opacity: 0;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+@keyframes bounce-in {
+  0% {
+    transform: scale(0);
+    opacity: 0;
+  }
+  60% {
+    transform: scale(1.2);
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+@keyframes star-scale-in {
+  0% {
+    transform: scale(0);
+  }
+  100% {
+    transform: scale(1);
+  }
+}
+
+@keyframes slide-down-fade {
+  0% {
+    transform: translateY(-10px);
+    opacity: 0;
+  }
+  100% {
+    transform: translateY(0);
+    opacity: 1;
   }
 }
 

--- a/src/components/game/ClearModal.tsx
+++ b/src/components/game/ClearModal.tsx
@@ -22,7 +22,11 @@ const DIFFICULTY_COLOR_MAP: Record<string, string> = {
   마스터: "text-difficulty-expert",
 };
 
-/** 3별 기준 시간 (초) */
+/**
+ * 3별 기준 시간 (초)
+ * 키는 STAGE_RANGES.label 기준 (입문/초급/중급/고급/마스터)
+ * cf. 홈 카드(difficulty-data.ts)는 쉬움/보통/어려움/전문가 표기
+ */
 const THREE_STAR_THRESHOLD: Record<string, number> = {
   입문: 300,   // 5분
   초급: 600,   // 10분
@@ -169,12 +173,10 @@ const ClearModal = () => {
 
   // ── 핸들러 ──
   const handleNextStage = useCallback(() => {
-    if (isLastStage) {
-      initGame(stage); // 같은 스테이지 재시작
-    } else {
-      initGame(stage + 1);
-    }
-  }, [stage, isLastStage, initGame]);
+    const nextStage = isLastStage ? stage : stage + 1;
+    initGame(nextStage);
+    router.replace(`/game?stage=${nextStage}`);
+  }, [stage, isLastStage, initGame, router]);
 
   const handleRanking = useCallback(() => {
     if (isAuthenticated) {

--- a/src/components/game/ClearModal.tsx
+++ b/src/components/game/ClearModal.tsx
@@ -1,0 +1,411 @@
+"use client";
+
+import { memo, useCallback, useEffect, useMemo, useRef } from "react";
+import { useRouter } from "next/navigation";
+import { PartyPopper, Star, Play, Trophy, Home, Unlock } from "lucide-react";
+import { useGameStore } from "@/stores/game-store";
+import { STAGE_RANGES } from "@/types/game";
+import { formatTime } from "./Timer";
+import { Button } from "@/components/ui/button";
+import useAuth from "@/hooks/useAuth";
+
+// ────────────────────────────────────────
+// 상수
+// ────────────────────────────────────────
+
+/** 난이도 라벨 -> Tailwind 색상 클래스 */
+const DIFFICULTY_COLOR_MAP: Record<string, string> = {
+  입문: "text-difficulty-easy",
+  초급: "text-difficulty-easy",
+  중급: "text-difficulty-medium",
+  고급: "text-difficulty-hard",
+  마스터: "text-difficulty-expert",
+};
+
+/** 3별 기준 시간 (초) */
+const THREE_STAR_THRESHOLD: Record<string, number> = {
+  입문: 300,   // 5분
+  초급: 600,   // 10분
+  중급: 1200,  // 20분
+  고급: 2400,  // 40분
+  마스터: 2400, // 40분
+};
+
+/** 최대 스테이지 */
+const MAX_STAGE = 50;
+
+/** 애니메이션 딜레이 (ms) — 디자인 명세 타임라인 */
+const DELAY = {
+  backdrop: 300,
+  modal: 500,
+  icon: 800,
+  title: 900,
+  card: 1000,
+  stars: 1100,
+  unlock: 1400,
+  buttons: 1500,
+} as const;
+
+// ────────────────────────────────────────
+// 헬퍼
+// ────────────────────────────────────────
+
+/** 스테이지 번호로 난이도 라벨 + 색상 클래스를 반환 */
+const getDifficultyInfo = (
+  stage: number,
+): { label: string; colorClass: string } => {
+  for (const range of STAGE_RANGES) {
+    if (stage >= range.startStage && stage <= range.endStage) {
+      return {
+        label: range.label,
+        colorClass: DIFFICULTY_COLOR_MAP[range.label] ?? "text-muted-foreground",
+      };
+    }
+  }
+  return { label: "알 수 없음", colorClass: "text-muted-foreground" };
+};
+
+/** 별점 계산 */
+const calculateStars = (
+  hintsUsed: number,
+  timer: number,
+  difficultyLabel: string,
+): number => {
+  if (hintsUsed >= 3) return 1;
+
+  const threshold = THREE_STAR_THRESHOLD[difficultyLabel] ?? 600;
+  if (hintsUsed === 0 && timer <= threshold) return 3;
+  return 2;
+};
+
+/** 다음 난이도 해금 정보 (마지막 스테이지 클리어 시) */
+const getUnlockInfo = (
+  stage: number,
+): { nextLabel: string } | null => {
+  for (let i = 0; i < STAGE_RANGES.length - 1; i++) {
+    if (stage === STAGE_RANGES[i].endStage) {
+      return { nextLabel: STAGE_RANGES[i + 1].label };
+    }
+  }
+  return null;
+};
+
+// ────────────────────────────────────────
+// 서브 컴포넌트
+// ────────────────────────────────────────
+
+interface StarRatingProps {
+  stars: number;
+  baseDelay: number;
+}
+
+/** 별점 표시 (순차 scale-in 애니메이션) */
+const StarRating = memo(({ stars, baseDelay }: StarRatingProps) => (
+  <div className="flex items-center gap-1" aria-label={`별 ${stars}개`}>
+    {[1, 2, 3].map((i) => (
+      <Star
+        key={i}
+        size={20}
+        className={
+          i <= stars
+            ? "text-warning fill-warning"
+            : "text-muted fill-muted"
+        }
+        style={{
+          animation: `star-scale-in 200ms ease-out ${baseDelay + (i - 1) * 100}ms both`,
+        }}
+        aria-hidden="true"
+      />
+    ))}
+  </div>
+));
+StarRating.displayName = "StarRating";
+
+// ────────────────────────────────────────
+// ClearModal 컴포넌트
+// ────────────────────────────────────────
+
+/**
+ * 클리어 결과 모달
+ *
+ * 퍼즐 완성(isComplete === true) 시 표시.
+ * 축하 아이콘 + 결과 요약 + 액션 버튼으로 구성.
+ *
+ * - 배경 클릭으로 닫히지 않음 (결과 확인 강제)
+ * - ESC 키: 홈으로 이동
+ * - 포커스 트랩 적용
+ * - 스태거 애니메이션 (~1.7초)
+ *
+ * @see docs/design/clear-modal.md
+ */
+const ClearModal = () => {
+  const router = useRouter();
+  const modalRef = useRef<HTMLDivElement>(null);
+  const primaryBtnRef = useRef<HTMLButtonElement>(null);
+
+  // ── 스토어 구독 ──
+  const isComplete = useGameStore((s) => s.isComplete);
+  const timer = useGameStore((s) => s.timer);
+  const stage = useGameStore((s) => s.stage);
+  const hintsUsed = useGameStore((s) => s.hintsUsed);
+  const initGame = useGameStore((s) => s.initGame);
+
+  // ── 인증 상태 ──
+  const { isAuthenticated } = useAuth();
+
+  // ── 계산된 값 ──
+  const { label: difficultyLabel, colorClass: difficultyColor } = useMemo(
+    () => getDifficultyInfo(stage),
+    [stage],
+  );
+
+  const stars = useMemo(
+    () => calculateStars(hintsUsed, timer, difficultyLabel),
+    [hintsUsed, timer, difficultyLabel],
+  );
+
+  const unlockInfo = useMemo(() => getUnlockInfo(stage), [stage]);
+  const isLastStage = stage >= MAX_STAGE;
+
+  // ── 핸들러 ──
+  const handleNextStage = useCallback(() => {
+    if (isLastStage) {
+      initGame(stage); // 같은 스테이지 재시작
+    } else {
+      initGame(stage + 1);
+    }
+  }, [stage, isLastStage, initGame]);
+
+  const handleRanking = useCallback(() => {
+    if (isAuthenticated) {
+      router.push("/ranking");
+    } else {
+      router.push("/login");
+    }
+  }, [router, isAuthenticated]);
+
+  const handleGoHome = useCallback(() => {
+    router.push("/");
+  }, [router]);
+
+  // ── 포커스 트랩 + ESC 핸들링 ──
+  useEffect(() => {
+    if (!isComplete) return;
+
+    // 애니메이션 완료 후 초기 포커스
+    const focusTimeout = setTimeout(() => {
+      primaryBtnRef.current?.focus();
+    }, DELAY.buttons + 200);
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        handleGoHome();
+        return;
+      }
+
+      // Tab 포커스 트랩
+      if (e.key === "Tab" && modalRef.current) {
+        const focusable = modalRef.current.querySelectorAll<HTMLElement>(
+          'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])',
+        );
+        if (focusable.length === 0) return;
+
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+
+        if (e.shiftKey) {
+          if (document.activeElement === first) {
+            e.preventDefault();
+            last.focus();
+          }
+        } else {
+          if (document.activeElement === last) {
+            e.preventDefault();
+            first.focus();
+          }
+        }
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      clearTimeout(focusTimeout);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [isComplete, handleGoHome]);
+
+  // ── 비표시 ──
+  if (!isComplete) return null;
+
+  return (
+    <>
+      {/* ── 배경 오버레이 ── */}
+      <div
+        className="fixed inset-0 z-[var(--z-modal-overlay)]"
+        style={{
+          backgroundColor: "oklch(0 0 0 / 0.5)",
+          backdropFilter: "blur(4px)",
+          animation: `clear-fade-in var(--duration-slow) ease-out ${DELAY.backdrop}ms both`,
+        }}
+        aria-hidden="true"
+      />
+
+      {/* ── 모달 ── */}
+      <div
+        ref={modalRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="퍼즐 완성 결과"
+        className={
+          "fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 " +
+          "z-[var(--z-modal)] " +
+          "w-[calc(100vw_-_48px)] max-w-[360px] " +
+          "max-[374px]:w-[calc(100vw_-_32px)] " +
+          "min-[768px]:max-w-[420px] " +
+          "max-h-[90vh] overflow-y-auto " +
+          "bg-card border border-border rounded-xl " +
+          "py-8 px-6 " +
+          "flex flex-col items-center " +
+          "max-[374px]:py-6 max-[374px]:px-4 " +
+          "min-[768px]:py-10 min-[768px]:px-8"
+        }
+        style={{
+          boxShadow: "var(--shadow-xl)",
+          animation: `modal-enter 300ms cubic-bezier(0, 0, 0.2, 1) ${DELAY.modal}ms both`,
+        }}
+      >
+        {/* ── 축하 아이콘 ── */}
+        <PartyPopper
+          size={48}
+          className="text-success mb-4"
+          aria-hidden="true"
+          style={{
+            animation: `bounce-in var(--duration-slower) var(--ease-bounce) ${DELAY.icon}ms both`,
+          }}
+        />
+
+        {/* ── 제목 ── */}
+        <h2
+          className="text-(length:--text-heading) font-bold text-foreground text-center mb-6"
+          style={{
+            animation: `clear-fade-in var(--duration-normal) ease-out ${DELAY.title}ms both`,
+          }}
+        >
+          퍼즐을 완성했어요!
+        </h2>
+
+        {/* ── 결과 카드 ── */}
+        <div
+          className="bg-muted rounded-[var(--radius-lg)] p-5 w-full mb-6 flex flex-col gap-3"
+          aria-live="polite"
+          style={{
+            animation: `clear-fade-in var(--duration-normal) ease-out ${DELAY.card}ms both`,
+          }}
+        >
+          {/* 난이도 */}
+          <div className="flex items-center justify-between">
+            <span className="text-muted-foreground text-(length:--text-caption)">
+              난이도
+            </span>
+            <span className={`text-(length:--text-caption) font-bold ${difficultyColor}`}>
+              {difficultyLabel}
+            </span>
+          </div>
+
+          {/* 시간 */}
+          <div className="flex items-center justify-between">
+            <span className="text-muted-foreground text-(length:--text-caption)">
+              시간
+            </span>
+            <span className="font-mono text-(length:--text-body) font-bold text-foreground">
+              {formatTime(timer)}
+            </span>
+          </div>
+
+          {/* 힌트 */}
+          <div className="flex items-center justify-between">
+            <span className="text-muted-foreground text-(length:--text-caption)">
+              힌트
+            </span>
+            <span className="text-(length:--text-caption) text-foreground">
+              {hintsUsed}회 사용
+            </span>
+          </div>
+
+          {/* 평가 */}
+          <div className="flex items-center justify-between">
+            <span className="text-muted-foreground text-(length:--text-caption)">
+              평가
+            </span>
+            <StarRating stars={stars} baseDelay={DELAY.stars} />
+          </div>
+        </div>
+
+        {/* ── 해금 알림 (조건부) ── */}
+        {unlockInfo && (
+          <div
+            className={
+              "w-full mb-6 flex items-center gap-3 " +
+              "bg-success/10 border border-success/30 " +
+              "rounded-[var(--radius-md)] py-3 px-4"
+            }
+            style={{
+              animation: `slide-down-fade 300ms ease-out ${DELAY.unlock}ms both`,
+            }}
+          >
+            <Unlock size={18} className="text-success shrink-0" aria-hidden="true" />
+            <div>
+              <p className="text-(length:--text-caption) font-semibold text-foreground">
+                새로운 난이도가 해금되었어요!
+              </p>
+              <p className="text-(length:--text-small) text-muted-foreground">
+                {unlockInfo.nextLabel} 도전 가능
+              </p>
+            </div>
+          </div>
+        )}
+
+        {/* ── 액션 버튼 ── */}
+        <div
+          className="flex flex-col gap-[10px] w-full"
+          style={{
+            animation: `clear-fade-in var(--duration-normal) ease-out ${DELAY.buttons}ms both`,
+          }}
+        >
+          {/* 다음 스테이지 / 한 번 더 */}
+          <Button
+            ref={primaryBtnRef}
+            variant="default"
+            className="h-12 w-full gap-2 text-base bg-sudoku-primary hover:bg-sudoku-primary/90"
+            onClick={handleNextStage}
+          >
+            <Play size={16} />
+            {isLastStage ? "한 번 더" : "다음 스테이지"}
+          </Button>
+
+          {/* 랭킹 보기 / 로그인하고 기록 저장 */}
+          <Button
+            variant="secondary"
+            className="h-11 w-full gap-2 text-base"
+            onClick={handleRanking}
+          >
+            <Trophy size={16} />
+            {isAuthenticated ? "랭킹 보기" : "로그인하고 기록 저장"}
+          </Button>
+
+          {/* 홈으로 */}
+          <Button
+            variant="ghost"
+            className="h-11 w-full gap-2 text-base"
+            onClick={handleGoHome}
+          >
+            <Home size={16} />
+            홈으로
+          </Button>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default ClearModal;

--- a/src/components/game/index.ts
+++ b/src/components/game/index.ts
@@ -1,5 +1,6 @@
 export { default as Board } from "./Board";
 export { default as Cell } from "./Cell";
+export { default as ClearModal } from "./ClearModal";
 export { default as GameHeader } from "./GameHeader";
 export { default as LockedCellPopover } from "./LockedCellPopover";
 export { default as NumberPad } from "./NumberPad";


### PR DESCRIPTION
## Summary
- 퍼즐 완성 시 표시되는 클리어 결과 모달 (`ClearModal.tsx`) 구현
- 결과 카드: 난이도 · 클리어 시간 · 힌트 사용 횟수 · 별점(3단계)
- 스태거 애니메이션 7단계 (~1.7초) — 디자인 명세 타임라인 준수
- 해금 배너: 스테이지 구간 마지막(10/20/30/40) 클리어 시 다음 난이도 해금 알림
- 인증 분기: 로그인 시 "랭킹 보기" / 비로그인 시 "로그인하고 기록 저장"
- 반응형 3단계: <375px / 375~767px / 768px+
- globals.css: 키프레임 4종 (clear-fade-in, bounce-in, star-scale-in, slide-down-fade) + `--shadow-xl` Light/Dark 변수 추가

## 변경 파일
| 파일 | 변경 내용 |
|------|----------|
| `src/components/game/ClearModal.tsx` | 신규 — 클리어 모달 컴포넌트 |
| `src/components/game/index.ts` | barrel export 추가 |
| `src/app/game/GameContent.tsx` | ClearModal 통합 |
| `src/app/globals.css` | 키프레임 + shadow-xl 변수 |
| `docs/adr/104-clear-modal.md` | 설계 결정 문서 |

## 디자인 명세 대응
| 명세 항목 | 구현 |
|----------|------|
| 오버레이 oklch(0 0 0 / 0.5) + blur(4px) | ✅ |
| 모달 animate-modal-enter | ✅ |
| PartyPopper bounce-in | ✅ |
| 결과 카드 (난이도/시간/힌트/별점) | ✅ |
| 별점 3단계 + 순차 scale-in | ✅ |
| 해금 배너 slide-down-fade | ✅ |
| 버튼 3종 (Primary/Secondary/Ghost) | ✅ |
| 반응형 (< 375 / 375~767 / 768+) | ✅ |
| 접근성 (포커스 트랩, ESC, aria) | ✅ |

## 의존성
- PR #45 `refactor/store-slices` ✅ 머지됨
- PR #46 `feat/engine-hint` ✅ 머지됨 (hintsUsed, useHint 액션)

## Test plan
- [x] TypeScript `tsc --noEmit` 0 에러
- [x] Next.js 빌드 성공
- [x] 게임 완료 시 모달 표시 확인 (수동)
- [x] 다음 스테이지/홈으로 버튼 동작 확인
- [ ] 반응형 레이아웃 확인 (모바일/PC)
- [ ] 다크 모드 대응 확인

Closes: Epic #5 하위 `feat/ui-clear-modal`

🤖 Generated with [Claude Code](https://claude.com/claude-code)