### PR TITLE
[Infra] feat/infra-offline-sync — 오프라인 클리어 기록 동기화

### DIFF
--- a/__tests__/stores/offline-clear-store.test.ts
+++ b/__tests__/stores/offline-clear-store.test.ts
@@ -1,0 +1,60 @@
+/**
+ * 오프라인 클리어 큐 무결성 테스트
+ * — 유실 방지가 목적이므로 FIFO 보존 / 정확한 제거 / 상한 처리를 확인한다.
+ */
+import { beforeEach, describe, expect, it } from "vitest";
+import { useOfflineClearStore } from "@/stores/offline-clear-store";
+
+const sample = (stage: number) => ({
+  stage,
+  clearTime: 100 + stage,
+  hintsUsed: 0,
+  stars: 3,
+});
+
+describe("offline-clear-store", () => {
+  beforeEach(() => {
+    useOfflineClearStore.setState({ pending: [] });
+  });
+
+  it("enqueue는 FIFO 순서로 쌓이고 id가 부여된다", () => {
+    const { enqueue } = useOfflineClearStore.getState();
+    enqueue(sample(1));
+    enqueue(sample(2));
+
+    const pending = useOfflineClearStore.getState().getPending();
+    expect(pending).toHaveLength(2);
+    expect(pending.map((p) => p.stage)).toEqual([1, 2]); // 넣은 순서 유지
+    expect(pending[0].id).toBeTruthy();
+    expect(pending[0].id).not.toBe(pending[1].id);
+  });
+
+  it("dequeue는 해당 id만 제거하고 나머지는 보존한다", () => {
+    const { enqueue, dequeue } = useOfflineClearStore.getState();
+    enqueue(sample(1));
+    enqueue(sample(2));
+    const [first] = useOfflineClearStore.getState().getPending();
+
+    dequeue(first.id);
+
+    const pending = useOfflineClearStore.getState().getPending();
+    expect(pending).toHaveLength(1);
+    expect(pending[0].stage).toBe(2); // 남은 건 유실되지 않음
+  });
+
+  it("상한(100)을 넘으면 가장 오래된 것부터 버린다", () => {
+    const { enqueue } = useOfflineClearStore.getState();
+    for (let i = 1; i <= 101; i++) enqueue(sample(i));
+
+    const pending = useOfflineClearStore.getState().getPending();
+    expect(pending).toHaveLength(100);
+    expect(pending[0].stage).toBe(2); // stage 1이 밀려남
+    expect(pending[99].stage).toBe(101);
+  });
+
+  it("hasPending은 큐 상태를 정확히 반영한다", () => {
+    expect(useOfflineClearStore.getState().hasPending()).toBe(false);
+    useOfflineClearStore.getState().enqueue(sample(1));
+    expect(useOfflineClearStore.getState().hasPending()).toBe(true);
+  });
+});

--- a/src/components/game/ClearModal.tsx
+++ b/src/components/game/ClearModal.tsx
@@ -5,6 +5,7 @@ import { useRouter } from "next/navigation";
 import { PartyPopper, Star, Play, Trophy, Home, Unlock } from "lucide-react";
 import { useGameStore } from "@/stores/game-store";
 import { useGuestRecordStore } from "@/stores/guest-record-store";
+import { useOfflineClearStore } from "@/stores/offline-clear-store";
 import { STAGE_RANGES } from "@/types/game";
 import { formatTime } from "./Timer";
 import { Button } from "@/components/ui/button";
