### PR TITLE
[Frontend] fix/logout-button — 로그아웃 버튼 미작동 수정

### DIFF
--- a/src/components/layout/AuthButton.tsx
+++ b/src/components/layout/AuthButton.tsx
@@ -54,8 +54,9 @@ const AuthButton = () => {
 
           {/* 로그아웃 */}
           <DropdownMenuItem
-            onSelect={async () => {
-              await logout();
+            onSelect={(e) => {
+              e.preventDefault(); // 메뉴 자동 닫힘 방지 → signOut 리다이렉트 보장
+              void logout();
             }}
             className="cursor-pointer gap-2"
           >

--- a/src/components/layout/AuthButton.tsx
+++ b/src/components/layout/AuthButton.tsx
@@ -54,10 +54,7 @@ const AuthButton = () => {
 
           {/* 로그아웃 */}
           <DropdownMenuItem
-            onSelect={(e) => {
-              e.preventDefault(); // 메뉴 자동 닫힘 방지 → signOut 리다이렉트 보장
-              void logout();
-            }}
+            onClick={() => void logout()}
             className="cursor-pointer gap-2"
           >
             <LogOut className="size-4" />

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -80,7 +80,11 @@ const useAuth = (): UseAuthReturn => {
   }, [pathname]);
 
   const logout = useCallback(async (callbackUrl: string = "/") => {
-    await signOut({ callbackUrl });
+    try {
+      await signOut({ callbackUrl });
+    } catch (error) {
+      console.error("[useAuth] signOut 실패:", error);
+    }
   }, []);
 
   return {

--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -2,7 +2,7 @@
 
 import { useSession, signIn, signOut } from "next-auth/react";
 import { useCallback, useMemo } from "react";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 
 // ────────────────────────────────────────
 // Types
@@ -58,6 +58,7 @@ export interface UseAuthReturn {
  */
 const useAuth = (): UseAuthReturn => {
   const { data: session, status } = useSession();
+  const router = useRouter();
   const pathname = usePathname();
 
   const user = useMemo<AuthUser | null>(() => {
@@ -81,11 +82,13 @@ const useAuth = (): UseAuthReturn => {
 
   const logout = useCallback(async (callbackUrl: string = "/") => {
     try {
-      await signOut({ callbackUrl });
+      await signOut({ redirect: false });
+      router.push(callbackUrl);
+      router.refresh();
     } catch (error) {
       console.error("[useAuth] signOut 실패:", error);
     }
-  }, []);
+  }, [router]);
 
   return {
     user,


### PR DESCRIPTION
## Summary

- 로그아웃 버튼 클릭 시 아무 반응 없던 버그 수정
- `@base-ui/react`의 `Menu.Item`이 `onSelect`를 지원하지 않아 핸들러가 실행되지 않던 근본 원인 해결
- `signOut` 리다이렉트를 Next.js Router로 분리하여 안정성 확보

## Root Cause

| 항목 | 내용 |
|------|------|
| **증상** | 프로필 → 로그아웃 클릭 → 아무 반응 없음 (쿠키 미삭제, 리다이렉트 없음) |
| **원인** | shadcn/ui가 Radix UI가 아닌 `@base-ui/react`를 사용. Base UI의 `Menu.Item`은 **`onSelect` prop을 지원하지 않아** 핸들러가 통째로 무시됨 |
| **해결** | `onSelect` → `onClick`으로 변경 |

## Changes

### `src/components/layout/AuthButton.tsx`
- `onSelect` → `onClick`으로 이벤트 핸들러 변경
- `e.preventDefault()` 제거 (불필요)

### `src/hooks/useAuth.ts`
- `useRouter` 추가
- `signOut({ callbackUrl })` → `signOut({ redirect: false })` + `router.push()` + `router.refresh()`
  - signOut 자체 리다이렉트 대신 Next.js Router로 직접 이동
  - `router.refresh()`로 서버 컴포넌트 세션 상태 재검증
- `try-catch` 에러 처리 추가

## Test plan

- [x] 로그인 후 프로필 클릭 → 로그아웃 버튼 클릭 → `/`로 리다이렉트 확인
- [x] 로그아웃 후 세션 쿠키 삭제 확인
- [x] 로그아웃 후 AuthButton이 로그인 링크로 전환 확인
- [x] TypeScript 타입 체크 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)