### PR TITLE
[Infra] feat/infra-meta-privacy — SEO 메타태그 + 개인정보처리방침

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,9 +13,15 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
+const SITE_URL = "https://sudoku-flax-gamma.vercel.app";
+const SITE_DESCRIPTION =
+  "언제 어디서든 즐기는 무료 스도쿠 퍼즐 게임. 50개 스테이지, 힌트, 랭킹을 지원하는 PWA.";
+
 export const metadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
   title: "Sudoku",
-  description: "스도쿠 웹앱 — Next.js 15 PWA",
+  description: SITE_DESCRIPTION,
+  keywords: ["스도쿠", "sudoku", "숫자 퍼즐", "퍼즐 게임", "무료 게임", "PWA"],
   appleWebApp: {
     capable: true,
     statusBarStyle: "black-translucent",
@@ -23,6 +29,21 @@ export const metadata: Metadata = {
   },
   icons: {
     apple: "/icons/apple-touch-icon.png",
+  },
+  openGraph: {
+    type: "website",
+    locale: "ko_KR",
+    url: SITE_URL,
+    siteName: "Sudoku",
+    title: "Sudoku",
+    description: SITE_DESCRIPTION,
+    images: [{ url: "/icons/icon-512x512.png", width: 512, height: 512, alt: "Sudoku" }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Sudoku",
+    description: SITE_DESCRIPTION,
+    images: ["/icons/icon-512x512.png"],
   },
 };
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useSearchParams, useRouter } from "next/navigation";
 import { Suspense, useEffect } from "react";
 import { Grid3X3, AlertCircle } from "lucide-react";
