### PR TITLE
[Frontend] fix/logout-clear-game-state — 로그아웃 시 게임 상태 초기화

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -3,6 +3,8 @@
 import { useSession, signIn, signOut } from "next-auth/react";
 import { useCallback, useMemo } from "react";
 import { usePathname, useRouter } from "next/navigation";
+import { useGameStore } from "@/stores/game-store";
+import { useGuestRecordStore } from "@/stores/guest-record-store";
 
 // ────────────────────────────────────────
 // Types
@@ -83,6 +85,13 @@ const useAuth = (): UseAuthReturn => {
   const logout = useCallback(async (callbackUrl: string = "/") => {
     try {
       await signOut({ redirect: false });
+
+      // 게임·게스트 기록 스토어 초기화 (persist 스토리지 + 인메모리)
+      useGameStore.persist.clearStorage();
+      useGameStore.setState(useGameStore.getInitialState());
+      useGuestRecordStore.persist.clearStorage();
+      useGuestRecordStore.setState(useGuestRecordStore.getInitialState());
+
       router.push(callbackUrl);
       router.refresh();
     } catch (error) {


### PR DESCRIPTION
## Summary

- 로그아웃 후에도 진행 중인 게임과 게스트 기록이 남아있던 문제 수정
- Zustand `persist.clearStorage()` + `getInitialState()`로 localStorage와 인메모리 상태 모두 초기화

## Changes

### `src/hooks/useAuth.ts`
- `useGameStore`, `useGuestRecordStore` import 추가
- `logout` 함수에서 `signOut` 후 두 스토어 초기화:
  - `persist.clearStorage()` — localStorage 제거
  - `setState(getInitialState())` — 인메모리 상태를 기본값으로 리셋

## Test plan

- [x] 로그인 → 게임 진행 → 로그아웃 → 게임 상태 초기화 확인
- [x] 로그아웃 후 localStorage에 `sudoku-game`, `sudoku-guest-records` 키 제거 확인
- [x] TypeScript 타입 체크 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)