### PR TITLE
[Frontend] fix/clear-save-ref — 연속 스테이지 클리어 기록 저장 유실 수정

### DIFF
--- a/src/components/game/ClearModal.tsx
+++ b/src/components/game/ClearModal.tsx
@@ -183,7 +183,14 @@ const ClearModal = () => {
   const savedRef = useRef(false);
 
   useEffect(() => {
-    if (!isComplete || savedRef.current) return;
+    // 새 퍼즐 시작(isComplete=false) 시 플래그 리셋.
+    // handleNextStage는 같은 라우트라 모달이 언마운트되지 않으므로
+    // 여기서 리셋하지 않으면 다음 클리어가 저장되지 않는다.
+    if (!isComplete) {
+      savedRef.current = false;
+      return;
+    }
+    if (savedRef.current) return;
 
     savedRef.current = true;
 
@@ -203,11 +210,6 @@ const ClearModal = () => {
     } else {
       // 비로그인 → 로컬 저장
       addGuestRecord(payload);
-    }
-
-    // 새 게임 시작 시 플래그 초기화
-    if (!isComplete) {
-      savedRef.current = false;
     }
   }, [isComplete, isAuthenticated, stage, timer, hintsUsed, stars, addGuestRecord, saveGameClear, enqueueOfflineClear]);
 


### PR DESCRIPTION
## 문제 (블로커, pre-existing)

첫 스테이지 클리어만 기록이 저장되고, **이후 연속 클리어가 서버·게스트·오프라인 큐 어디에도 저장되지 않는** 회귀.

## 근본 원인

`src/components/game/ClearModal.tsx`의 클리어 자동 저장 `useEffect`:

```js
if (!isComplete || savedRef.current) return;  // early return
savedRef.current = true;
// ... 저장 ...
if (!isComplete) { savedRef.current = false; }  // 죽은 코드
```

- 리셋 블록(`if (!isComplete)`)이 early-return **뒤**에 있어 `!isComplete`는 이미 걸러진 상태 → **절대 실행되지 않음**.
- `handleNextStage`는 `initGame(nextStage)` + `router.replace('/game?stage=N')`로 **같은 라우트**를 유지 → `ClearModal`이 언마운트되지 않음.
- `initGame`은 `isComplete: false`로 동기 세팅(`game-core-slice.ts:118`)하지만 `savedRef.current`는 `true`로 고정 유지 → 다음 퍼즐 완성 시 early-return으로 저장 스킵.

## 수정

`isComplete`가 false로 바뀔 때(새 퍼즐 시작) `savedRef`를 리셋하도록 가드를 재구성:

```js
if (!isComplete) {
  savedRef.current = false;
  return;
}
if (savedRef.current) return;
savedRef.current = true;
// ... 저장 (온라인/오프라인/게스트 분기 그대로) ...
```

죽은 리셋 블록 제거. 온라인/오프라인/게스트 분기 로직은 변경 없음.

## 검증

- `pnpm build` 통과
- `pnpm test` 통과 (367/367)
- 중복 저장 없음: `isComplete`가 true로 유지되는 동안 `savedRef`가 재저장을 차단, false 전환 시에만 리셋.

## 테스트 미추가 사유

프로젝트에 testing-library/jsdom 미설치(엔진 전용 vitest). 컴포넌트 테스트는 신규 의존성+셋업이 필요해 과도 → 생략.

관련: Frontend #5