@@ -119,6 +120,16 @@ const LoginContent = () => {
           {/* 하단 캡션 */}
           <p className="mt-6 text-center text-xs text-muted-foreground">
             게임은 로그인 없이도 즐길 수 있어요
+          </p>
+          <p className="mt-2 text-center text-xs text-muted-foreground">
+            로그인 시{" "}
+            <Link
+              href="/privacy"
+              className="underline underline-offset-2 hover:text-foreground"
+            >
+              개인정보처리방침
+            </Link>
+            에 동의하게 됩니다
           </p>
         </div>
       </div>

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,0 +1,113 @@
+import type { Metadata } from "next";
+import { AppLayout } from "@/components/layout";
+
+export const metadata: Metadata = {
+  title: "개인정보처리방침 · Sudoku",
+  description: "Sudoku 웹앱의 개인정보 수집·이용에 관한 안내",
+};
+
+const UPDATED_AT = "2026년 7월 23일";
+const CONTACT_EMAIL = "your-email@example.com"; // TODO: 실제 문의 연락처로 교체
+
+const PrivacyPage = () => {
+  return (
+    <AppLayout headerVariant="home">
+      <div className="mx-auto w-full max-w-2xl px-6 py-10">
+        <h1 className="text-2xl font-bold">개인정보처리방침</h1>
+        <p className="mt-2 text-sm text-muted-foreground">
+          시행일: {UPDATED_AT}
+        </p>
+
+        <div className="mt-8 space-y-8 text-sm leading-relaxed text-foreground/90">
+          <p>
+            Sudoku(이하 “서비스”)는 이용자의 개인정보를 소중히 다루며, 아래와
+            같이 최소한의 정보만 수집·이용합니다. 본 서비스는 개인이 운영하는
+            비영리 프로젝트입니다.
+          </p>
+
+          <section>
+            <h2 className="mb-2 text-base font-semibold">
+              1. 수집하는 개인정보 항목
+            </h2>
+            <p className="mb-2 text-muted-foreground">
+              게임은 로그인 없이 이용할 수 있으며, 이 경우 아무런 개인정보도
+              서버로 전송되지 않습니다.
+            </p>
+            <ul className="list-disc space-y-2 pl-5">
+              <li>
+                <strong>소셜 로그인 시(Google·Naver)</strong>: 이름, 이메일
+                주소, 프로필 이미지, 닉네임, 그리고 로그인 유지를 위한 인증
+                토큰·세션 정보.
+              </li>
+              <li>
+                <strong>게임 기록</strong>: 스테이지 번호, 클리어 시간, 힌트 사용
+                횟수, 별점, 클리어 일시.
+              </li>
+              <li>
+                <strong>비로그인(게스트) 이용 시</strong>: 게임 기록은 서버가
+                아닌 이용자의 브라우저(localStorage)에만 저장됩니다. 이후
+                로그인하면 해당 기록이 서버 계정으로 동기화될 수 있습니다.
+              </li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="mb-2 text-base font-semibold">2. 이용 목적</h2>
+            <ul className="list-disc space-y-2 pl-5">
+              <li>회원 식별 및 로그인 상태 유지</li>
+              <li>게임 진행 상황 저장 및 스테이지별 랭킹 제공</li>
+            </ul>
+          </section>
+
+          <section>
+            <h2 className="mb-2 text-base font-semibold">
+              3. 보유 및 이용 기간
+            </h2>
+            <p>
+              수집한 개인정보는 회원 탈퇴 시 지체 없이 파기합니다. 브라우저에
+              저장된 게스트 기록은 이용자가 브라우저 데이터를 삭제하면 함께
+              삭제됩니다.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="mb-2 text-base font-semibold">4. 제3자 제공</h2>
+            <p>
+              서비스는 이용자의 개인정보를 제3자에게 제공하거나 판매하지
+              않습니다. 로그인은 Google·Naver의 OAuth 인증을 통해 이루어지며, 각
+              제공사의 개인정보처리방침이 별도로 적용됩니다.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="mb-2 text-base font-semibold">5. 이용자의 권리</h2>
+            <p>
+              이용자는 언제든지 자신의 개인정보 열람·수정·삭제 및 회원 탈퇴를
+              요청할 수 있습니다. 요청은 아래 연락처로 문의해 주세요.
+            </p>
+          </section>
+
+          <section>
+            <h2 className="mb-2 text-base font-semibold">6. 문의</h2>
+            <p>
+              개인정보 관련 문의:{" "}
+              <a
+                href={`mailto:${CONTACT_EMAIL}`}
+                className="text-sudoku-primary underline underline-offset-2"
+              >
+                {CONTACT_EMAIL}
+              </a>
+            </p>
+          </section>
+
+          <p className="text-muted-foreground">
+            본 방침은 {UPDATED_AT}부터 적용됩니다. 내용이 변경될 경우 본
+            페이지를 통해 안내합니다.
+          </p>
+        </div>
+      </div>
+    </AppLayout>
+  );
+};
+
+export default PrivacyPage;


### PR DESCRIPTION
## 개요
Epic #7 배포 & QA — SEO/공유용 메타태그를 확장하고 개인정보처리방침 페이지를 추가합니다.

## 변경 목록
- **`src/app/layout.tsx`**: 기존 metadata에 다음 추가 (기존 title/description/appleWebApp/icons 유지)
  - `metadataBase` (프로덕션 URL `https://sudoku-flax-gamma.vercel.app`)
  - `keywords`, 확장된 `description`
  - `openGraph` (type, locale `ko_KR`, url, siteName, title, description, image)
  - `twitter` (card `summary_large_image`)
  - OG 이미지는 새로 만들지 않고 기존 `public/icons/icon-512x512.png` 재사용
- **`src/app/privacy/page.tsx`** (신규): 서버 컴포넌트. 기존 `AppLayout` 레이아웃/Tailwind 토큰 재사용. 문의 연락처는 플레이스홀더(`your-email@example.com`, TODO 주석).
- **`src/app/login/page.tsx`**: 하단 캡션에 개인정보처리방침 링크 1개 추가 (OAuth 로그인 = 동의 시점이라 가장 자연스러운 위치).

## 개인정보 수집 항목 근거 (코드 확인)
추측이 아니라 실제 코드에서 확인한 수집 항목만 기재했습니다.

| 항목 | 근거 |
| --- | --- |
| 이름·이메일·프로필 이미지·닉네임 | `prisma/schema.prisma` `User` 모델 (name, email, image, nickname) |
| OAuth 토큰·세션 | `prisma/schema.prisma` `Account`(access_token 등)·`Session` 모델, `src/lib/auth/config.ts` (Google·Naver, DB 세션 전략) |
| 게임 기록 (스테이지·클리어 시간·힌트·별점·클리어 일시) | `prisma/schema.prisma` `GameRecord` 모델 |
| 게스트 기록은 localStorage 로컬 저장, 로그인 시 서버 동기화 | `src/types/guest.ts` (`GUEST_STORAGE_KEY = "sudoku-guest-records"`, `GUEST_SYNC_ENDPOINT = "/api/game/sync"`), `src/stores/guest-record-store.ts` |
| 제3자 제공 없음 | OAuth 외 외부 전송 코드 없음 |

## 테스트 결과
- `pnpm build`: 성공 — `/privacy` 정적 프리렌더 확인
- `pnpm test`: 18 파일, 367 테스트 전부 통과