### PR TITLE
[Backend] feat/api-ranking-schema — GameRecord 스키마 + 동기화 DB 연결

### DIFF
--- a/docs/adr/204-game-record-schema.md
+++ b/docs/adr/204-game-record-schema.md
@@ -1,0 +1,89 @@
+# ADR-204: GameRecord 스키마 설계
+
+## Status
+
+Accepted
+
+## Context
+
+Epic #6 랭킹 시스템의 핵심 데이터 모델인 **게임 클리어 기록(GameRecord)**의 스키마를 설계한다.
+
+### 요구사항
+
+1. 로그인 사용자의 게임 클리어 기록을 영구 저장
+2. 스테이지별 랭킹(최단 시간) 조회를 효율적으로 지원
+3. 사용자별 기록 이력 관리 (같은 스테이지 복수 기록 허용)
+4. 게스트 동기화 API(`POST /api/game/sync`)의 DB 저장 연결
+
+### 기존 구조
+
+- ADR-203에서 게스트 기록은 클라이언트 `GuestGameRecord` 타입으로 정의
+- `/api/game/sync` 라우트가 유효성 검증만 수행하고 DB 저장은 TODO로 남겨둠
+- 필드: `stage(1~50)`, `clearTime(초)`, `hintsUsed(0~3)`, `stars(1~3)`, `completedAt`
+
+## Decision
+
+### 1. GameRecord 모델
+
+```prisma
+model GameRecord {
+  id          String   @id @default(cuid())
+  userId      String
+  stage       Int      @db.SmallInt   // 1~50
+  clearTime   Int                     // 클리어 시간 (초)
+  hintsUsed   Int      @db.SmallInt   // 0~3
+  stars       Int      @db.SmallInt   // 1~3
+  completedAt DateTime               // 실제 클리어 일시
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([userId])
+  @@index([stage, clearTime])
+  @@index([userId, stage])
+  @@map("game_records")
+}
+```
+
+### 2. 설계 결정 사항
+
+#### 복수 기록 허용
+
+같은 사용자가 같은 스테이지를 여러 번 클리어할 수 있다. `@@unique([userId, stage])` 제약을 두지 않음.
+
+- 랭킹 조회 시 사용자별 최고 기록을 쿼리로 추출
+- 기록 이력 확인, 성장 추적 등 확장 가능
+
+#### 인덱스 전략
+
+| 인덱스 | 용도 |
+|--------|------|
+| `[userId]` | 사용자별 전체 기록 조회 |
+| `[stage, clearTime]` | 스테이지별 랭킹 (최단 시간 정렬) |
+| `[userId, stage]` | 사용자의 특정 스테이지 기록 조회 |
+
+#### SmallInt 사용
+
+`stage`, `hintsUsed`, `stars`는 값 범위가 작으므로 `@db.SmallInt`로 저장 공간 최적화.
+
+### 3. 동기화 API 연결
+
+`/api/game/sync` 라우트에서 검증 통과한 기록을 `prisma.gameRecord.createMany()`로 일괄 저장.
+저장 성공 시 결과 상태를 `pending` → `synced`로 전환.
+
+## Consequences
+
+### 긍정적
+
+- 스테이지별 랭킹 쿼리가 `[stage, clearTime]` 인덱스로 최적화됨
+- 복수 기록 허용으로 사용자 이력 추적, 통계 분석 등 향후 확장 가능
+- 게스트 동기화 → DB 저장 파이프라인이 완성됨
+
+### 고려사항
+
+- 기록이 누적되면 랭킹 쿼리에서 사용자별 최고 기록 추출 비용 발생
+  → 데이터 규모에 따라 Materialized View 또는 별도 BestRecord 테이블 도입 검토
+- 현재는 서버 사이드 유효성 검증(범위 체크)만 수행
+  → 치팅 방지를 위한 추가 검증은 별도 이슈로 관리

