### PR TITLE
[Frontend] feat/ui-ranking-hooks — 랭킹 React Query 커스텀 훅

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,6 +1,8 @@
 export { default as useAuth } from "./useAuth";
 export { default as useAuthGuard } from "./useAuthGuard";
 export { default as useGuestSync } from "./useGuestSync";
+export { useStageRanking, useMyRanking, rankingKeys } from "./useRanking";
+export { useGameClear } from "./useGameClear";
 
 export type { AuthUser, AuthStatus, UseAuthReturn } from "./useAuth";
 export type { UseGuestSyncReturn } from "./useGuestSync";

--- a/src/hooks/useGameClear.ts
+++ b/src/hooks/useGameClear.ts
@@ -1,0 +1,60 @@
+/**
+ * 게임 클리어 기록 저장 커스텀 훅
+ *
+ * React Query useMutation 기반으로 클리어 기록을 서버에 저장한다.
+ * 저장 성공 시 관련 랭킹 쿼리를 자동 무효화하여 최신 데이터를 반영한다.
+ *
+ * - 인증된 사용자만 호출 가능 (POST /api/game/clear)
+ * - 비로그인 사용자는 guest-record-store에 별도 저장
+ *
+ * @see src/types/ranking.ts — 타입 정의
+ * @see src/app/api/game/clear/route.ts — API 엔드포인트
+ * @see GitHub Issue #6 — Epic: 랭킹 시스템
+ */
+
+"use client";
+
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import type {
+  GameClearRequest,
+  GameClearResponseData,
+} from "@/types/ranking";
+import type { ApiResponse } from "@/types/api";
+import { rankingKeys } from "./useRanking";
+
+// ─── Fetcher ────────────────────────────────────────
+
+const postGameClear = async (
+  data: GameClearRequest,
+): Promise<GameClearResponseData> => {
+  const res = await fetch("/api/game/clear", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+  });
+
+  const json = (await res.json()) as ApiResponse<GameClearResponseData>;
+
+  if (!res.ok || !json.success) {
+    throw new Error(
+      json.success === false ? json.error : "기록 저장에 실패했습니다",
+    );
+  }
+
+  return json.data;
+};
+
+// ─── Hook ───────────────────────────────────────────
+
+/** 게임 클리어 기록 저장 + 랭킹 캐시 무효화 */
+export const useGameClear = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: postGameClear,
+    onSuccess: () => {
+      // 랭킹 전체 + 내 기록 캐시 무효화
+      void queryClient.invalidateQueries({ queryKey: rankingKeys.all });
+    },
+  });
+};

--- a/src/hooks/useRanking.ts
+++ b/src/hooks/useRanking.ts
@@ -1,0 +1,95 @@
+/**
+ * 랭킹 조회 커스텀 훅
+ *
+ * React Query 기반으로 스테이지별 랭킹과 내 기록을 조회한다.
+ *
+ * - useStageRanking: GET /api/ranking?stage=N&limit=M
+ * - useMyRanking: GET /api/ranking/me (인증 필수)
+ *
+ * @see src/types/ranking.ts — 타입 정의
+ * @see src/app/api/ranking/ — API 엔드포인트
+ * @see GitHub Issue #6 — Epic: 랭킹 시스템
+ */
+
+"use client";
+
+import { useQuery } from "@tanstack/react-query";
+import type {
+  RankingResponseData,
+  MyRankingResponseData,
+} from "@/types/ranking";
+import { RANKING_DEFAULT_LIMIT } from "@/types/ranking";
+import type { ApiResponse } from "@/types/api";
+import useAuth from "./useAuth";
+
+// ─── Query Keys ─────────────────────────────────────
+
+export const rankingKeys = {
+  all: ["ranking"] as const,
+  stage: (stage: number, limit: number) =>
+    [...rankingKeys.all, "stage", stage, limit] as const,
+  me: () => [...rankingKeys.all, "me"] as const,
+};
+
+// ─── Fetchers ───────────────────────────────────────
+
+const fetchStageRanking = async (
+  stage: number,
+  limit: number,
+): Promise<RankingResponseData> => {
+  const params = new URLSearchParams({
+    stage: String(stage),
+    limit: String(limit),
+  });
+
+  const res = await fetch(`/api/ranking?${params}`);
+  const json = (await res.json()) as ApiResponse<RankingResponseData>;
+
+  if (!res.ok || !json.success) {
+    throw new Error(
+      json.success === false ? json.error : "랭킹 조회에 실패했습니다",
+    );
+  }
+
+  return json.data;
+};
+
+const fetchMyRanking = async (): Promise<MyRankingResponseData> => {
+  const res = await fetch("/api/ranking/me");
+  const json = (await res.json()) as ApiResponse<MyRankingResponseData>;
+
+  if (!res.ok || !json.success) {
+    throw new Error(
+      json.success === false ? json.error : "내 기록 조회에 실패했습니다",
+    );
+  }
+
+  return json.data;
+};
+
+// ─── Hooks ──────────────────────────────────────────
+
+/** 스테이지별 랭킹 조회 (공개 API, 인증 불필요) */
+export const useStageRanking = (
+  stage: number,
+  limit: number = RANKING_DEFAULT_LIMIT,
+) => {
+  return useQuery({
+    queryKey: rankingKeys.stage(stage, limit),
+    queryFn: () => fetchStageRanking(stage, limit),
+    enabled: stage > 0,
+    staleTime: 30 * 1000, // 30초간 캐시 유지
+  });
+};
+
+/** 내 스테이지별 최고 기록 조회 (인증 필수) */
+export const useMyRanking = () => {
+  const { isAuthenticated } = useAuth();
+
+  return useQuery({
+    queryKey: rankingKeys.me(),
+    queryFn: fetchMyRanking,
+    enabled: isAuthenticated,
+    staleTime: 60 * 1000, // 1분간 캐시 유지
+  });
+};


### PR DESCRIPTION
## Summary

- 스테이지별 랭킹 조회, 내 기록 조회, 클리어 기록 저장을 위한 React Query 훅 3종 구현
- Backend API (PR #52, #55)에 대응하는 클라이언트 데이터 레이어

## Changes

### 신규 파일

| 파일 | 설명 |
|------|------|
| `src/hooks/useRanking.ts` | `useStageRanking` + `useMyRanking` 조회 훅, `rankingKeys` 쿼리 키 팩토리 |
| `src/hooks/useGameClear.ts` | `useGameClear` mutation 훅 (저장 성공 시 랭킹 캐시 자동 무효화) |

### 수정 파일

| 파일 | 변경 |
|------|------|
| `src/hooks/index.ts` | 신규 훅 re-export 추가 |

## 훅 명세

| 훅 | API | 인증 | 캐시 |
|----|-----|------|------|
| `useStageRanking(stage, limit?)` | `GET /api/ranking` | 불필요 | 30초 staleTime |
| `useMyRanking()` | `GET /api/ranking/me` | 필수 (enabled 제어) | 60초 staleTime |
| `useGameClear()` | `POST /api/game/clear` | 필수 | mutation 성공 시 `rankingKeys.all` 무효화 |

## Test plan

- [x] TypeScript 타입 체크 통과
- [ ] 랭킹 페이지 UI 완성 후 통합 테스트 (`feat/ui-leaderboard`에서 검증 예정)

관련 이슈: #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)