### PR TITLE
[Frontend] feat/ui-ranking-page — 랭킹 페이지 조립

### DIFF
--- a/src/app/ranking/RankingContent.tsx
+++ b/src/app/ranking/RankingContent.tsx
@@ -1,0 +1,90 @@
+/**
+ * 랭킹 페이지 메인 콘텐츠 (클라이언트)
+ *
+ * 난이도 탭 선택 → 스테이지별 랭킹 조회 → 포디움 + 리스트 표시.
+ * 비로그인 시 LoginBanner, 로딩 시 스켈레톤, 에러 시 재시도 버튼.
+ *
+ * @see docs/design/ranking.md — 와이어프레임
+ * @see GitHub Issue #6 — Epic: 랭킹 시스템
+ */
+
+"use client";
+
+import { useState, useCallback } from "react";
+import { useAuth } from "@/hooks";
+import { useStageRanking } from "@/hooks/useRanking";
+import {
+  DifficultyTabs,
+  RankingPodium,
+  RankingList,
+  RankingEmpty,
+  RankingSkeleton,
+  RankingError,
+  LoginBanner,
+  DIFFICULTY_TABS,
+  type DifficultyTab,
+} from "@/components/ranking";
+
+const RankingContent = () => {
+  const { user, isAuthenticated } = useAuth();
+  const [activeTab, setActiveTab] = useState<DifficultyTab>(DIFFICULTY_TABS[0]);
+
+  const {
+    data,
+    isLoading,
+    isError,
+    refetch,
+  } = useStageRanking(activeTab.stage);
+
+  const handleTabChange = useCallback((tab: DifficultyTab) => {
+    setActiveTab(tab);
+  }, []);
+
+  // 포디움 (1~3위) / 리스트 (4위~) 분리
+  const podiumData = data?.rankings.slice(0, 3) ?? [];
+  const listData = data?.rankings.slice(3) ?? [];
+
+  return (
+    <div className="flex flex-1 flex-col">
+      {/* 비로그인 배너 */}
+      {!isAuthenticated && (
+        <div className="pt-4">
+          <LoginBanner />
+        </div>
+      )}
+
+      {/* 난이도 필터 탭 */}
+      <div className="mt-4">
+        <DifficultyTabs activeId={activeTab.id} onChange={handleTabChange} />
+      </div>
+
+      {/* 콘텐츠 영역 */}
+      <div className="mx-auto w-full max-w-[600px] flex-1 py-4 lg:max-w-full">
+        {isLoading ? (
+          <RankingSkeleton />
+        ) : isError ? (
+          <RankingError onRetry={() => void refetch()} />
+        ) : !data || data.rankings.length === 0 ? (
+          <RankingEmpty />
+        ) : (
+          <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:gap-6">
+            {/* 포디움 */}
+            <div className="lg:w-[360px] lg:shrink-0">
+              <RankingPodium rankings={podiumData} />
+            </div>
+
+            {/* 리스트 */}
+            <div className="flex-1">
+              <RankingList
+                rankings={listData}
+                currentUserId={user?.id ?? null}
+              />
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default RankingContent;

--- a/src/app/ranking/page.tsx
+++ b/src/app/ranking/page.tsx
@@ -1,0 +1,17 @@
+import { AppLayout } from "@/components/layout";
+import RankingContent from "./RankingContent";
+
+export const metadata = {
+  title: "랭킹 | 스도쿠",
+  description: "난이도별 스도쿠 클리어 랭킹을 확인하세요",
+};
+
+const RankingPage = () => {
+  return (
+    <AppLayout headerVariant="ranking">
+      <RankingContent />
+    </AppLayout>
+  );
+};
+
+export default RankingPage;

--- a/src/components/ranking/DifficultyTabs.tsx
+++ b/src/components/ranking/DifficultyTabs.tsx
@@ -32,7 +32,7 @@ const DifficultyTabs = ({ activeId, onChange }: DifficultyTabsProps) => {
             aria-selected={isActive}
             onClick={() => onChange(tab)}
             className={cn(
-              "relative flex-1 py-3 text-sm font-medium transition-colors duration-200",
+              "relative flex-1 cursor-pointer py-3 text-sm font-medium transition-colors duration-200",
               isActive
                 ? "font-semibold text-foreground"
                 : "text-muted-foreground hover:text-foreground",


### PR DESCRIPTION
## Summary

- `/ranking` 페이지 구현 — 이전 PR의 훅(#56) + 컴포넌트(#57)를 조립
- Epic #6 Frontend 작업 최종 PR

## Changes

| 파일 | 설명 |
|------|------|
| `src/app/ranking/page.tsx` | 서버 컴포넌트 (metadata + AppLayout) |
| `src/app/ranking/RankingContent.tsx` | 클라이언트 컴포넌트 — 탭 선택, 데이터 조회, 상태 분기 |

## 페이지 구조

```
AppLayout (headerVariant="ranking")
  └─ RankingContent
       ├─ LoginBanner (비로그인 시)
       ├─ DifficultyTabs (쉬움/보통/어려움/전문가)
       ├─ RankingSkeleton (로딩 시)
       ├─ RankingError (에러 시)
       ├─ RankingEmpty (데이터 없음)
       └─ RankingPodium + RankingList (정상 표시)
            └─ lg: 2컬럼 배치
```

## 반응형

| 브레이크포인트 | 동작 |
|---|---|
| 모바일 (기본) | 포디움 → 리스트 세로 배치, max-w 600px |
| lg (1024px~) | 포디움 + 리스트 나란히 2컬럼 배치 |

## Test plan

- [x] TypeScript 타입 체크 통과
- [ ] `/ranking` 접속 → 난이도 탭 전환 → 랭킹 조회 확인
- [ ] 비로그인 시 LoginBanner 표시 확인
- [ ] 데이터 없는 난이도에서 빈 상태 표시 확인

관련 이슈: #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)