--- a/prisma/migrations/20260403043534_add_game_record/migration.sql
+++ b/prisma/migrations/20260403043534_add_game_record/migration.sql
@@ -1,0 +1,26 @@
+-- CreateTable
+CREATE TABLE "game_records" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "stage" SMALLINT NOT NULL,
+    "clearTime" INTEGER NOT NULL,
+    "hintsUsed" SMALLINT NOT NULL,
+    "stars" SMALLINT NOT NULL,
+    "completedAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "game_records_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "game_records_userId_idx" ON "game_records"("userId");
+
+-- CreateIndex
+CREATE INDEX "game_records_stage_clearTime_idx" ON "game_records"("stage", "clearTime");
+
+-- CreateIndex
+CREATE INDEX "game_records_userId_stage_idx" ON "game_records"("userId", "stage");
+
+-- AddForeignKey
+ALTER TABLE "game_records" ADD CONSTRAINT "game_records_userId_fkey" FOREIGN KEY ("userId") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -24,8 +24,9 @@ model User {
   image         String?
   nickname      String?   @db.VarChar(20)
 
-  accounts Account[]
-  sessions Session[]
+  accounts    Account[]
+  sessions    Session[]
+  gameRecords GameRecord[]
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
@@ -70,6 +71,30 @@ model Session {
 
   @@index([userId])
   @@map("sessions")
+}
+
+// ─────────────────────────────────────────────
+// Game Records (Epic #6: 랭킹 시스템)
+// ─────────────────────────────────────────────
+
+model GameRecord {
+  id          String   @id @default(cuid())
+  userId      String
+  stage       Int      @db.SmallInt // 1~50
+  clearTime   Int      // 클리어 시간 (초)
+  hintsUsed   Int      @db.SmallInt // 0~3
+  stars       Int      @db.SmallInt // 1~3
+  completedAt DateTime // 실제 클리어 일시
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  @@index([userId])
+  @@index([stage, clearTime]) // 랭킹 조회: 스테이지별 최단 시간
+  @@index([userId, stage]) // 사용자별 스테이지 기록 조회
+  @@map("game_records")
 }
 
 model VerificationToken {

--- a/src/app/api/game/sync/route.ts
+++ b/src/app/api/game/sync/route.ts
@@ -6,7 +6,7 @@
  *
  * - 인증 필수 (requireAuth)
  * - 요청 본문: { records: GuestGameRecord[] }
- * - 각 레코드를 유효성 검증 후 DB에 저장 (Epic #6에서 연결)
+ * - 각 레코드를 유효성 검증 후 GameRecord 테이블에 저장
  * - 중복/유효하지 않은 건은 스킵하고 개별 결과를 응답
  *
  * @see docs/adr/203-guest-mode.md
@@ -15,6 +15,7 @@
 import { NextResponse } from "next/server";
 import { requireAuth } from "@/lib/auth/helpers";
 import { validateSyncRequest } from "@/lib/api/guest";
+import { prisma } from "@/lib/prisma";
 import type { ApiResponse } from "@/types/api";
 import type { GuestSyncResponseData } from "@/types/guest";
 
@@ -50,19 +51,33 @@ export const POST = async (req: Request) => {
   }
 
   // ── 4. DB 저장 ──
-  // Epic #6 (feat/api-ranking-schema)에서 GameRecord 모델 생성 후
-  // 여기에 Prisma upsert 로직을 연결한다.
-  //
-  // 현재는 유효성 검증만 수행하고 결과를 반환.
-  // 실제 저장은 아래 TODO 블록에서 구현 예정:
-  //
-  // TODO: Epic #6 — GameRecord 스키마 완성 후 구현
-  // const userId = session.user.id;
-  // await prisma.gameRecord.createMany({
-  //   data: validRecords.map((r) => ({ ... })),
-  //   skipDuplicates: true,
-  // });
-  void validRecords; // Epic #6에서 DB 저장 시 사용 예정
+  const userId = session.user.id;
+
+  try {
+    await prisma.gameRecord.createMany({
+      data: validRecords.map((r) => ({
+        userId,
+        stage: r.stage,
+        clearTime: r.clearTime,
+        hintsUsed: r.hintsUsed,
+        stars: r.stars,
+        completedAt: new Date(r.completedAt),
+      })),
+    });
+
+    // 저장 성공 → pending 상태를 synced로 전환
+    for (const result of results) {
+      if (result.status === "pending") {
+        result.status = "synced";
+      }
+    }
+  } catch (error) {
+    console.error("[sync] DB 저장 실패:", error);
+    return NextResponse.json<ApiResponse>(
+      { success: false, error: "기록 저장 중 오류가 발생했습니다" },
+      { status: 500 },
+    );
+  }
 
   // ── 5. 응답 ──
   const synced = results.filter((r) => r.status === "synced").length;

--- a/src/lib/api/guest.ts
+++ b/src/lib/api/guest.ts
@@ -196,8 +196,7 @@ export const validateSyncRequest = (
 
     seenIds.add(r.id);
     validRecords.push(r);
-    // DB 저장 전까지는 "pending", 실제 저장 완료 후 "synced"로 변경
-    // → Epic #6에서 DB 연결 시 이 status를 "synced"로 전환
+    // 검증 통과 시 "pending", DB 저장 완료 후 호출부에서 "synced"로 전환
     results.push({
       guestRecordId: r.id,
       status: "pending",

--- a/src/types/db.ts
+++ b/src/types/db.ts
@@ -10,4 +10,5 @@ export type {
   Account,
   Session,
   VerificationToken,
+  GameRecord,
 } from "@prisma/client";


### PR DESCRIPTION
## Summary
- Prisma `GameRecord` 모델 추가 (stage, clearTime, hintsUsed, stars, completedAt)
- User ↔ GameRecord 1:N 관계 설정 + 랭킹 조회 최적화 인덱스 3종
- `/api/game/sync` 라우트에 `prisma.gameRecord.createMany()` 연결 (pending → synced 전환)
- ADR-204: GameRecord 스키마 설계 문서 작성

## Changes
| 파일 | 내용 |
|------|------|
| `prisma/schema.prisma` | GameRecord 모델 + User 관계 추가 |
| `prisma/migrations/..._add_game_record/` | 마이그레이션 (Supabase 적용 완료) |
| `src/types/db.ts` | GameRecord 타입 re-export |
| `src/app/api/game/sync/route.ts` | TODO → 실제 DB 저장 구현 |
| `src/lib/api/guest.ts` | TODO 주석 정리 |
| `docs/adr/204-game-record-schema.md` | 스키마 설계 ADR |

## 인덱스 전략
| 인덱스 | 용도 |
|--------|------|
| `[userId]` | 사용자별 전체 기록 조회 |
| `[stage, clearTime]` | 스테이지별 랭킹 (최단 시간 정렬) |
| `[userId, stage]` | 사용자의 특정 스테이지 기록 조회 |

## Test plan
- [x] TypeScript 타입 체크 통과 (`tsc --noEmit`)
- [x] ESLint 통과
- [x] Prisma 마이그레이션 Supabase DB 적용 완료
- [ ] `/api/game/sync` 동기화 API 동작 확인 (로그인 후 게스트 기록 동기화)

Closes #6 (Epic: 랭킹 시스템 — 1/2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)