@@ -161,6 +162,7 @@ const ClearModal = () => {
 
   // ── 기록 저장 ──
   const addGuestRecord = useGuestRecordStore((s) => s.addRecord);
+  const enqueueOfflineClear = useOfflineClearStore((s) => s.enqueue);
   const { mutate: saveGameClear } = useGameClear();
 
   // ── 계산된 값 ──
@@ -185,19 +187,29 @@ const ClearModal = () => {
 
     savedRef.current = true;
 
+    const payload = { stage, clearTime: timer, hintsUsed, stars };
+
     if (isAuthenticated) {
-      // 로그인 사용자 → 서버 저장 (POST /api/game/clear)
-      saveGameClear({ stage, clearTime: timer, hintsUsed, stars });
+      const offline = typeof navigator !== "undefined" && !navigator.onLine;
+      if (offline) {
+        // 오프라인 → 큐에 저장 (온라인 복귀 시 자동 전송)
+        enqueueOfflineClear(payload);
+      } else {
+        // 온라인 → 서버 저장. 전송 실패 시 큐로 폴백 (유실 방지)
+        saveGameClear(payload, {
+          onError: () => enqueueOfflineClear(payload),
+        });
+      }
     } else {
       // 비로그인 → 로컬 저장
-      addGuestRecord({ stage, clearTime: timer, hintsUsed, stars });
+      addGuestRecord(payload);
     }
 
     // 새 게임 시작 시 플래그 초기화
     if (!isComplete) {
       savedRef.current = false;
     }
-  }, [isComplete, isAuthenticated, stage, timer, hintsUsed, stars, addGuestRecord, saveGameClear]);
+  }, [isComplete, isAuthenticated, stage, timer, hintsUsed, stars, addGuestRecord, saveGameClear, enqueueOfflineClear]);
 
   // ── 핸들러 ──
   const handleNextStage = useCallback(() => {

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -4,11 +4,18 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { SessionProvider } from "next-auth/react";
 import { useEffect, useState } from "react";
 import useGuestSync from "@/hooks/useGuestSync";
+import useOfflineClearSync from "@/hooks/useOfflineClearSync";
 import { registerServiceWorker } from "@/lib/utils/sw-register";
 
 /** 로그인 전환 시 게스트 기록 자동 동기화 (SessionProvider 내부에서 작동) */
 const GuestSyncRunner = () => {
   useGuestSync();
+  return null;
+};
+
+/** 온라인 복귀 시 오프라인 클리어 큐 자동 전송 */
+const OfflineClearSyncRunner = () => {
+  useOfflineClearSync();
   return null;
 };
 
@@ -37,6 +44,7 @@ const Providers = ({ children }: { children: React.ReactNode }) => {
     <SessionProvider>
       <QueryClientProvider client={queryClient}>
         <GuestSyncRunner />
+        <OfflineClearSyncRunner />
         <ServiceWorkerRunner />
         {children}
       </QueryClientProvider>

--- a/src/hooks/useOfflineClearSync.ts
+++ b/src/hooks/useOfflineClearSync.ts
@@ -1,0 +1,95 @@
+/**
+ * 오프라인 클리어 큐 → 서버 flush 훅
+ *
+ * 온라인 복귀(`online` 이벤트) 또는 앱 마운트 시, localStorage에 쌓인
+ * 미전송 클리어 기록을 순차적으로 POST /api/game/clear 로 전송한다.
+ *
+ * - 인증 상태 + navigator.onLine 확인 후에만 전송
+ * - 전송 성공 → 큐에서 제거 / 실패 → 남겨두고 다음 기회에 재시도
+ * - 하나라도 성공하면 랭킹 캐시 무효화
+ * - 동시 flush 방지 (ref 가드)
+ *
+ * ponytail: POST 성공 직후 앱이 죽으면 해당 건이 재전송되어 중복 행이 생길 수 있음
+ * (창이 매우 좁음). /api/game/clear가 append-only라 발생 시 중복은 무해한 잉여 행.
+ * 문제가 되면 서버에 (userId,stage,completedAt) 멱등 upsert 추가.
+ *
+ * @see src/stores/offline-clear-store.ts
+ */
+
+"use client";
+
+import { useCallback, useEffect, useRef } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import useAuth from "./useAuth";
+import { useOfflineClearStore } from "@/stores/offline-clear-store";
+import { rankingKeys } from "./useRanking";
+import type { ApiResponse } from "@/types/api";
+import type { GameClearResponseData } from "@/types/ranking";
+import type { PendingClear } from "@/stores/offline-clear-store";
+
+const postClear = async (record: PendingClear): Promise<boolean> => {
+  const { id: _id, ...payload } = record;
+  void _id;
+  const res = await fetch("/api/game/clear", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+  const json = (await res.json()) as ApiResponse<GameClearResponseData>;
+  return res.ok && json.success;
+};
+
+const useOfflineClearSync = () => {
+  const { isAuthenticated } = useAuth();
+  const queryClient = useQueryClient();
+  const isFlushingRef = useRef(false);
+
+  const getPending = useOfflineClearStore((s) => s.getPending);
+  const dequeue = useOfflineClearStore((s) => s.dequeue);
+
+  const flush = useCallback(async () => {
+    if (isFlushingRef.current) return;
+    if (!isAuthenticated) return;
+    if (typeof navigator !== "undefined" && !navigator.onLine) return;
+
+    const pending = getPending();
+    if (pending.length === 0) return;
+
+    isFlushingRef.current = true;
+    let anySuccess = false;
+
+    try {
+      for (const record of pending) {
+        try {
+          const ok = await postClear(record);
+          if (ok) {
+            dequeue(record.id);
+            anySuccess = true;
+          } else {
+            // 서버가 거부(4xx/5xx) — 남겨두고 중단, 다음 기회에 재시도
+            break;
+          }
+        } catch {
+          // 네트워크 에러 — 남겨두고 중단
+          break;
+        }
+      }
+    } finally {
+      isFlushingRef.current = false;
+      if (anySuccess) {
+        void queryClient.invalidateQueries({ queryKey: rankingKeys.all });
+      }
+    }
+  }, [isAuthenticated, getPending, dequeue, queryClient]);
+
+  // 마운트 시 + 온라인 복귀 시 flush
+  useEffect(() => {
+    void flush();
+    window.addEventListener("online", flush);
+    return () => window.removeEventListener("online", flush);
+  }, [flush]);
+
+  return { flush };
+};
+
+export default useOfflineClearSync;

--- a/src/stores/offline-clear-store.ts
+++ b/src/stores/offline-clear-store.ts
@@ -1,0 +1,64 @@
+/**
+ * 오프라인 클리어 기록 큐 (로그인 사용자용)
+ *
+ * 로그인 사용자가 오프라인에서 퍼즐을 클리어하면 서버 저장(POST /api/game/clear)이
+ * 실패하므로, 기록을 localStorage 큐에 쌓아두고 온라인 복귀 시 일괄 전송한다.
+ *
+ * - 게스트 기록(guest-record-store)과 별개: 이쪽은 "이미 로그인한" 사용자의 미전송분
+ * - Zustand persist로 localStorage 자동 저장 → 페이지 새로고침/앱 종료에도 유지
+ *
+ * @see src/hooks/useOfflineClearSync.ts — 큐 flush 훅
+ * @see src/app/api/game/clear/route.ts — 전송 대상 API
+ */
+
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+import type { GameClearRequest } from "@/types/ranking";
+
+// ─── 타입 ──────────────────────────────────────────
+
+export interface PendingClear extends GameClearRequest {
+  /** 로컬 큐 식별자 (전송 성공 시 제거용) */
+  id: string;
+}
+
+interface OfflineClearStore {
+  pending: PendingClear[];
+  enqueue: (record: GameClearRequest) => void;
+  dequeue: (id: string) => void;
+  getPending: () => PendingClear[];
+  hasPending: () => boolean;
+}
+
+/** 큐 최대 길이 — 폭주 방지 (오래된 것부터 유지) */
+const MAX_PENDING = 100;
+
+// ─── 스토어 ────────────────────────────────────────
+
+export const useOfflineClearStore = create<OfflineClearStore>()(
+  persist(
+    (set, get) => ({
+      pending: [],
+
+      enqueue: (record) => {
+        const item: PendingClear = { ...record, id: crypto.randomUUID() };
+        set((state) => {
+          const next = [...state.pending, item];
+          return { pending: next.slice(-MAX_PENDING) };
+        });
+      },
+
+      dequeue: (id) => {
+        set((state) => ({ pending: state.pending.filter((r) => r.id !== id) }));
+      },
+
+      getPending: () => get().pending,
+
+      hasPending: () => get().pending.length > 0,
+    }),
+    {
+      name: "sudoku-offline-clears",
+      version: 1,
+    },
+  ),
+);


### PR DESCRIPTION
## 개요
로그인 사용자의 오프라인 클리어 기록 유실을 막고, 온라인 복귀 시 자동 전송한다. (Epic #7)

## 문제
로그인 사용자가 **오프라인에서 퍼즐을 클리어**하면 `ClearModal`이 곧바로 `POST /api/game/clear`를 호출 → 네트워크 실패 → **기록이 조용히 유실**. (게스트 스토어는 비로그인 전용이라 이 경로를 못 잡음)

## 전략 (이슈 명세 그대로)
1. 오프라인 클리어 → localStorage 큐에 저장
2. 온라인 복귀 시 큐 일괄 전송 (`POST /api/game/clear`)
3. 성공 → 큐에서 제거 / 실패 → 보존 후 재시도

## 변경
- **`stores/offline-clear-store.ts`** — Zustand persist 큐. 새로고침·앱 종료에도 유지. 상한 100건
- **`hooks/useOfflineClearSync.ts`** — 마운트 + `online` 이벤트 시 큐를 **순차** flush. 성공분만 dequeue, 첫 실패에서 중단(미전송분 보존), 하나라도 성공하면 랭킹 캐시 무효화. 동시 flush 가드
- **`ClearModal.tsx`** — 인증 사용자: `navigator.onLine` false면 큐 저장, 온라인이면 서버 저장하되 **실패 시 큐로 폴백**. → 어떤 경로에서도 **이중 저장 없음** (clear API가 append-only라 중요)
- **`providers.tsx`** — `OfflineClearSyncRunner` 마운트

## 테스트
- 큐 무결성 4케이스(FIFO 보존·정확한 제거·상한 100·hasPending) — 통과
- 전체 스위트 367 passed, `pnpm build` 통과

## 알려진 한계 (ponytail)
- POST 성공 직후 앱이 죽으면 해당 건 재전송으로 **중복 행** 가능(창 매우 좁음). clear API가 append-only라 중복은 무해한 잉여 행. 문제가 되면 서버에 `(userId, stage, completedAt)` 멱등 upsert 추가.

## 관련 이슈
Epic #7 — 배포 & QA (`feat/infra-offline-sync`)