### PR TITLE
[Infra] fix/privacy-contact-email — 개인정보처리방침 문의 이메일 교체

### DIFF
--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -7,7 +7,7 @@ export const metadata: Metadata = {
 };
 
 const UPDATED_AT = "2026년 7월 23일";
-const CONTACT_EMAIL = "your-email@example.com"; // TODO: 실제 문의 연락처로 교체
+const CONTACT_EMAIL = "leeji.circle@gmail.com";
 
 const PrivacyPage = () => {
   return (


### PR DESCRIPTION
개인정보처리방침 페이지의 플레이스홀더 이메일(`your-email@example.com`)을 실제 값 `leeji.circle@gmail.com`으로 교체. 단순 값 교체(로직 변경 없음). PR #65 리뷰에서 배포 전 조치로 지적했던 항목.

관련: Epic #7 배포 & QA