### PR TITLE
[Frontend] feat/ui-guest-mode — 게스트 모드 Frontend 연동

### DIFF
--- a/src/components/game/ClearModal.tsx
+++ b/src/components/game/ClearModal.tsx
@@ -4,6 +4,7 @@ import { memo, useCallback, useEffect, useMemo, useRef } from "react";
 import { useRouter } from "next/navigation";
 import { PartyPopper, Star, Play, Trophy, Home, Unlock } from "lucide-react";
 import { useGameStore } from "@/stores/game-store";
+import { useGuestRecordStore } from "@/stores/guest-record-store";
 import { STAGE_RANGES } from "@/types/game";
 import { formatTime } from "./Timer";
 import { Button } from "@/components/ui/button";
@@ -157,6 +158,9 @@ const ClearModal = () => {
   // ── 인증 상태 ──
   const { isAuthenticated } = useAuth();
 
+  // ── 게스트 기록 저장 ──
+  const addGuestRecord = useGuestRecordStore((s) => s.addRecord);
+
   // ── 계산된 값 ──
   const { label: difficultyLabel, colorClass: difficultyColor } = useMemo(
     () => getDifficultyInfo(stage),
@@ -170,6 +174,27 @@ const ClearModal = () => {
 
   const unlockInfo = useMemo(() => getUnlockInfo(stage), [stage]);
   const isLastStage = stage >= MAX_STAGE;
+
+  // ── 게스트 클리어 기록 자동 저장 ──
+  const savedRef = useRef(false);
+
+  useEffect(() => {
+    // 게임 완료 + 비로그인 + 아직 저장 안 했으면 기록 추가
+    if (isComplete && !isAuthenticated && !savedRef.current) {
+      savedRef.current = true;
+      addGuestRecord({
+        stage,
+        clearTime: timer,
+        hintsUsed,
+        stars,
+      });
+    }
+
+    // 새 게임 시작 시 플래그 초기화
+    if (!isComplete) {
+      savedRef.current = false;
+    }
+  }, [isComplete, isAuthenticated, stage, timer, hintsUsed, stars, addGuestRecord]);
 
   // ── 핸들러 ──
   const handleNextStage = useCallback(() => {

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -3,6 +3,13 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { SessionProvider } from "next-auth/react";
 import { useState } from "react";
+import useGuestSync from "@/hooks/useGuestSync";
+
+/** 로그인 전환 시 게스트 기록 자동 동기화 (SessionProvider 내부에서 작동) */
+const GuestSyncRunner = () => {
+  useGuestSync();
+  return null;
+};
 
 const Providers = ({ children }: { children: React.ReactNode }) => {
   const [queryClient] = useState(
@@ -19,7 +26,10 @@ const Providers = ({ children }: { children: React.ReactNode }) => {
 
   return (
     <SessionProvider>
-      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+      <QueryClientProvider client={queryClient}>
+        <GuestSyncRunner />
+        {children}
+      </QueryClientProvider>
     </SessionProvider>
   );
 };

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,4 +1,6 @@
 export { default as useAuth } from "./useAuth";
 export { default as useAuthGuard } from "./useAuthGuard";
+export { default as useGuestSync } from "./useGuestSync";
 
 export type { AuthUser, AuthStatus, UseAuthReturn } from "./useAuth";
+export type { UseGuestSyncReturn } from "./useGuestSync";

--- a/src/hooks/useGuestSync.ts
+++ b/src/hooks/useGuestSync.ts
@@ -68,8 +68,11 @@ const useGuestSync = (): UseGuestSyncReturn => {
         return null;
       }
 
-      // 동기화 성공 — 로컬 기록 삭제
-      clearRecords();
+      // DB에 실제 저장(synced)된 건이 있을 때만 로컬 기록 삭제
+      // Epic #6 DB 연결 전까지는 pending만 반환되므로 기록 보존
+      if (json.data.synced > 0) {
+        clearRecords();
+      }
       return json.data;
     } catch (error) {
       // 네트워크 에러 등 — 로컬 기록 보존

--- a/src/hooks/useGuestSync.ts
+++ b/src/hooks/useGuestSync.ts
@@ -1,0 +1,103 @@
+/**
+ * 게스트 기록 → 서버 동기화 훅
+ *
+ * 로그인 전환이 감지되면 로컬에 쌓인 게스트 기록을
+ * POST /api/game/sync 로 일괄 전송하고, 성공 시 로컬 기록을 삭제한다.
+ *
+ * - 인증 상태 변화(unauthenticated → authenticated) 시 자동 실행
+ * - 동기화 중 중복 호출 방지
+ * - 실패 시 로컬 기록 보존 (다음 로그인 시 재시도)
+ *
+ * @see src/stores/guest-record-store.ts
+ * @see src/app/api/game/sync/route.ts
+ */
+
+"use client";
+
+import { useEffect, useRef, useCallback } from "react";
+import useAuth from "./useAuth";
+import { useGuestRecordStore } from "@/stores/guest-record-store";
+import type { ApiResponse } from "@/types/api";
+import type { GuestSyncResponseData } from "@/types/guest";
+import { GUEST_SYNC_ENDPOINT } from "@/types/guest";
+
+// ─── Types ─────────────────────────────────────────
+
+export interface UseGuestSyncReturn {
+  /** 동기화 진행 중 여부 */
+  isSyncing: boolean;
+  /** 수동 동기화 트리거 */
+  syncNow: () => Promise<GuestSyncResponseData | null>;
+}
+
+// ─── Hook ──────────────────────────────────────────
+
+const useGuestSync = (): UseGuestSyncReturn => {
+  const { isAuthenticated, status } = useAuth();
+  const isSyncingRef = useRef(false);
+  const hasSyncedRef = useRef(false);
+
+  const getRecords = useGuestRecordStore((s) => s.getRecords);
+  const clearRecords = useGuestRecordStore((s) => s.clearRecords);
+  const hasRecords = useGuestRecordStore((s) => s.hasRecords);
+
+  /**
+   * 서버로 기록 동기화 수행
+   * 성공 시 로컬 기록 삭제, 실패 시 보존
+   */
+  const syncNow = useCallback(async (): Promise<GuestSyncResponseData | null> => {
+    // 이미 진행 중이면 스킵
+    if (isSyncingRef.current) return null;
+    // 동기화할 기록이 없으면 스킵
+    if (!hasRecords()) return null;
+
+    isSyncingRef.current = true;
+
+    try {
+      const records = getRecords();
+      const response = await fetch(GUEST_SYNC_ENDPOINT, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ records }),
+      });
+
+      const json = (await response.json()) as ApiResponse<GuestSyncResponseData>;
+
+      if (!response.ok || !json.success) {
+        console.warn("[useGuestSync] 동기화 실패:", json);
+        return null;
+      }
+
+      // 동기화 성공 — 로컬 기록 삭제
+      clearRecords();
+      return json.data;
+    } catch (error) {
+      // 네트워크 에러 등 — 로컬 기록 보존
+      console.warn("[useGuestSync] 동기화 에러:", error);
+      return null;
+    } finally {
+      isSyncingRef.current = false;
+    }
+  }, [getRecords, clearRecords, hasRecords]);
+
+  // ── 로그인 감지 시 자동 동기화 ──
+  useEffect(() => {
+    // 세션 로딩 완료 + 인증됨 + 아직 동기화 안 했음
+    if (status === "authenticated" && isAuthenticated && !hasSyncedRef.current) {
+      hasSyncedRef.current = true;
+      void syncNow();
+    }
+
+    // 로그아웃 시 플래그 초기화 (다음 로그인 시 재동기화)
+    if (status === "unauthenticated") {
+      hasSyncedRef.current = false;
+    }
+  }, [status, isAuthenticated, syncNow]);
+
+  return {
+    isSyncing: isSyncingRef.current,
+    syncNow,
+  };
+};
+
+export default useGuestSync;

--- a/src/stores/guest-record-store.ts
+++ b/src/stores/guest-record-store.ts
@@ -1,0 +1,92 @@
+/**
+ * 게스트(비로그인) 게임 기록 스토어
+ *
+ * 비로그인 사용자가 퍼즐을 클리어하면 로컬 스토리지에 기록을 저장하고,
+ * 로그인 전환 시 서버 동기화 후 일괄 삭제할 수 있도록 관리한다.
+ *
+ * Zustand persist 미들웨어로 localStorage에 자동 저장.
+ *
+ * @see src/types/guest.ts — 타입 정의
+ * @see src/hooks/useGuestSync.ts — 동기화 훅
+ * @see docs/adr/203-guest-mode.md
+ */
+
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import type {
+  GuestGameRecord,
+  GuestRecordStore,
+} from "@/types/guest";
+import {
+  GUEST_STORAGE_KEY,
+  GUEST_MAX_RECORDS,
+} from "@/types/guest";
+
+// ─── 스토어 생성 ────────────────────────────────────
+
+export const useGuestRecordStore = create<GuestRecordStore>()(
+  persist(
+    (set, get) => ({
+      // ── 상태 ──
+      records: [],
+
+      // ── 액션 ──
+
+      addRecord: (partial) => {
+        const record: GuestGameRecord = {
+          id: crypto.randomUUID(),
+          stage: partial.stage,
+          clearTime: partial.clearTime,
+          hintsUsed: partial.hintsUsed,
+          stars: partial.stars,
+          completedAt: new Date().toISOString(),
+        };
+
+        set((state) => {
+          const next = [record, ...state.records];
+          // 최대 저장 개수 초과 시 오래된 기록 제거
+          if (next.length > GUEST_MAX_RECORDS) {
+            return { records: next.slice(0, GUEST_MAX_RECORDS) };
+          }
+          return { records: next };
+        });
+      },
+
+      removeRecord: (id) => {
+        set((state) => ({
+          records: state.records.filter((r) => r.id !== id),
+        }));
+      },
+
+      clearRecords: () => {
+        set({ records: [] });
+      },
+
+      getRecords: () => {
+        return get().records;
+      },
+
+      getBestRecord: (stage) => {
+        const stageRecords = get().records.filter((r) => r.stage === stage);
+        if (stageRecords.length === 0) return null;
+
+        // 별점 높은 순 → 클리어 시간 빠른 순
+        return stageRecords.reduce((best, curr) => {
+          if (curr.stars > best.stars) return curr;
+          if (curr.stars === best.stars && curr.clearTime < best.clearTime) {
+            return curr;
+          }
+          return best;
+        });
+      },
+
+      hasRecords: () => {
+        return get().records.length > 0;
+      },
+    }),
+    {
+      name: GUEST_STORAGE_KEY,
+      version: 1,
+    },
+  ),
+);


### PR DESCRIPTION
## Summary
- `src/stores/guest-record-store.ts`: Zustand persist 스토어 — 게스트 클리어 기록을 localStorage에 저장/관리
- `src/hooks/useGuestSync.ts`: 로그인 전환 감지 → `POST /api/game/sync` 자동 동기화 훅
- `src/components/game/ClearModal.tsx`: 비로그인 클리어 시 게스트 기록 자동 저장 연동
- `src/components/providers.tsx`: GuestSyncRunner로 앱 전역 동기화 활성화
- `src/hooks/index.ts`: useGuestSync export 추가

## 구현 상세

### guest-record-store (Zustand persist)
| 액션 | 설명 |
|------|------|
| `addRecord` | 클리어 기록 추가 (crypto.randomUUID, ISO 8601 자동 생성) |
| `removeRecord` | 특정 기록 삭제 |
| `clearRecords` | 동기화 완료 후 전체 삭제 |
| `getBestRecord` | 스테이지별 최고 기록 (별점 > 시간 순) |
| `hasRecords` | 기록 존재 여부 |

- 최대 200건 제한 (GUEST_MAX_RECORDS)
- localStorage 키: `sudoku-guest-records`

### useGuestSync 훅
- `status === "authenticated"` 감지 시 자동 동기화
- 중복 호출 방지 (isSyncingRef)
- 실패 시 로컬 기록 보존 → 다음 로그인 시 재시도
- `syncNow()` 수동 트리거 지원

### ClearModal 연동
- `isComplete && !isAuthenticated` 조건에서 자동 저장
- `savedRef`로 중복 저장 방지, 새 게임 시작 시 초기화

## 관련 이슈
- Refs #4 (Epic: 인증 시스템)
- 선행 PR: #50 (Backend 게스트 모드 타입·API·헬퍼)

## Test plan
- [x] TypeScript 타입 체크 통과 (`tsc --noEmit`)
- [x] ESLint 경고/에러 0건
- [ ] 비로그인 상태에서 퍼즐 클리어 → localStorage에 기록 저장 확인
- [ ] 로그인 전환 → `/api/game/sync` 호출 + 로컬 기록 삭제 확인
- [ ] 네트워크 실패 시 로컬 기록 보존 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)