### PR TITLE
[Backend] feat/api-ranking-endpoints — 클리어 기록 저장 + 랭킹 조회 API

### DIFF
--- a/src/app/api/game/clear/route.ts
+++ b/src/app/api/game/clear/route.ts
@@ -1,0 +1,175 @@
+/**
+ * POST /api/game/clear
+ *
+ * 로그인 사용자의 게임 클리어 기록을 저장한다.
+ *
+ * - 인증 필수 (requireAuth)
+ * - 요청 본문: { stage, clearTime, hintsUsed, stars }
+ * - 유효성 검증 후 GameRecord 테이블에 저장
+ * - 개인 최고 기록 여부를 함께 응답
+ *
+ * @see docs/adr/204-game-record-schema.md
+ */
+
+import { NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth/helpers";
+import { prisma } from "@/lib/prisma";
+import type { ApiResponse } from "@/types/api";
+import type { GameClearRequest, GameClearResponseData } from "@/types/ranking";
+import {
+  MIN_STAGE,
+  MAX_STAGE,
+  MAX_CLEAR_TIME,
+  MAX_HINTS,
+  MIN_STARS,
+  MAX_STARS,
+} from "@/types/guest";
+
+// ─── 유효성 검증 ──────────────────────────────────────
+
+const validateClearRequest = (
+  body: unknown,
+): { valid: true; data: GameClearRequest } | { valid: false; error: string } => {
+  if (!body || typeof body !== "object") {
+    return { valid: false, error: "유효하지 않은 요청입니다" };
+  }
+
+  const b = body as Record<string, unknown>;
+
+  if (
+    typeof b.stage !== "number" ||
+    !Number.isInteger(b.stage) ||
+    b.stage < MIN_STAGE ||
+    b.stage > MAX_STAGE
+  ) {
+    return {
+      valid: false,
+      error: `스테이지는 ${MIN_STAGE}~${MAX_STAGE} 정수여야 합니다`,
+    };
+  }
+
+  if (
+    typeof b.clearTime !== "number" ||
+    !Number.isInteger(b.clearTime) ||
+    b.clearTime <= 0 ||
+    b.clearTime > MAX_CLEAR_TIME
+  ) {
+    return {
+      valid: false,
+      error: `클리어 시간은 1~${MAX_CLEAR_TIME}초 정수여야 합니다`,
+    };
+  }
+
+  if (
+    typeof b.hintsUsed !== "number" ||
+    !Number.isInteger(b.hintsUsed) ||
+    b.hintsUsed < 0 ||
+    b.hintsUsed > MAX_HINTS
+  ) {
+    return {
+      valid: false,
+      error: `힌트 사용 횟수는 0~${MAX_HINTS} 정수여야 합니다`,
+    };
+  }
+
+  if (
+    typeof b.stars !== "number" ||
+    !Number.isInteger(b.stars) ||
+    b.stars < MIN_STARS ||
+    b.stars > MAX_STARS
+  ) {
+    return {
+      valid: false,
+      error: `별점은 ${MIN_STARS}~${MAX_STARS} 정수여야 합니다`,
+    };
+  }
+
+  return {
+    valid: true,
+    data: {
+      stage: b.stage,
+      clearTime: b.clearTime,
+      hintsUsed: b.hintsUsed,
+      stars: b.stars,
+    },
+  };
+};
+
+// ─── 핸들러 ───────────────────────────────────────────
+
+export const POST = async (req: Request) => {
+  // ── 1. 인증 검증 ──
+  const session = await requireAuth();
+  if (!session) {
+    return NextResponse.json<ApiResponse>(
+      { success: false, error: "로그인이 필요합니다" },
+      { status: 401 },
+    );
+  }
+
+  // ── 2. 요청 본문 파싱 ──
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json<ApiResponse>(
+      { success: false, error: "유효하지 않은 JSON 형식입니다" },
+      { status: 400 },
+    );
+  }
+
+  // ── 3. 유효성 검증 ──
+  const validation = validateClearRequest(body);
+  if (!validation.valid) {
+    return NextResponse.json<ApiResponse>(
+      { success: false, error: validation.error },
+      { status: 400 },
+    );
+  }
+
+  const { stage, clearTime, hintsUsed, stars } = validation.data;
+  const userId = session.user.id;
+
+  try {
+    // ── 4. 기록 저장 ──
+    const record = await prisma.gameRecord.create({
+      data: {
+        userId,
+        stage,
+        clearTime,
+        hintsUsed,
+        stars,
+        completedAt: new Date(),
+      },
+      select: { id: true },
+    });
+
+    // ── 5. 개인 최고 기록 확인 ──
+    const personalBest = await prisma.gameRecord.findFirst({
+      where: { userId, stage },
+      orderBy: { clearTime: "asc" },
+      select: { clearTime: true },
+    });
+
+    const personalBestTime = personalBest?.clearTime ?? clearTime;
+    const isPersonalBest = clearTime <= personalBestTime;
+
+    // ── 6. 응답 ──
+    const responseData: GameClearResponseData = {
+      recordId: record.id,
+      isPersonalBest,
+      personalBestTime,
+    };
+
+    return NextResponse.json<ApiResponse<GameClearResponseData>>(
+      { success: true, data: responseData },
+      { status: 201 },
+    );
+  } catch (error) {
+    console.error("[game/clear] DB 저장 실패:", error);
+    return NextResponse.json<ApiResponse>(
+      { success: false, error: "기록 저장 중 오류가 발생했습니다" },
+      { status: 500 },
+    );
+  }
+};

