### PR TITLE
[Frontend] fix/nav-login-button — 비로그인 헤더를 명시적 "로그인" 버튼으로 교체

### DIFF
--- a/src/components/layout/AuthButton.tsx
+++ b/src/components/layout/AuthButton.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import Link from "next/link";
-import { User, LogOut } from "lucide-react";
+import { LogOut } from "lucide-react";
 import { useAuth } from "@/hooks";
+import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -13,7 +14,11 @@ import {
 
 /** 로그인/프로필 아이콘 버튼 — 세션 상태에 따라 변형 */
 const AuthButton = () => {
-  const { user, isAuthenticated, logout } = useAuth();
+  const { user, isAuthenticated, isLoading, logout } = useAuth();
+
+  // 세션 로딩 중 — 아바타와 동일한 크기의 빈 자리만 잡아 "로그인" 버튼 깜빡임(FOUC) 방지
+  // ponytail: 스켈레톤 애니메이션 생략, 로딩이 체감될 만큼 길어지면 추가
+  if (isLoading) return <div className="size-11" aria-hidden="true" />;
 
   if (isAuthenticated && user) {
     const name = user.nickname ?? user.name ?? "";
@@ -66,13 +71,13 @@ const AuthButton = () => {
   }
 
   return (
-    <Link
-      href="/login"
-      className="flex size-11 items-center justify-center text-muted-foreground transition-colors duration-100 hover:text-foreground"
+    <Button
+      render={<Link href="/login" />}
+      className="h-11 rounded-full px-4"
       aria-label="로그인"
     >
-      <User className="size-6" />
-    </Link>
+      로그인
+    </Button>
   );
 };
 


### PR DESCRIPTION
## 문제

모바일 실기기 테스트 중 발견 — 헤더 우상단에서 **로그인 유저와 비로그인 유저가 시각적으로 구별되지 않음**.

- 로그인: 프로필 이미지 / 이니셜 원형 뱃지
- 비로그인: lucide `User` 아이콘

둘 다 "작고 둥근 아이콘"이라 한눈에 구분 불가. 프로필 이미지가 없어 이니셜 뱃지가 뜰 때 특히 헷갈림.

## 변경 내용

`src/components/layout/AuthButton.tsx` **한 파일만** 수정 (+12 / -7).

비로그인 분기의 아이콘 링크를 기존 `@/components/ui/button`의 `Button`을 재사용한 텍스트 버튼으로 교체:

```tsx
<Button
  render={<Link href="/login" />}
  className="h-11 rounded-full px-4"
  aria-label="로그인"
>
  로그인
</Button>
```

- `Button`은 base-ui 기반이라 `asChild` 대신 `render` prop 사용 (`src/components/ui/dialog.tsx`, `select.tsx`의 기존 패턴과 동일).
- `variant`는 기본값 `default`(`bg-primary` / `text-primary-foreground`) — 새 색상 정의 없이 기존 토큰만 사용.
- `rounded-full`은 `DesktopNav`의 pill 스타일과 톤 일치.
- **로그인 상태(아바타 + 드롭다운) 로직은 전혀 건드리지 않음.**

## 로딩 상태 처리 (FOUC 방지)

`useAuth`는 `status: "authenticated" | "loading" | "unauthenticated"`와 파생값 `isLoading`을 제공한다. 기존 코드는 `isAuthenticated`만 봤기 때문에 세션 로딩 중에는 비로그인 분기가 렌더됐다. 아이콘일 땐 티가 안 났지만, 텍스트 버튼으로 바꾸면 로그인된 사용자에게도 "로그인" 버튼이 잠깐 보였다가 아바타로 바뀌는 깜빡임이 생긴다.

→ **로딩 중에는 아바타와 동일한 `size-11` 빈 자리만 렌더**한다.

```tsx
if (isLoading) return <div className="size-11" aria-hidden="true" />;
```

- `Header.tsx`가 이미 빈 슬롯에 `<div className="size-11" />`를 쓰고 있어 같은 패턴을 재사용.
- 아바타와 크기가 정확히 같으므로 재방문(로그인) 사용자는 레이아웃 시프트 0.
- 스켈레톤 애니메이션은 의도적으로 생략 (`ponytail:` 주석으로 표기). 로딩이 체감될 만큼 길어지면 그때 추가.

## 모바일 레이아웃 확인 (375×812 실측)

dev 서버를 375px 뷰포트로 띄우고 `getBoundingClientRect()`로 실측:

| 페이지 | 로고 | 중앙 | 로그인 버튼 | 가로 오버플로 |
|---|---|---|---|---|
| `/` (home) | 16–105 | — | 286–359 | 없음 |
| `/ranking` | 16–105 | 173–202 ("랭킹") | 286–359 | 없음 |

- 버튼 실측 크기 **73 × 44px** → 터치 타겟 44px 유지 (기존 `size-11`과 동일).
- 헤더 높이 56px 안에 여유 있게 들어가고, 로고/중앙 타이틀과 겹치지 않음 (최소 84px 간격).
- `document.documentElement.scrollWidth > innerWidth` → `false` (가로 스크롤 없음).

## 접근성

- 터치 타겟 44×44px 이상 유지 (WCAG 2.5.5).
- `aria-label="로그인"` 유지, 로딩 플레이스홀더는 `aria-hidden="true"`.
- 색상은 `bg-primary` / `text-primary-foreground` 디자인 토큰 그대로 사용.

## 테스트 결과

- `pnpm build` — 통과 (TypeScript 포함, 13개 정적 페이지 생성 완료)
- `pnpm test` — **367 passed (18 files)**, 실패 0

## 관련

모바일 실기기 UX 개선 (Epic #5 후속)
