### PR TITLE
[Frontend] fix/clear-record-save — 로그인 사용자 클리어 기록 서버 저장 연결

### DIFF
--- a/src/components/game/ClearModal.tsx
+++ b/src/components/game/ClearModal.tsx
@@ -9,6 +9,7 @@ import { STAGE_RANGES } from "@/types/game";
 import { formatTime } from "./Timer";
 import { Button } from "@/components/ui/button";
 import useAuth from "@/hooks/useAuth";
+import { useGameClear } from "@/hooks/useGameClear";
 
 // ────────────────────────────────────────
 // 상수
@@ -158,8 +159,9 @@ const ClearModal = () => {
   // ── 인증 상태 ──
   const { isAuthenticated } = useAuth();
 
-  // ── 게스트 기록 저장 ──
+  // ── 기록 저장 ──
   const addGuestRecord = useGuestRecordStore((s) => s.addRecord);
+  const { mutate: saveGameClear } = useGameClear();
 
   // ── 계산된 값 ──
   const { label: difficultyLabel, colorClass: difficultyColor } = useMemo(
@@ -175,26 +177,27 @@ const ClearModal = () => {
   const unlockInfo = useMemo(() => getUnlockInfo(stage), [stage]);
   const isLastStage = stage >= MAX_STAGE;
 
-  // ── 게스트 클리어 기록 자동 저장 ──
+  // ── 클리어 기록 자동 저장 ──
   const savedRef = useRef(false);
 
   useEffect(() => {
-    // 게임 완료 + 비로그인 + 아직 저장 안 했으면 기록 추가
-    if (isComplete && !isAuthenticated && !savedRef.current) {
-      savedRef.current = true;
-      addGuestRecord({
-        stage,
-        clearTime: timer,
-        hintsUsed,
-        stars,
-      });
+    if (!isComplete || savedRef.current) return;
+
+    savedRef.current = true;
+
+    if (isAuthenticated) {
+      // 로그인 사용자 → 서버 저장 (POST /api/game/clear)
+      saveGameClear({ stage, clearTime: timer, hintsUsed, stars });
+    } else {
+      // 비로그인 → 로컬 저장
+      addGuestRecord({ stage, clearTime: timer, hintsUsed, stars });
     }
 
     // 새 게임 시작 시 플래그 초기화
     if (!isComplete) {
       savedRef.current = false;
     }
-  }, [isComplete, isAuthenticated, stage, timer, hintsUsed, stars, addGuestRecord]);
+  }, [isComplete, isAuthenticated, stage, timer, hintsUsed, stars, addGuestRecord, saveGameClear]);
 
   // ── 핸들러 ──
   const handleNextStage = useCallback(() => {


### PR DESCRIPTION
## Summary

- 로그인 사용자가 게임 클리어 시 랭킹에 반영되지 않던 버그 수정
- ClearModal에서 `useGameClear` 훅을 연결하여 `POST /api/game/clear` 호출

## Root Cause

| 항목 | 내용 |
|------|------|
| **증상** | 로그인 상태에서 스테이지 클리어 → 랭킹 페이지에 기록 미반영 |
| **원인** | ClearModal이 비로그인(게스트) 기록만 로컬 저장하고, 로그인 사용자의 서버 저장(`POST /api/game/clear`) 호출이 누락됨 |
| **해결** | `useGameClear` 훅 연결 — 로그인 시 `saveGameClear()`, 비로그인 시 `addGuestRecord()` |

## Changes

### `src/components/game/ClearModal.tsx`
- `useGameClear` import 추가
- 클리어 기록 저장 로직 분기:
  - `isAuthenticated` → `saveGameClear({ stage, clearTime, hintsUsed, stars })`
  - `!isAuthenticated` → `addGuestRecord(...)` (기존 동작 유지)

## Test plan

- [x] TypeScript 타입 체크 통과
- [ ] 로그인 → 스테이지 클리어 → 랭킹 페이지에서 기록 확인
- [ ] 비로그인 → 스테이지 클리어 → 로컬 기록 정상 저장 확인

관련 이슈: #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)