--- a/src/app/api/ranking/me/route.ts
+++ b/src/app/api/ranking/me/route.ts
@@ -1,0 +1,113 @@
+/**
+ * GET /api/ranking/me
+ *
+ * 로그인 사용자의 스테이지별 최고 기록을 조회한다.
+ * 각 스테이지의 최단 클리어 시간 + 플레이 횟수를 반환.
+ *
+ * - 인증 필수 (requireAuth)
+ *
+ * @see docs/adr/204-game-record-schema.md
+ */
+
+import { NextResponse } from "next/server";
+import { requireAuth } from "@/lib/auth/helpers";
+import { prisma } from "@/lib/prisma";
+import type { ApiResponse } from "@/types/api";
+import type { PersonalBestRecord, MyRankingResponseData } from "@/types/ranking";
+
+export const GET = async () => {
+  // ── 1. 인증 검증 ──
+  const session = await requireAuth();
+  if (!session) {
+    return NextResponse.json<ApiResponse>(
+      { success: false, error: "로그인이 필요합니다" },
+      { status: 401 },
+    );
+  }
+
+  const userId = session.user.id;
+
+  try {
+    // ── 2. 스테이지별 집계 (최소 clearTime + 플레이 횟수) ──
+    const stageStats = await prisma.gameRecord.groupBy({
+      by: ["stage"],
+      where: { userId },
+      _min: { clearTime: true },
+      _count: { id: true },
+      orderBy: { stage: "asc" },
+    });
+
+    if (stageStats.length === 0) {
+      const responseData: MyRankingResponseData = {
+        records: [],
+        clearedStages: 0,
+        totalPlays: 0,
+      };
+      return NextResponse.json<ApiResponse<MyRankingResponseData>>(
+        { success: true, data: responseData },
+        { status: 200 },
+      );
+    }
+
+    // ── 3. 각 스테이지 최고 기록 상세 조회 ──
+    const bestRecords = await prisma.gameRecord.findMany({
+      where: {
+        userId,
+        OR: stageStats.map((s) => ({
+          stage: s.stage,
+          clearTime: s._min.clearTime!,
+        })),
+      },
+      orderBy: [{ stage: "asc" }, { completedAt: "asc" }],
+      select: {
+        stage: true,
+        clearTime: true,
+        hintsUsed: true,
+        stars: true,
+        completedAt: true,
+      },
+    });
+
+    // 스테이지별 중복 제거 (같은 최고 시간이 여러 개면 가장 먼저 달성한 것)
+    const seenStages = new Set<number>();
+    const uniqueBests = bestRecords.filter((r) => {
+      if (seenStages.has(r.stage)) return false;
+      seenStages.add(r.stage);
+      return true;
+    });
+
+    // playCount 맵 생성
+    const playCountMap = new Map(
+      stageStats.map((s) => [s.stage, s._count.id]),
+    );
+
+    // ── 4. 응답 데이터 조합 ──
+    const records: PersonalBestRecord[] = uniqueBests.map((r) => ({
+      stage: r.stage,
+      clearTime: r.clearTime,
+      hintsUsed: r.hintsUsed,
+      stars: r.stars,
+      completedAt: r.completedAt.toISOString(),
+      playCount: playCountMap.get(r.stage) ?? 1,
+    }));
+
+    const totalPlays = stageStats.reduce((sum, s) => sum + s._count.id, 0);
+
+    const responseData: MyRankingResponseData = {
+      records,
+      clearedStages: stageStats.length,
+      totalPlays,
+    };
+
+    return NextResponse.json<ApiResponse<MyRankingResponseData>>(
+      { success: true, data: responseData },
+      { status: 200 },
+    );
+  } catch (error) {
+    console.error("[ranking/me] 조회 실패:", error);
+    return NextResponse.json<ApiResponse>(
+      { success: false, error: "내 기록 조회 중 오류가 발생했습니다" },
+      { status: 500 },
+    );
+  }
+};

