### PR TITLE
[Frontend] feat/ui-leaderboard — 리더보드 UI 컴포넌트

### DIFF
--- a/src/components/ranking/DifficultyTabs.tsx
+++ b/src/components/ranking/DifficultyTabs.tsx
@@ -1,0 +1,59 @@
+/**
+ * 난이도 필터 탭
+ *
+ * 쉬움 / 보통 / 어려움 / 전문가 4개 탭을 균등 분할하고,
+ * 활성 탭 하단에 난이도 색상 인디케이터를 표시한다.
+ *
+ * @see docs/design/ranking.md §3 — 난이도 필터 탭
+ */
+
+"use client";
+
+import { cn } from "@/lib/utils";
+import { DIFFICULTY_TABS, type DifficultyTab } from "./ranking-utils";
+
+interface DifficultyTabsProps {
+  /** 현재 선택된 탭 ID */
+  activeId: string;
+  /** 탭 변경 콜백 */
+  onChange: (tab: DifficultyTab) => void;
+}
+
+const DifficultyTabs = ({ activeId, onChange }: DifficultyTabsProps) => {
+  return (
+    <div className="relative flex border-b border-border" role="tablist">
+      {DIFFICULTY_TABS.map((tab) => {
+        const isActive = tab.id === activeId;
+
+        return (
+          <button
+            key={tab.id}
+            role="tab"
+            aria-selected={isActive}
+            onClick={() => onChange(tab)}
+            className={cn(
+              "relative flex-1 py-3 text-sm font-medium transition-colors duration-200",
+              isActive
+                ? "font-semibold text-foreground"
+                : "text-muted-foreground hover:text-foreground",
+            )}
+          >
+            {tab.label}
+
+            {/* 활성 인디케이터 */}
+            {isActive && (
+              <span
+                className={cn(
+                  "absolute bottom-0 left-1/2 h-0.5 w-3/4 -translate-x-1/2 rounded-full transition-all duration-200",
+                  tab.activeClass,
+                )}
+              />
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export default DifficultyTabs;

--- a/src/components/ranking/LoginBanner.tsx
+++ b/src/components/ranking/LoginBanner.tsx
@@ -1,0 +1,31 @@
+/**
+ * 비로그인 배너
+ *
+ * 비로그인 사용자에게 로그인 유도 메시지를 표시한다.
+ *
+ * @see docs/design/ranking.md §2 — 비로그인 배너
+ */
+
+import Link from "next/link";
+import { LogIn } from "lucide-react";
+
+const LoginBanner = () => {
+  return (
+    <div
+      className="mx-4 flex items-center gap-3 rounded-md border border-info/20 bg-info/10 px-4 py-3"
+    >
+      <LogIn className="size-4 shrink-0 text-foreground" />
+      <p className="flex-1 text-sm">
+        로그인하면 기록을 저장할 수 있어요
+      </p>
+      <Link
+        href="/login"
+        className="shrink-0 text-sm font-medium text-sudoku-primary hover:underline"
+      >
+        로그인 &rarr;
+      </Link>
+    </div>
+  );
+};
+
+export default LoginBanner;

--- a/src/components/ranking/RankingAvatar.tsx
+++ b/src/components/ranking/RankingAvatar.tsx
@@ -1,0 +1,56 @@
+/**
+ * 랭킹 아바타 컴포넌트
+ *
+ * 프로필 이미지가 있으면 표시, 없으면 이니셜 폴백.
+ * 포디움과 리스트에서 공통 사용.
+ *
+ * @see docs/design/ranking.md §4.3 — 아바타
+ */
+
+import { cn } from "@/lib/utils";
+
+interface RankingAvatarProps {
+  /** 프로필 이미지 URL */
+  image: string | null;
+  /** 표시 이름 (이니셜 폴백용) */
+  name: string;
+  /** 크기 (px) */
+  size: number;
+  /** 보더 색상 (메달 색상 등) */
+  borderColor?: string;
+}
+
+const RankingAvatar = ({ image, name, size, borderColor }: RankingAvatarProps) => {
+  const initial = name.charAt(0).toUpperCase() || "U";
+  const sizeStyle = { width: size, height: size };
+
+  return (
+    <div
+      className={cn(
+        "flex shrink-0 items-center justify-center overflow-hidden rounded-full bg-muted",
+      )}
+      style={{
+        ...sizeStyle,
+        border: borderColor ? `2px solid ${borderColor}` : undefined,
+      }}
+    >
+      {image ? (
+        /* eslint-disable-next-line @next/next/no-img-element */
+        <img
+          src={image}
+          alt={name}
+          className="size-full object-cover"
+        />
+      ) : (
+        <span
+          className="font-sans text-sm font-bold text-muted-foreground"
+          style={{ fontSize: size * 0.4 }}
+        >
+          {initial}
+        </span>
+      )}
+    </div>
+  );
+};
+
+export default RankingAvatar;

--- a/src/components/ranking/RankingEmpty.tsx
+++ b/src/components/ranking/RankingEmpty.tsx
@@ -1,0 +1,28 @@
+/**
+ * 랭킹 빈 상태
+ *
+ * 해당 난이도에 클리어 기록이 없을 때 표시.
+ *
+ * @see docs/design/ranking.md §5.4 — 빈 상태
+ */
+
+import Link from "next/link";
+import { Trophy } from "lucide-react";
+import { buttonVariants } from "@/components/ui/button";
+
+const RankingEmpty = () => {
+  return (
+    <div className="flex flex-col items-center gap-3 py-16">
+      <Trophy className="size-12 text-muted-foreground" />
+      <p className="text-base font-medium">아직 기록이 없습니다</p>
+      <p className="text-sm text-muted-foreground">
+        첫 번째 도전자가 되어보세요!
+      </p>
+      <Link href="/" className={buttonVariants({ className: "mt-2" })}>
+        게임 시작하기
+      </Link>
+    </div>
+  );
+};
+
+export default RankingEmpty;

--- a/src/components/ranking/RankingError.tsx
+++ b/src/components/ranking/RankingError.tsx
@@ -1,0 +1,31 @@
+/**
+ * 랭킹 에러 상태
+ *
+ * 네트워크 오류 등으로 데이터 조회 실패 시 표시.
+ *
+ * @see docs/design/ranking.md §6.2 — 네트워크 에러
+ */
+
+import { AlertCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface RankingErrorProps {
+  /** 재시도 콜백 */
+  onRetry: () => void;
+}
+
+const RankingError = ({ onRetry }: RankingErrorProps) => {
+  return (
+    <div className="flex flex-col items-center gap-3 py-16">
+      <AlertCircle className="size-12 text-muted-foreground" />
+      <p className="text-sm text-muted-foreground">
+        랭킹을 불러올 수 없습니다
+      </p>
+      <Button variant="outline" onClick={onRetry}>
+        다시 시도
+      </Button>
+    </div>
+  );
+};
+
+export default RankingError;

--- a/src/components/ranking/RankingList.tsx
+++ b/src/components/ranking/RankingList.tsx
@@ -1,0 +1,93 @@
+/**
+ * 랭킹 리스트 (4위~)
+ *
+ * 포디움 아래에 표시되는 순위 리스트.
+ * 로그인 사용자의 순위는 하이라이트 처리.
+ *
+ * 현재는 limit 파라미터로 한번에 전부 로드한다.
+ * TODO: 사용자 증가 시 무한 스크롤 또는 페이지네이션 도입 (Backend offset/cursor 추가 필요)
+ *
+ * @see docs/design/ranking.md §5 — 랭킹 리스트
+ */
+
+"use client";
+
+import { cn } from "@/lib/utils";
+import type { RankingEntry } from "@/types/ranking";
+import { formatTime, formatDate } from "./ranking-utils";
+import RankingAvatar from "./RankingAvatar";
+import StarRating from "./StarRating";
+
+interface RankingListProps {
+  /** 4위 이후 랭킹 데이터 */
+  rankings: RankingEntry[];
+  /** 현재 로그인 사용자 ID (하이라이트용) */
+  currentUserId?: string | null;
+}
+
+const RankingListItem = ({
+  entry,
+  isMe,
+}: {
+  entry: RankingEntry;
+  isMe: boolean;
+}) => {
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-3 border-b border-border px-4 py-3 transition-colors hover:bg-accent",
+        isMe && "border-l-3 border-l-sudoku-primary bg-sudoku-primary/8",
+      )}
+      style={{ minHeight: 64 }}
+    >
+      {/* 순위 */}
+      <span className="w-8 shrink-0 font-mono text-base font-bold">
+        {entry.rank}
+      </span>
+
+      {/* 아바타 */}
+      <RankingAvatar
+        image={entry.profileImage}
+        name={entry.displayName}
+        size={36}
+      />
+
+      {/* 이름 + 날짜 */}
+      <div className="min-w-0 flex-1">
+        <p className="truncate text-sm font-medium">
+          {entry.displayName}
+          {isMe && (
+            <span className="ml-1 text-xs text-sudoku-primary">(나)</span>
+          )}
+        </p>
+        <p className="text-xs text-muted-foreground">
+          {formatDate(entry.completedAt)}
+        </p>
+      </div>
+
+      {/* 시간 + 별점 */}
+      <div className="flex shrink-0 flex-col items-end gap-0.5">
+        <span className="font-mono text-sm">{formatTime(entry.clearTime)}</span>
+        <StarRating stars={entry.stars} size={12} />
+      </div>
+    </div>
+  );
+};
+
+const RankingList = ({ rankings, currentUserId }: RankingListProps) => {
+  if (rankings.length === 0) return null;
+
+  return (
+    <div className="flex flex-col">
+      {rankings.map((entry) => (
+        <RankingListItem
+          key={entry.userId}
+          entry={entry}
+          isMe={currentUserId === entry.userId}
+        />
+      ))}
+    </div>
+  );
+};
+
+export default RankingList;

--- a/src/components/ranking/RankingPodium.tsx
+++ b/src/components/ranking/RankingPodium.tsx
@@ -1,0 +1,92 @@
+/**
+ * 상위 3위 포디움
+ *
+ * 1, 2, 3위를 메달과 아바타로 시각적으로 구분 표시한다.
+ * 데이터가 3명 미만이면 있는 만큼만 표시.
+ *
+ * @see docs/design/ranking.md §4 — 포디움
+ */
+
+"use client";
+
+import type { RankingEntry } from "@/types/ranking";
+import { formatTime, MEDAL_COLORS, MEDAL_EMOJI } from "./ranking-utils";
+import RankingAvatar from "./RankingAvatar";
+import StarRating from "./StarRating";
+
+interface RankingPodiumProps {
+  /** 상위 3위 데이터 */
+  rankings: RankingEntry[];
+}
+
+/** 포디움 순서: 2위(좌) - 1위(중앙) - 3위(우) */
+const PODIUM_ORDER = [1, 0, 2] as const;
+
+const PodiumItem = ({ entry, rank }: { entry: RankingEntry; rank: 1 | 2 | 3 }) => {
+  const isFirst = rank === 1;
+  const avatarSize = isFirst ? 56 : 44;
+  const medalColor = MEDAL_COLORS[rank];
+  const medal = MEDAL_EMOJI[rank];
+
+  return (
+    <div
+      className="flex flex-1 flex-col items-center gap-1"
+      style={{ paddingTop: isFirst ? 0 : 20 }}
+    >
+      {/* 메달 */}
+      <span className="text-lg" aria-label={`${rank}위`}>
+        {medal}
+      </span>
+
+      {/* 아바타 */}
+      <RankingAvatar
+        image={entry.profileImage}
+        name={entry.displayName}
+        size={avatarSize}
+        borderColor={medalColor}
+      />
+
+      {/* 닉네임 */}
+      <p
+        className={
+          isFirst
+            ? "max-w-[100px] truncate text-base font-bold"
+            : "max-w-[80px] truncate text-sm font-medium"
+        }
+      >
+        {entry.displayName}
+      </p>
+
+      {/* 시간 + 별점 */}
+      <p className="font-mono text-xs text-muted-foreground">
+        {formatTime(entry.clearTime)}
+      </p>
+      <StarRating stars={entry.stars} size={12} />
+    </div>
+  );
+};
+
+const RankingPodium = ({ rankings }: RankingPodiumProps) => {
+  const top3 = rankings.slice(0, 3);
+  if (top3.length === 0) return null;
+
+  return (
+    <div className="mx-4 rounded-lg bg-card p-5" style={{ minHeight: 180 }}>
+      <div className="flex items-end justify-center">
+        {PODIUM_ORDER.map((index) => {
+          const entry = top3[index];
+          if (!entry) return <div key={index} className="flex-1" />;
+          return (
+            <PodiumItem
+              key={entry.userId}
+              entry={entry}
+              rank={(index + 1) as 1 | 2 | 3}
+            />
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default RankingPodium;

--- a/src/components/ranking/RankingSkeleton.tsx
+++ b/src/components/ranking/RankingSkeleton.tsx
@@ -1,0 +1,66 @@
+/**
+ * 랭킹 로딩 스켈레톤
+ *
+ * 데이터 로딩 중 포디움 + 리스트 영역 placeholder 표시.
+ *
+ * @see docs/design/ranking.md §6.1 — 로딩
+ */
+
+const SkeletonBox = ({ className }: { className?: string }) => (
+  <div className={`animate-pulse rounded bg-muted ${className ?? ""}`} />
+);
+
+/** 포디움 스켈레톤 */
+const PodiumSkeleton = () => (
+  <div className="mx-4 flex items-end justify-center gap-4 rounded-lg bg-card p-5" style={{ minHeight: 180 }}>
+    {/* 2위 */}
+    <div className="flex flex-1 flex-col items-center gap-2 pt-5">
+      <SkeletonBox className="size-11 rounded-full" />
+      <SkeletonBox className="h-3 w-14" />
+      <SkeletonBox className="h-2.5 w-10" />
+    </div>
+    {/* 1위 */}
+    <div className="flex flex-1 flex-col items-center gap-2">
+      <SkeletonBox className="size-14 rounded-full" />
+      <SkeletonBox className="h-4 w-16" />
+      <SkeletonBox className="h-3 w-12" />
+    </div>
+    {/* 3위 */}
+    <div className="flex flex-1 flex-col items-center gap-2 pt-5">
+      <SkeletonBox className="size-11 rounded-full" />
+      <SkeletonBox className="h-3 w-14" />
+      <SkeletonBox className="h-2.5 w-10" />
+    </div>
+  </div>
+);
+
+/** 리스트 아이템 스켈레톤 */
+const ListItemSkeleton = () => (
+  <div className="flex items-center gap-3 border-b border-border px-4 py-3" style={{ minHeight: 64 }}>
+    <SkeletonBox className="h-5 w-8" />
+    <SkeletonBox className="size-9 rounded-full" />
+    <div className="flex flex-1 flex-col gap-1.5">
+      <SkeletonBox className="h-3.5 w-24" />
+      <SkeletonBox className="h-2.5 w-16" />
+    </div>
+    <div className="flex flex-col items-end gap-1">
+      <SkeletonBox className="h-3.5 w-12" />
+      <SkeletonBox className="h-3 w-10" />
+    </div>
+  </div>
+);
+
+const RankingSkeleton = () => {
+  return (
+    <div className="flex flex-col gap-4">
+      <PodiumSkeleton />
+      <div className="flex flex-col">
+        {Array.from({ length: 5 }, (_, i) => (
+          <ListItemSkeleton key={i} />
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default RankingSkeleton;

--- a/src/components/ranking/StarRating.tsx
+++ b/src/components/ranking/StarRating.tsx
@@ -1,0 +1,38 @@
+/**
+ * 별점 표시 컴포넌트
+ *
+ * 1~3 별점을 채워진/빈 별 아이콘으로 표시한다.
+ *
+ * @see docs/design/ranking.md §5.2 — 별점
+ */
+
+import { Star } from "lucide-react";
+
+interface StarRatingProps {
+  /** 획득 별점 (1~3) */
+  stars: number;
+  /** 최대 별 수 */
+  max?: number;
+  /** 별 크기 (px) */
+  size?: number;
+}
+
+const StarRating = ({ stars, max = 3, size = 14 }: StarRatingProps) => {
+  return (
+    <div className="flex gap-0.5" aria-label={`별점 ${stars}/${max}`}>
+      {Array.from({ length: max }, (_, i) => (
+        <Star
+          key={i}
+          size={size}
+          className={
+            i < stars
+              ? "fill-warning text-warning"
+              : "fill-transparent text-muted"
+          }
+        />
+      ))}
+    </div>
+  );
+};
+
+export default StarRating;

--- a/src/components/ranking/index.ts
+++ b/src/components/ranking/index.ts
@@ -1,0 +1,12 @@
+export { default as DifficultyTabs } from "./DifficultyTabs";
+export { default as RankingPodium } from "./RankingPodium";
+export { default as RankingList } from "./RankingList";
+export { default as RankingEmpty } from "./RankingEmpty";
+export { default as RankingSkeleton } from "./RankingSkeleton";
+export { default as RankingError } from "./RankingError";
+export { default as LoginBanner } from "./LoginBanner";
+export { default as RankingAvatar } from "./RankingAvatar";
+export { default as StarRating } from "./StarRating";
+
+export { DIFFICULTY_TABS, formatTime, formatDate } from "./ranking-utils";
+export type { DifficultyTab } from "./ranking-utils";

--- a/src/components/ranking/ranking-utils.ts
+++ b/src/components/ranking/ranking-utils.ts
@@ -1,0 +1,58 @@
+/**
+ * 랭킹 컴포넌트 공통 유틸리티
+ *
+ * 시간 포맷, 별점 렌더링, 난이도 탭 데이터 등
+ * 랭킹 UI 전반에서 사용하는 헬퍼.
+ */
+
+// ─── 난이도 탭 데이터 ─────────────────────────────────
+
+export interface DifficultyTab {
+  id: string;
+  label: string;
+  /** 대표 스테이지 번호 (API 조회용) */
+  stage: number;
+  /** 활성 인디케이터 Tailwind 색상 클래스 */
+  activeClass: string;
+}
+
+export const DIFFICULTY_TABS: readonly DifficultyTab[] = [
+  { id: "easy", label: "쉬움", stage: 1, activeClass: "bg-difficulty-easy" },
+  { id: "medium", label: "보통", stage: 11, activeClass: "bg-difficulty-medium" },
+  { id: "hard", label: "어려움", stage: 21, activeClass: "bg-difficulty-hard" },
+  { id: "expert", label: "전문가", stage: 31, activeClass: "bg-difficulty-expert" },
+] as const;
+
+// ─── 시간 포맷 ────────────────────────────────────────
+
+/** 초 → "MM:SS" 형식 변환 */
+export const formatTime = (seconds: number): string => {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+};
+
+// ─── 날짜 포맷 ────────────────────────────────────────
+
+/** ISO 문자열 → "YYYY.MM.DD" 형식 변환 */
+export const formatDate = (isoString: string): string => {
+  const d = new Date(isoString);
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}.${m}.${day}`;
+};
+
+// ─── 메달 색상 ────────────────────────────────────────
+
+export const MEDAL_COLORS = {
+  1: "oklch(0.80 0.15 85)",   // 금
+  2: "oklch(0.75 0.02 250)",  // 은
+  3: "oklch(0.65 0.10 55)",   // 동
+} as const;
+
+export const MEDAL_EMOJI = {
+  1: "\uD83E\uDD47",
+  2: "\uD83E\uDD48",
+  3: "\uD83E\uDD49",
+} as const;


### PR DESCRIPTION
## Summary

- 랭킹 페이지에 사용할 UI 컴포넌트 11개 구현
- 디자인 명세(`docs/design/ranking.md`) 기반, 모바일 우선 레이아웃

## 신규 파일 (src/components/ranking/)

| 컴포넌트 | 설명 |
|----------|------|
| `DifficultyTabs` | 난이도 필터 탭 (4종, 활성 인디케이터) |
| `RankingPodium` | 상위 3위 포디움 (메달 + 아바타 + 시간/별점) |
| `RankingList` | 4위~ 순위 리스트 (내 순위 하이라이트) |
| `RankingEmpty` | 빈 상태 (게임 시작 CTA) |
| `RankingSkeleton` | 로딩 스켈레톤 (포디움 + 리스트 5줄) |
| `RankingError` | 에러 상태 (다시 시도 버튼) |
| `LoginBanner` | 비로그인 유도 배너 |
| `RankingAvatar` | 아바타 (이미지/이니셜 폴백) |
| `StarRating` | 별점 표시 (1~3) |
| `ranking-utils` | 시간/날짜 포맷, 메달 색상, 탭 데이터 |
| `index.ts` | barrel export |

## 설계 메모

- 현재 랭킹 리스트는 `limit` 파라미터로 한번에 전부 로드 (기본 20건, 최대 100건)
- TODO: 사용자 증가 시 무한 스크롤 또는 페이지네이션 도입 (Backend offset/cursor 추가 필요)
- Base UI 기반이므로 `asChild` 대신 `buttonVariants` + Link 조합 사용

## Test plan

- [x] TypeScript 타입 체크 통과
- [ ] 랭킹 페이지 조립 후 통합 테스트 (`feat/ui-ranking-page`에서 검증 예정)

관련 이슈: #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)