--- a/src/app/api/ranking/route.ts
+++ b/src/app/api/ranking/route.ts
@@ -1,0 +1,141 @@
+/**
+ * GET /api/ranking?stage=1&limit=20
+ *
+ * 특정 스테이지의 랭킹(최단 클리어 시간)을 조회한다.
+ * 사용자별 최고 기록만 추출하여 순위를 매긴다.
+ *
+ * - 인증 불필요 (공개 API)
+ * - 쿼리 파라미터: stage (필수, 1~50), limit (선택, 기본 20, 최대 100)
+ *
+ * @see docs/adr/204-game-record-schema.md
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import type { ApiResponse } from "@/types/api";
+import type { RankingEntry, RankingResponseData } from "@/types/ranking";
+import { RANKING_DEFAULT_LIMIT, RANKING_MAX_LIMIT } from "@/types/ranking";
+import { MIN_STAGE, MAX_STAGE } from "@/types/guest";
+
+export const GET = async (req: NextRequest) => {
+  // ── 1. 쿼리 파라미터 파싱 ──
+  const { searchParams } = req.nextUrl;
+
+  const stageParam = searchParams.get("stage");
+  if (!stageParam) {
+    return NextResponse.json<ApiResponse>(
+      { success: false, error: "stage 파라미터가 필요합니다" },
+      { status: 400 },
+    );
+  }
+
+  const stage = parseInt(stageParam, 10);
+  if (isNaN(stage) || stage < MIN_STAGE || stage > MAX_STAGE) {
+    return NextResponse.json<ApiResponse>(
+      {
+        success: false,
+        error: `stage는 ${MIN_STAGE}~${MAX_STAGE} 정수여야 합니다`,
+      },
+      { status: 400 },
+    );
+  }
+
+  const limitParam = searchParams.get("limit");
+  const limit = limitParam
+    ? Math.min(
+        Math.max(parseInt(limitParam, 10) || RANKING_DEFAULT_LIMIT, 1),
+        RANKING_MAX_LIMIT,
+      )
+    : RANKING_DEFAULT_LIMIT;
+
+  try {
+    // ── 2. 사용자별 최고 기록 조회 ──
+    // 각 사용자의 해당 스테이지 최단 클리어 시간 기록을 가져온다.
+    // Prisma에서 groupBy + min 후 상세 정보를 가져오는 2단계 쿼리.
+
+    // 2-1. 사용자별 최소 clearTime 추출
+    const bestTimes = await prisma.gameRecord.groupBy({
+      by: ["userId"],
+      where: { stage },
+      _min: { clearTime: true },
+    });
+
+    if (bestTimes.length === 0) {
+      const responseData: RankingResponseData = {
+        stage,
+        rankings: [],
+        totalPlayers: 0,
+      };
+      return NextResponse.json<ApiResponse<RankingResponseData>>(
+        { success: true, data: responseData },
+        { status: 200 },
+      );
+    }
+
+    // 2-2. 각 사용자의 최고 기록 상세 정보 조회
+    const records = await prisma.gameRecord.findMany({
+      where: {
+        stage,
+        OR: bestTimes.map((bt) => ({
+          userId: bt.userId,
+          clearTime: bt._min.clearTime!,
+        })),
+      },
+      // 같은 clearTime 기록이 복수일 때 가장 먼저 달성한 것 선택
+      orderBy: [{ clearTime: "asc" }, { completedAt: "asc" }],
+      select: {
+        userId: true,
+        clearTime: true,
+        hintsUsed: true,
+        stars: true,
+        completedAt: true,
+        user: {
+          select: {
+            nickname: true,
+            name: true,
+            image: true,
+          },
+        },
+      },
+    });
+
+    // 2-3. 사용자별 중복 제거 (가장 빠른 기록만)
+    const seenUsers = new Set<string>();
+    const uniqueRecords = records.filter((r) => {
+      if (seenUsers.has(r.userId)) return false;
+      seenUsers.add(r.userId);
+      return true;
+    });
+
+    // 2-4. limit 적용 + 순위 부여
+    const rankings: RankingEntry[] = uniqueRecords
+      .slice(0, limit)
+      .map((r, index) => ({
+        rank: index + 1,
+        userId: r.userId,
+        displayName: r.user.nickname ?? r.user.name ?? "익명",
+        profileImage: r.user.image,
+        clearTime: r.clearTime,
+        hintsUsed: r.hintsUsed,
+        stars: r.stars,
+        completedAt: r.completedAt.toISOString(),
+      }));
+
+    const responseData: RankingResponseData = {
+      stage,
+      rankings,
+      totalPlayers: bestTimes.length,
+    };
+
+    return NextResponse.json<ApiResponse<RankingResponseData>>(
+      { success: true, data: responseData },
+      { status: 200 },
+    );
+  } catch (error) {
+    console.error("[ranking] 조회 실패:", error);
+    return NextResponse.json<ApiResponse>(
+      { success: false, error: "랭킹 조회 중 오류가 발생했습니다" },
+      { status: 500 },
+    );
+  }
+};

--- a/src/types/ranking.ts
+++ b/src/types/ranking.ts
@@ -1,0 +1,101 @@
+/**
+ * 랭킹 시스템 관련 타입 정의
+ *
+ * 게임 클리어 기록 저장, 스테이지별 랭킹 조회,
+ * 개인 기록 조회에 사용되는 타입.
+ *
+ * @see docs/adr/204-game-record-schema.md
+ * @see GitHub Issue #6 — Epic: 랭킹 시스템
+ */
+
+// ─── 클리어 기록 저장 ────────────────────────────────
+
+/** POST /api/game/clear 요청 본문 */
+export interface GameClearRequest {
+  /** 스테이지 번호 (1~50) */
+  stage: number;
+  /** 클리어 시간 (초, 양의 정수) */
+  clearTime: number;
+  /** 힌트 사용 횟수 (0~3) */
+  hintsUsed: number;
+  /** 별점 (1~3) */
+  stars: number;
+}
+
+/** POST /api/game/clear 응답 데이터 */
+export interface GameClearResponseData {
+  /** 저장된 기록 ID */
+  recordId: string;
+  /** 해당 스테이지 개인 최고 기록 여부 */
+  isPersonalBest: boolean;
+  /** 해당 스테이지 개인 최고 클리어 시간 (초) */
+  personalBestTime: number;
+}
+
+// ─── 랭킹 조회 ──────────────────────────────────────
+
+/** 랭킹 항목 (스테이지별 최고 기록 1건/사용자) */
+export interface RankingEntry {
+  /** 순위 (1부터 시작) */
+  rank: number;
+  /** 사용자 ID */
+  userId: string;
+  /** 사용자 닉네임 또는 이름 */
+  displayName: string;
+  /** 프로필 이미지 URL */
+  profileImage: string | null;
+  /** 최고 클리어 시간 (초) */
+  clearTime: number;
+  /** 해당 기록의 힌트 사용 횟수 */
+  hintsUsed: number;
+  /** 해당 기록의 별점 */
+  stars: number;
+  /** 클리어 일시 (ISO 8601) */
+  completedAt: string;
+}
+
+/** GET /api/ranking 응답 데이터 */
+export interface RankingResponseData {
+  /** 조회한 스테이지 번호 */
+  stage: number;
+  /** 랭킹 목록 */
+  rankings: RankingEntry[];
+  /** 전체 참여자 수 */
+  totalPlayers: number;
+}
+
+// ─── 내 기록 조회 ────────────────────────────────────
+
+/** 스테이지별 개인 최고 기록 */
+export interface PersonalBestRecord {
+  /** 스테이지 번호 */
+  stage: number;
+  /** 최고 클리어 시간 (초) */
+  clearTime: number;
+  /** 힌트 사용 횟수 */
+  hintsUsed: number;
+  /** 별점 */
+  stars: number;
+  /** 클리어 일시 (ISO 8601) */
+  completedAt: string;
+  /** 해당 스테이지 플레이 횟수 */
+  playCount: number;
+}
+
+/** GET /api/ranking/me 응답 데이터 */
+export interface MyRankingResponseData {
+  /** 스테이지별 최고 기록 목록 */
+  records: PersonalBestRecord[];
+  /** 클리어한 스테이지 총 수 */
+  clearedStages: number;
+  /** 전체 플레이 횟수 */
+  totalPlays: number;
+}
+
+// ─── 상수 ────────────────────────────────────────────
+
+/** 랭킹 목록 기본 조회 개수 */
+export const RANKING_DEFAULT_LIMIT = 20;
+
+/** 랭킹 목록 최대 조회 개수 */
+export const RANKING_MAX_LIMIT = 100;


### PR DESCRIPTION
## Summary
- `POST /api/game/clear` — 게임 클리어 기록 저장 API (인증 필수, 개인 최고 기록 여부 응답)
- `GET /api/ranking?stage=N&limit=20` — 스테이지별 랭킹 조회 API (공개, 사용자별 최고 기록 추출)
- `GET /api/ranking/me` — 내 스테이지별 최고 기록 조회 API (인증 필수)
- `src/types/ranking.ts` — 랭킹 관련 타입 정의

## API 명세

### POST /api/game/clear
| 항목 | 내용 |
|------|------|
| 인증 | 필수 (requireAuth) |
| 요청 | `{ stage, clearTime, hintsUsed, stars }` |
| 응답 | `{ recordId, isPersonalBest, personalBestTime }` |
| 상태코드 | 201 (성공), 400 (검증 실패), 401 (미인증), 500 (서버 오류) |

### GET /api/ranking
| 항목 | 내용 |
|------|------|
| 인증 | 불필요 (공개) |
| 파라미터 | `stage` (필수, 1~50), `limit` (선택, 기본 20, 최대 100) |
| 응답 | `{ stage, rankings: RankingEntry[], totalPlayers }` |
| 로직 | 사용자별 최고 기록만 추출 → 최단 시간순 정렬 → 순위 부여 |

### GET /api/ranking/me
| 항목 | 내용 |
|------|------|
| 인증 | 필수 (requireAuth) |
| 응답 | `{ records: PersonalBestRecord[], clearedStages, totalPlays }` |
| 로직 | 스테이지별 groupBy → 최고 기록 상세 조회 → 플레이 횟수 포함 |

## Test plan
- [x] TypeScript 타입 체크 통과 (`tsc --noEmit`)
- [x] ESLint 통과
- [ ] `POST /api/game/clear` — 로그인 후 클리어 기록 저장 + 개인 최고 기록 응답 확인
- [ ] `GET /api/ranking?stage=1` — 스테이지별 랭킹 조회 확인
- [ ] `GET /api/ranking/me` — 내 기록 조회 확인
- [ ] 미인증 시 401 응답 확인 (clear, me)
- [ ] 잘못된 파라미터 시 400 응답 확인

Related: #6 (Epic: 랭킹 시스템 — Backend 2/2)

🤖 Generated with [Claude Code](https://claude.com/claude-code)