### PR TITLE
[Frontend] feat/ui-paper-tone — 페이퍼/퍼즐북 디자인 톤 재정립

### DIFF
--- a/__tests__/theme/theme-init.test.ts
+++ b/__tests__/theme/theme-init.test.ts
@@ -1,0 +1,54 @@
+/**
+ * 테마 초기화 스크립트 테스트
+ * — layout.tsx의 <head>에서 첫 페인트 전에 실행되므로 브라우저에서 눈으로 잡기 어렵다.
+ *   저장된 선택 / 시스템 설정 / 저장소 접근 실패 세 갈래만 확인한다.
+ */
+import { describe, expect, it } from "vitest";
+import { THEME_COLOR, THEME_INIT_SCRIPT } from "@/lib/theme";
+
+/** 스크립트를 최소 DOM 스텁 위에서 실행하고 결과 상태를 돌려준다 */
+const run = (opts: { stored?: string | null; systemDark: boolean; throwOnRead?: boolean }) => {
+  const classes = new Set<string>();
+  let metaContent = THEME_COLOR.light;
+
+  const localStorage = {
+    getItem: () => {
+      if (opts.throwOnRead) throw new Error("SecurityError");
+      return opts.stored ?? null;
+    },
+  };
+  const document = {
+    documentElement: { classList: { add: (c: string) => classes.add(c) } },
+    querySelector: () => ({ setAttribute: (_: string, v: string) => (metaContent = v) }),
+  };
+  const matchMedia = () => ({ matches: opts.systemDark });
+
+  new Function("localStorage", "document", "matchMedia", THEME_INIT_SCRIPT)(
+    localStorage,
+    document,
+    matchMedia,
+  );
+
+  return { dark: classes.has("dark"), metaContent };
+};
+
+describe("THEME_INIT_SCRIPT", () => {
+  it("저장된 선택이 시스템 설정보다 우선한다", () => {
+    expect(run({ stored: "dark", systemDark: false }).dark).toBe(true);
+    expect(run({ stored: "light", systemDark: true }).dark).toBe(false);
+  });
+
+  it("저장된 선택이 없으면 시스템 설정을 따른다", () => {
+    expect(run({ stored: null, systemDark: true }).dark).toBe(true);
+    expect(run({ stored: null, systemDark: false }).dark).toBe(false);
+  });
+
+  it("다크일 때 theme-color meta도 함께 바꾼다", () => {
+    expect(run({ stored: "dark", systemDark: false }).metaContent).toBe(THEME_COLOR.dark);
+    expect(run({ stored: "light", systemDark: true }).metaContent).toBe(THEME_COLOR.light);
+  });
+
+  it("localStorage 접근이 막혀도 던지지 않는다 (Safari 프라이빗 모드)", () => {
+    expect(() => run({ throwOnRead: true, systemDark: true })).not.toThrow();
+  });
+});

--- a/__tests__/theme/theme-init.test.ts
+++ b/__tests__/theme/theme-init.test.ts
@@ -9,7 +9,7 @@ import { THEME_COLOR, THEME_INIT_SCRIPT } from "@/lib/theme";
 /** 스크립트를 최소 DOM 스텁 위에서 실행하고 결과 상태를 돌려준다 */
 const run = (opts: { stored?: string | null; systemDark: boolean; throwOnRead?: boolean }) => {
   const classes = new Set<string>();
-  let metaContent = THEME_COLOR.light;
+  let metaContent: string = THEME_COLOR.light;
 
   const localStorage = {
     getItem: () => {

--- a/docs/design/cell-states.md
+++ b/docs/design/cell-states.md
@@ -3,6 +3,20 @@
 > 스도쿠 보드 각 셀의 시각적 상태를 정의한다.
 > Frontend 에이전트는 이 명세대로 셀 컴포넌트를 구현한다.
 
+> **v2 — 페이퍼 톤 반영 (2026-08).** 토큰 값은 `design-system.md` §2.3, 구분 전략은 §12 참조.
+> **핵심 규칙: 모든 상태는 "색 + 색이 아닌 신호" 두 겹으로 표현한다.**
+> 페이퍼 톤에서 배경 색차가 얕아진 만큼, 실제 판별은 **굵기 · 링 · 밑줄 · 빗금**이 책임진다.
+> 셀 배경끼리의 대비는 3:1을 만족하지 않으며 이는 의도된 설계다(`design-system.md` §9.2 마지막 표).
+
+### 인쇄물 은유
+
+| 실물 | 앱 |
+|------|-----|
+| 문제집에 **인쇄된 숫자** | `given` — 검정 잉크, Bold |
+| 내가 **볼펜으로 써넣은 숫자** | `filled` — 파란 잉크, Medium |
+| 연필 **메모** | `memo` — 회색 소형 숫자 |
+| 빨간펜 **첨삭** | `error` — 빨간 잉크 + 밑줄 |
+
 ---
 
 ## 1. 셀 상태 목록
@@ -36,24 +50,28 @@
 | 커서 | pointer |
 | 트랜지션 | background `--duration-fast` |
 
-### 2.2 초기 제공 (Given)
+### 2.2 초기 제공 (Given) — "인쇄된 문제"
 
 | 속성 | 값 |
 |------|-----|
-| 배경 | `--cell-given` |
-| 텍스트 색상 | `--cell-given-foreground` |
+| 배경 | `--cell-given` — **v2에서 `--cell-default`와 같은 값** |
+| 텍스트 색상 | `--cell-given-foreground` (검정 잉크, 16.85:1) |
 | 폰트 크기 | `--text-cell-given` (24px) |
-| 폰트 가중치 | **700 (Bold)** |
+| 폰트 가중치 | **700 (Bold)** ← 비색상 구분 신호 |
 | 폰트 패밀리 | `--font-geist-mono` |
 | 커서 | default (수정 불가 표시) |
 | 특이사항 | 숫자 입력 시도 시 무반응 (shake 없음) |
 
-### 2.3 유저 입력 (Filled)
+> **배경으로 given을 구분하지 않는다.** 실제 문제집에서 인쇄된 칸과 빈 칸의 종이는 같다.
+> 구분은 **잉크 색(검정 vs 파랑) + 굵기(700 vs 500)** 두 축이 담당하므로,
+> 색각이상 환경에서도 굵기만으로 분리된다.
+
+### 2.3 유저 입력 (Filled) — "볼펜으로 써넣은 답"
 
 | 속성 | 값 |
 |------|-----|
 | 배경 | `--cell-default` |
-| 텍스트 색상 | `--cell-default-foreground` |
+| 텍스트 색상 | `--cell-default-foreground` (**파란 볼펜 잉크**, 7.21:1) |
 | 폰트 크기 | `--text-cell` (24px) |
 | 폰트 가중치 | 500 (Medium) |
 | 폰트 패밀리 | `--font-geist-mono` |
@@ -63,59 +81,81 @@
 
 | 속성 | 값 |
 |------|-----|
-| 배경 | `--cell-selected` |
-| 텍스트 색상 | `--cell-selected-foreground` |
-| 그림자 | `--shadow-cell-selected` (inset 2px border) |
+| 배경 | `--cell-selected` (파란 음영, 가장 진함) |
+| 텍스트 색상 | `--cell-selected-foreground` (11.38:1) |
+| 그림자 | **`--shadow-cell-selected` (inset 2px 잉크 링) — 필수, 제거 금지** |
 | z-index | `--z-cell-highlight` (20) |
 | 트랜지션 | background, box-shadow `--duration-fast` |
+
+> 링 대비는 배경 대비 **5.54:1**(라이트) / **4.13:1**(다크)로, 배경색만으로 판별이 어려운
+> 환경에서도 선택 위치가 항상 읽힌다. 이 링이 selected를 same-number와 가르는 유일한 형태 신호다.
 
 ### 2.5 같은 행/열/박스 하이라이트 (Highlighted)
 
 | 속성 | 값 |
 |------|-----|
-| 배경 | `--cell-highlighted` |
+| 배경 | `--cell-highlighted` — **무채색 음영** (파란 계열 아님) |
 | 텍스트 색상 | 기존 상태 유지 |
 | 보더 | 없음 |
 | 트랜지션 | background `--duration-fast` |
+
+> v1에서는 highlighted/same-number/selected가 전부 hue 250 파란 계열이라 명도만으로 갈렸다.
+> v2는 highlighted만 **무채색축**으로 옮겨 색상축 자체를 분리한다.
 
 ### 2.6 같은 숫자 하이라이트 (Same Number)
 
 | 속성 | 값 |
 |------|-----|
-| 배경 | `--cell-same-number` |
+| 배경 | `--cell-same-number` (파란 음영, 중간) |
 | 텍스트 색상 | 기존 상태 유지 |
-| 폰트 가중치 | 기존 + Bold 강조 (700) |
+| 폰트 가중치 | **Bold 강조 (700) ← 비색상 구분 신호** |
 | 트랜지션 | background `--duration-fast` |
 
-### 2.7 에러 (Error)
+### 2.7 에러 (Error) — "빨간펜 첨삭"
 
 | 속성 | 값 |
 |------|-----|
 | 배경 | `--cell-error` |
-| 텍스트 색상 | `--cell-error-foreground` |
+| 텍스트 색상 | `--cell-error-foreground` (5.34:1) |
+| **텍스트 장식** | **`underline decoration-2 underline-offset-4` ← 비색상 구분 신호 (v2 신규)** |
 | 폰트 크기 | `--text-cell` (24px) |
 | 폰트 가중치 | 500 |
 | 입력 애니메이션 | `animate-cell-error-shake` |
+| ARIA | `aria-invalid="true"` |
 | 지속 | 에러 상태는 올바른 숫자 입력 또는 삭제까지 유지 |
+
+> 오류는 **즉시** 오류로 읽혀야 하므로 신호가 4겹이다: 빨간 배경 + 빨간 잉크 + 밑줄 + shake.
+> 이 중 색을 뺀 3겹(밑줄·shake·aria)만으로도 오류 판별이 가능해야 한다.
 
 ### 2.8 잠금 (Locked)
 
 | 속성 | 값 |
 |------|-----|
 | 배경 | `--cell-locked` |
+| **패턴** | **`.cell-hatch` 대각 45° 빗금 — v2에서 필수 (선택사항 아님)** |
 | 아이콘 | `Lock` (Lucide), 16px, 중앙 배치 |
-| 아이콘 색상 | `--cell-locked-foreground` |
+| 아이콘 색상 | `--cell-locked-foreground` (4.82:1) |
 | 숫자 | 표시 안 함 |
 | 커서 | not-allowed |
 | 탭 동작 | 잠금 팝오버 표시 (`lock-popover.md` 참조) |
-| opacity | 0.6 |
-| 패턴 | 대각선 빗금 패턴 (선택사항, CSS background) |
+| ~~opacity~~ | **제거** — 페이퍼 톤은 투명도로 상태를 표현하지 않는다. 빗금이 대신한다 |
+
+```css
+/* globals.css */
+.cell-hatch {
+  background-image: repeating-linear-gradient(
+    45deg,
+    transparent 0 3px,
+    color-mix(in oklch, var(--cell-locked-foreground) 22%, transparent) 3px 4px
+  );
+}
+```
 
 ### 2.9 완성 플래시 (Completed)
 
 | 속성 | 값 |
 |------|-----|
-| 배경 | `--cell-completed` → `--cell-default` (애니메이션) |
+| 배경 | `--cell-completed` (v2: 초록 → **황토 스탬프 톤**) → `--cell-default` (애니메이션) |
 | 애니메이션 | `animate-cell-complete-flash` (500ms) |
 | 적용 대상 | 완성된 행/열/박스의 모든 셀 |
 | 트리거 | 행, 열, 또는 3×3 박스가 1-9로 완성될 때 |
@@ -143,6 +183,28 @@
 │ 7  │ 8  │ 9  │
 └────┴────┴────┘
 ```
+
+---
+
+## 2.11 비색상 신호 요약 (페이퍼 톤 필수 검증표)
+
+**색을 전부 회색조로 바꿔도 아래 신호만으로 모든 상태가 구별되어야 한다.**
+QA 시 브라우저 필터 `grayscale(1)`를 걸고 확인한다.
+
+| 상태 | 배경 색상축 | 배경 명도(L) | 링 | 숫자 굵기 | 밑줄 | 빗금 | 아이콘 |
+|------|:---------:|:-----------:|:--:|:--------:|:----:|:----:|:-----:|
+| default | 종이 | 0.99 | — | — | — | — | — |
+| given | 종이 | 0.99 | — | **700** | — | — | — |
+| filled | 종이 | 0.99 | — | 500 | — | — | — |
+| selected | 파랑 | **0.86** | **2px** | 상속 | — | — | — |
+| same-number | 파랑 | 0.905 | — | **700** | — | — | — |
+| highlighted | **무채색** | 0.955 | — | 상속 | — | — | — |
+| error | 빨강 | 0.895 | — | 500 | **✓** | — | — |
+| locked | 무채색 | 0.925 | — | — | — | **✓** | **Lock** |
+| completed | 황토 | 0.93 | — | 상속 | — | — | — |
+
+> 회색조에서 selected(가장 어두운 배경 + 링) → same-number(Bold) → highlighted(가장 옅음)
+> 순으로 확실히 갈린다. error는 밑줄, locked는 빗금+아이콘으로 색 없이도 즉시 읽힌다.
 
 ---
 

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -944,28 +944,39 @@ export const MEDAL_COLORS = {
 ## 16. 구현 체크리스트 (Frontend 인계용)
 
 ```
-[ ] globals.css :root 값 교체              → §13.1
-[ ] globals.css .dark 값 교체              → §13.2
-[ ] globals.css .paper-bg 추가             → §14.1
-[ ] globals.css .cell-hatch 추가           → §12.1
-[ ] globals.css 삭제: .home-mesh-bg, .sudoku-grid-bg, .gradient-*,
+[x] globals.css :root 값 교체              → §13.1
+[x] globals.css .dark 값 교체              → §13.2
+[x] globals.css .paper-bg 추가             → §14.1
+[x] globals.css .cell-hatch 추가           → §12.1
+[x] globals.css 삭제: .home-mesh-bg, .sudoku-grid-bg, .gradient-*,
     .card-glow-*, .text-gradient-brand, .animate-text-shimmer,
     .animate-float-slow, @keyframes shimmer, @keyframes float-slow,
     @media(forced-colors) 폴백           → §14.1, §14.2, §14.3
-[ ] AppLayout.tsx 배경 레이어 1개로       → §14.1
-[ ] Header.tsx backdrop-blur 제거          → §14.1
-[ ] BrandWordmark.tsx 단색 + 세리프        → §14.2
-[ ] AppLogo.tsx 그라데이션 점 삭제         → §14.2
-[ ] HomeContent.tsx 스파클 뱃지 → 간행 캡션 → §14.2
-[ ] difficulty-data.ts level/toneClass     → §14.3
-[ ] DifficultyCard.tsx pip 게이지 + 괘선   → §14.3
-[ ] Cell.tsx 오류 밑줄 + 빗금 (2줄)        → §12.1
-[ ] NumberPad.tsx 버튼 보더 1px 추가       → §15.3
-[ ] RankingPodium.tsx 글로우 2겹 삭제      → §14.4
-[ ] ranking-utils.ts MEDAL_* 교체          → §14.4
-[ ] DifficultyTabs/RankingList 잉크 밑줄   → §14.4
-[ ] LoginBanner/ContinueBanner 평면화      → §14.5
-[ ] layout.tsx themeColor "#15120f"        → §13.3
-[ ] layout.tsx Instrument Serif (선택)     → §3.1
-[ ] Lighthouse 재측정: A11y ≥93, Perf ≥97
+[x] AppLayout.tsx 배경 레이어 1개로       → §14.1
+[x] Header.tsx backdrop-blur 제거          → §14.1
+[x] BrandWordmark.tsx 단색 (세리프 미채택 → §16.1)  → §14.2
+[x] AppLogo.tsx 그라데이션 점 삭제         → §14.2
+[x] HomeContent.tsx 스파클 뱃지 → 간행 캡션 → §14.2
+[x] difficulty-data.ts level/toneClass     → §14.3
+[x] DifficultyCard.tsx pip 게이지 + 괘선   → §14.3
+[x] Cell.tsx 오류 밑줄 + 빗금 (2줄)        → §12.1
+[x] NumberPad.tsx 버튼 보더 1px 추가       → §15.3
+[x] RankingPodium.tsx 글로우 2겹 삭제      → §14.4
+[x] ranking-utils.ts MEDAL_* 교체          → §14.4
+[x] DifficultyTabs/RankingList 잉크 밑줄   → §14.4
+[x] LoginBanner/ContinueBanner 평면화      → §14.5
+[x] layout.tsx themeColor "#15120f"        → §13.3
+[ ] layout.tsx Instrument Serif            → **미채택** (§16.1)
+[ ] Lighthouse 재측정: A11y ≥93, Perf ≥97  → 배포 후 측정 (Infra)
 ```
+
+### 16.1 구현 시 스펙과 다르게 처리한 3건
+
+| 항목 | 스펙 | 구현 | 이유 |
+|------|------|------|------|
+| **Instrument Serif** | 선택적·권장 | **미채택.** 워드마크는 Geist Sans + `tracking-[0.14em]` + `font-normal` | 앱이 이미 Geist Sans · Geist Mono · Noto Sans KR 3종을 싣고 있다. 라틴 6글자 2곳을 위해 4번째 패밀리를 더하는 건 PWA 페이로드 대비 이득이 낮다. §3.1이 명시한 대체안을 그대로 적용했다. |
+| **간행 캡션 문구** | `DAILY PUZZLE · NO.{stageNo}` | `DAILY PUZZLE · 50 STAGES` (`STAGE_RANGES` 마지막 `endStage`에서 산출) | 홈 히어로는 특정 스테이지에 묶이지 않아 `stageNo`가 존재하지 않는다. 진행 중 스테이지는 이미 바로 아래 `ContinueBanner`가 표시한다. |
+| **`--shadow-xs/sm/md/lg` 토큰** | §6 표에 정의 | `:root`에 넣지 않음. `--shadow-board` · `--shadow-cell-selected` · `--shadow-numpad` · `--shadow-xl` 4종만 유지 | Tailwind v4의 `shadow-*` 유틸리티는 빌드 타임에 값을 인라인하므로 `:root` 재정의를 읽지 않는다. 실제로 `var()`로 참조되는 4개만 살렸다. |
+
+> 워드마크에는 `font-sans`가 아니라 `font-[family-name:var(--font-geist-sans)]`를 쓴다.
+> `@theme inline`의 `--font-sans`가 자기 참조라 비어 있어 `font-sans`는 Noto Sans KR로 떨어진다.

--- a/docs/design/design-system.md
+++ b/docs/design/design-system.md
@@ -3,6 +3,12 @@
 > Sudoku Web App의 모든 시각 요소를 정의하는 단일 진실 원천(Single Source of Truth).
 > Frontend 에이전트는 이 문서와 `globals.css`의 CSS 변수를 참조하여 구현한다.
 
+> **v2 — 페이퍼 / 퍼즐북 톤 (2026-08)**
+> 기존 v1은 메시 그라데이션 배경 + 무지개 난이도 색으로 "AI 생성물" 인상이 강했다.
+> v2는 **따뜻한 오프화이트 종이 + 잉크**로 전면 재정립한다. 그라데이션은 전면 배제.
+> **토큰 이름은 전부 그대로 두고 값만 교체**한다 → 컴포넌트 수정 최소화.
+> 마이그레이션 대조표는 §13, 장식 요소 처리는 §14 참조.
+
 ---
 
 ## 1. 디자인 원칙
@@ -14,6 +20,17 @@
 | **직관적 상태 표현** | 셀 상태(잠금, 에러, 선택 등)가 색상+형태로 즉시 인지 가능 |
 | **접근성** | 색상 대비 WCAG AA 이상, 터치 타겟 최소 44px |
 | **일관성** | 디자인 토큰 기반, 임의 값(magic number) 사용 금지 |
+| **인쇄물 감성 (v2)** | 종이 · 잉크 · 괘선. 그라데이션 · 글로우 · 블러 금지 |
+
+### 1.1 페이퍼 톤 3원칙 (v2)
+
+1. **면이 아니라 선으로 나눈다** — 카드/섹션 구분은 배경색 대신 1px 괘선(`--border`).
+2. **색은 기능일 때만 쓴다** — 장식용 색 금지. 색이 붙는 곳은 셀 상태·에러·펜 잉크뿐.
+3. **깊이 대신 인쇄** — `blur` / `glow` / 큰 `box-shadow` 금지. 그림자는 1~2px 오프셋까지.
+
+**금지 목록** (v2에서 코드베이스에 남아 있으면 안 되는 것):
+`linear-gradient` / `radial-gradient` 로 채운 면, `background-clip: text`,
+`backdrop-blur-*`, `blur-2xl` 등 데코 블러, 색상환을 넓게 쓰는 다색 팔레트.
 
 ---
 
@@ -21,56 +38,124 @@
 
 모든 색상은 **oklch** 색상 공간으로 정의한다 (shadcn/ui 기본 컨벤션 유지).
 
-### 2.1 브랜드 / 게임 색상
+### 2.0 팔레트 개요
+
+페이퍼 톤은 **두 축**만 쓴다.
+
+| 축 | 색상환 | 역할 |
+|----|--------|------|
+| **종이 / 잉크** (주축) | hue 65~85, chroma 0.004~0.016 | 배경·표면·텍스트·괘선 전부. 사실상 무채색이지만 미세한 온기를 가진다 |
+| **펜 잉크 블루** (보조축) | hue 250, chroma 0.045~0.10 | 유저가 "써넣은" 값, 선택, 같은 숫자 — 인터랙션 신호 전용 |
+| **첨삭 레드** (예외축) | hue 28~30 | 오류 **한 곳에만**. 다른 어떤 용도로도 쓰지 않는다 |
+
+> 왜 파랑인가: 인쇄된 문제(검정 잉크)와 **내가 볼펜으로 써넣은 답**(파랑)이 실제 문제집에서 구분되는 방식 그대로다. 기존 브랜드 hue(250)를 유지하므로 값 교체만으로 끝난다.
+
+### 2.1 shadcn/ui 기본 토큰
 
 | 토큰명 | Light Mode | Dark Mode | 용도 |
 |--------|------------|-----------|------|
-| `--sudoku-primary` | `oklch(0.55 0.18 250)` | `oklch(0.68 0.16 250)` | 주 브랜드 색상 (파란색 계열) |
-| `--sudoku-primary-foreground` | `oklch(0.98 0 0)` | `oklch(0.98 0 0)` | 브랜드 색상 위 텍스트 |
-| `--sudoku-accent` | `oklch(0.65 0.15 250)` | `oklch(0.55 0.13 250)` | 보조 강조 (호버, 포커스 링) |
+| `--background` | `oklch(0.968 0.008 85)` | `oklch(0.185 0.008 70)` | 페이지 = 종이 / 갱지 |
+| `--foreground` | `oklch(0.24 0.012 65)` | `oklch(0.92 0.012 85)` | 본문 잉크 |
+| `--card` | `oklch(0.985 0.006 85)` | `oklch(0.235 0.008 70)` | 카드 = 종이 위 한 장 더 |
+| `--card-foreground` | `oklch(0.24 0.012 65)` | `oklch(0.92 0.012 85)` | 카드 텍스트 |
+| `--popover` | `oklch(0.985 0.006 85)` | `oklch(0.235 0.008 70)` | 팝오버 배경 |
+| `--popover-foreground` | `oklch(0.24 0.012 65)` | `oklch(0.92 0.012 85)` | 팝오버 텍스트 |
+| `--primary` | `oklch(0.24 0.012 65)` | `oklch(0.92 0.012 85)` | 잉크 (=foreground) |
+| `--primary-foreground` | `oklch(0.98 0.005 85)` | `oklch(0.18 0.010 70)` | 잉크 위 종이색 |
+| `--secondary` | `oklch(0.935 0.007 85)` | `oklch(0.285 0.008 70)` | 보조 면 |
+| `--secondary-foreground` | `oklch(0.24 0.012 65)` | `oklch(0.92 0.012 85)` | 보조 면 텍스트 |
+| `--muted` | `oklch(0.935 0.007 85)` | `oklch(0.285 0.008 70)` | 음영 면 |
+| `--muted-foreground` | `oklch(0.50 0.010 65)` | `oklch(0.70 0.010 80)` | 보조 텍스트 (연필 톤) |
+| `--accent` | `oklch(0.925 0.008 85)` | `oklch(0.30 0.008 70)` | 호버 면 |
+| `--accent-foreground` | `oklch(0.24 0.012 65)` | `oklch(0.92 0.012 85)` | 호버 텍스트 |
+| `--destructive` | `oklch(0.47 0.17 28)` | `oklch(0.68 0.15 28)` | 파괴적 액션 |
+| `--border` | `oklch(0.86 0.010 85)` | `oklch(0.34 0.008 70)` | 괘선 (장식적 구분선) |
+| `--input` | `oklch(0.64 0.008 80)` | `oklch(0.54 0.008 70)` | **입력 필드 테두리 — 3:1 확보용으로 border보다 진하다** |
+| `--ring` | `oklch(0.42 0.09 250)` | `oklch(0.72 0.095 250)` | 포커스 링 (펜 잉크) |
+| `--radius` | `0.375rem` (6px) | 동일 | **10px → 6px. 인쇄물은 덜 둥글다** |
 
-### 2.2 셀 상태 색상
+> `--border`(1.4:1)는 **장식적 구분선 전용**이다. 테두리가 요소의 유일한 경계 표시일 때(입력 필드, outline 버튼)는 반드시 `--input`(3.07:1)을 쓴다. §9.2 참조.
+
+**차트/사이드바 토큰** (현재 미사용, 톤 일관성 유지용):
+
+```css
+/* :root */
+--chart-1: oklch(0.86 0.008 80); --chart-2: oklch(0.66 0.008 80);
+--chart-3: oklch(0.52 0.010 70); --chart-4: oklch(0.40 0.012 70);
+--chart-5: oklch(0.28 0.014 65);
+--sidebar: oklch(0.985 0.006 85); --sidebar-foreground: oklch(0.24 0.012 65);
+--sidebar-primary: oklch(0.24 0.012 65); --sidebar-primary-foreground: oklch(0.98 0.005 85);
+--sidebar-accent: oklch(0.925 0.008 85); --sidebar-accent-foreground: oklch(0.24 0.012 65);
+--sidebar-border: oklch(0.86 0.010 85); --sidebar-ring: oklch(0.42 0.09 250);
+
+/* .dark */
+--chart-1: oklch(0.30 0.008 70); --chart-2: oklch(0.46 0.008 70);
+--chart-3: oklch(0.60 0.010 75); --chart-4: oklch(0.74 0.010 80);
+--chart-5: oklch(0.88 0.012 85);
+--sidebar: oklch(0.235 0.008 70); --sidebar-foreground: oklch(0.92 0.012 85);
+--sidebar-primary: oklch(0.92 0.012 85); --sidebar-primary-foreground: oklch(0.18 0.010 70);
+--sidebar-accent: oklch(0.30 0.008 70); --sidebar-accent-foreground: oklch(0.92 0.012 85);
+--sidebar-border: oklch(0.34 0.008 70); --sidebar-ring: oklch(0.72 0.095 250);
+```
+
+### 2.2 브랜드 / 게임 색상
 
 | 토큰명 | Light Mode | Dark Mode | 용도 |
 |--------|------------|-----------|------|
-| `--cell-default` | `oklch(1 0 0)` | `oklch(0.22 0 0)` | 빈 셀 배경 |
-| `--cell-default-foreground` | `oklch(0.25 0 0)` | `oklch(0.92 0 0)` | 유저 입력 숫자 |
-| `--cell-given` | `oklch(0.97 0 0)` | `oklch(0.26 0 0)` | 초기 제공 숫자 셀 배경 |
-| `--cell-given-foreground` | `oklch(0.15 0 0)` | `oklch(0.95 0 0)` | 초기 제공 숫자 (Bold) |
-| `--cell-selected` | `oklch(0.88 0.08 250)` | `oklch(0.35 0.10 250)` | 현재 선택된 셀 |
-| `--cell-selected-foreground` | `oklch(0.20 0 0)` | `oklch(0.95 0 0)` | 선택된 셀 숫자 |
-| `--cell-highlighted` | `oklch(0.93 0.04 250)` | `oklch(0.28 0.06 250)` | 같은 행/열/박스 하이라이트 |
-| `--cell-same-number` | `oklch(0.90 0.06 250)` | `oklch(0.32 0.08 250)` | 같은 숫자 하이라이트 |
-| `--cell-error` | `oklch(0.90 0.10 25)` | `oklch(0.30 0.10 25)` | 에러 셀 배경 |
-| `--cell-error-foreground` | `oklch(0.50 0.20 25)` | `oklch(0.70 0.18 25)` | 에러 숫자 |
-| `--cell-locked` | `oklch(0.94 0 0)` | `oklch(0.24 0 0)` | 잠금 칸 배경 |
-| `--cell-locked-foreground` | `oklch(0.55 0 0)` | `oklch(0.60 0 0)` | 잠금 칸 아이콘/텍스트 |
-| `--cell-completed` | `oklch(0.90 0.10 145)` | `oklch(0.35 0.10 145)` | 완성된 행/열/박스 (잠깐 플래시) |
+| `--sudoku-primary` | `oklch(0.42 0.09 250)` | `oklch(0.72 0.095 250)` | 펜 잉크 블루 — CTA, 활성 상태, 포커스 |
+| `--sudoku-primary-foreground` | `oklch(0.98 0.005 85)` | `oklch(0.18 0.010 70)` | 펜 잉크 위 텍스트 |
+| `--sudoku-accent` | `oklch(0.52 0.08 250)` | `oklch(0.62 0.085 250)` | 보조 강조 (호버) |
 
-### 2.3 보드 색상
+### 2.3 셀 상태 색상
 
 | 토큰명 | Light Mode | Dark Mode | 용도 |
 |--------|------------|-----------|------|
-| `--board-border` | `oklch(0.25 0 0)` | `oklch(0.80 0 0)` | 보드 외곽선 + 3×3 박스 구분선 |
-| `--board-border-thin` | `oklch(0.80 0 0)` | `oklch(0.35 0 0)` | 셀 간 얇은 구분선 |
-| `--board-bg` | `oklch(0.97 0 0)` | `oklch(0.18 0 0)` | 보드 전체 배경 |
+| `--cell-default` | `oklch(0.99 0.004 85)` | `oklch(0.235 0.008 70)` | 셀 배경 (보드 = 가장 흰 종이) |
+| `--cell-default-foreground` | `oklch(0.45 0.10 250)` | `oklch(0.78 0.09 250)` | **유저 입력 = 볼펜 파랑** |
+| `--cell-given` | `oklch(0.99 0.004 85)` | `oklch(0.235 0.008 70)` | **default와 동일 — 인쇄된 문제는 배경이 같다** |
+| `--cell-given-foreground` | `oklch(0.22 0.012 65)` | `oklch(0.94 0.008 85)` | **초기 제공 = 인쇄 잉크 (Bold)** |
+| `--cell-selected` | `oklch(0.86 0.055 250)` | `oklch(0.375 0.075 250)` | 선택 셀 |
+| `--cell-selected-foreground` | `oklch(0.22 0.012 65)` | `oklch(0.95 0.008 85)` | 선택 셀 숫자 |
+| `--cell-highlighted` | `oklch(0.955 0.005 85)` | `oklch(0.295 0.005 70)` | 같은 행/열/박스 — **무채색 음영** |
+| `--cell-same-number` | `oklch(0.905 0.045 250)` | `oklch(0.335 0.06 250)` | 같은 숫자 — **파란 음영 + Bold** |
+| `--cell-error` | `oklch(0.895 0.055 30)` | `oklch(0.325 0.08 28)` | 오류 셀 배경 |
+| `--cell-error-foreground` | `oklch(0.47 0.17 28)` | `oklch(0.76 0.14 28)` | 오류 숫자 (첨삭 빨간펜) |
+| `--cell-locked` | `oklch(0.925 0.005 85)` | `oklch(0.205 0.005 70)` | 잠금 칸 (+ 빗금 패턴 필수) |
+| `--cell-locked-foreground` | `oklch(0.50 0.008 65)` | `oklch(0.62 0.008 70)` | 잠금 아이콘 |
+| `--cell-completed` | `oklch(0.93 0.045 80)` | `oklch(0.34 0.05 80)` | 완성 플래시 (초록 → **황토 스탬프 톤**) |
 
-### 2.4 난이도 색상
+> **`--cell-given`을 `--cell-default`와 같게 두는 것은 의도된 설계다.** 실제 문제집에서 인쇄된 숫자와 빈 칸은 배경이 같고, 잉크의 종류로만 구분된다. 구분은 색+굵기가 담당한다 → given = 검정 잉크 Bold(16.85:1) / filled = 파란 볼펜 Medium(7.21:1). 두 톤은 명도·색상이 모두 달라 색각이상에서도 굵기로 분리된다.
 
-| 토큰명 | 값 | 용도 |
-|--------|-----|------|
-| `--difficulty-easy` | `oklch(0.72 0.16 145)` | 쉬움 (초록) |
-| `--difficulty-medium` | `oklch(0.75 0.15 85)` | 보통 (노랑) |
-| `--difficulty-hard` | `oklch(0.68 0.18 50)` | 어려움 (주황) |
-| `--difficulty-expert` | `oklch(0.60 0.20 25)` | 전문가 (빨강) |
+### 2.4 난이도 색상 — 무채색 명도 사다리
+
+**v2에서 난이도는 색으로 구분하지 않는다.** 무지개(초록/노랑/주황/빨강)를 폐기하고,
+**진해질수록 어렵다**는 단일 잉크 사다리로 바꾼다. 실제 구분 신호는 §14.3의 **pip 게이지(■■□□)** 가 담당하고, 이 토큰은 텍스트/눈금 색으로만 쓰인다.
+
+| 토큰명 | Light Mode | Dark Mode | 의미 |
+|--------|------------|-----------|------|
+| `--difficulty-easy` | `oklch(0.53 0.010 65)` | `oklch(0.62 0.010 85)` | 옅은 잉크 |
+| `--difficulty-medium` | `oklch(0.44 0.012 65)` | `oklch(0.72 0.010 85)` | ↓ |
+| `--difficulty-hard` | `oklch(0.36 0.014 65)` | `oklch(0.82 0.010 85)` | ↓ |
+| `--difficulty-expert` | `oklch(0.25 0.016 65)` | `oklch(0.94 0.010 85)` | 가장 진한 잉크 |
+
+> 라이트는 진해지고 다크는 밝아진다 — 두 모드 모두 "잉크가 세진다"로 읽힌다.
+> 네 값 모두 배경 대비 4.8:1 이상(§9.2)이라 `text-difficulty-*` 를 소형 텍스트에 그대로 써도 AA를 만족한다.
 
 ### 2.5 기능 색상
 
 | 토큰명 | Light Mode | Dark Mode | 용도 |
 |--------|------------|-----------|------|
-| `--success` | `oklch(0.72 0.16 145)` | `oklch(0.65 0.14 145)` | 성공/완료 |
-| `--warning` | `oklch(0.75 0.15 85)` | `oklch(0.68 0.13 85)` | 경고 |
-| `--info` | `oklch(0.65 0.15 250)` | `oklch(0.58 0.13 250)` | 정보/힌트 |
+| `--success` | `oklch(0.48 0.09 150)` | `oklch(0.70 0.10 150)` | 성공/완료 (채도 낮춘 잉크 그린) |
+| `--warning` | `oklch(0.53 0.09 75)` | `oklch(0.76 0.095 75)` | 경고 · 별점 채움 (황토/금박 스탬프) |
+| `--info` | `oklch(0.45 0.09 250)` | `oklch(0.72 0.09 250)` | 정보/힌트 (펜 잉크와 동일 계열) |
+
+### 2.6 보드 색상
+
+| 토큰명 | Light Mode | Dark Mode | 용도 |
+|--------|------------|-----------|------|
+| `--board-border` | `oklch(0.26 0.012 65)` | `oklch(0.78 0.010 85)` | 외곽선 + 3×3 굵은 괘선 |
+| `--board-border-thin` | `oklch(0.64 0.008 80)` | `oklch(0.54 0.008 70)` | 셀 간 얇은 괘선 (**3:1 확보를 위해 v1보다 진함**) |
+| `--board-bg` | `oklch(0.968 0.008 85)` | `oklch(0.185 0.008 70)` | 보드 배경 = 종이 |
 
 ---
 
@@ -78,13 +163,43 @@
 
 ### 3.1 폰트 패밀리
 
-| 용도 | 폰트 | CSS 변수 |
-|------|-------|----------|
-| UI 텍스트 | Geist Sans | `--font-geist-sans` |
-| 셀 숫자 | Geist Mono | `--font-geist-mono` |
-| 메모 숫자 | Geist Mono | `--font-geist-mono` |
+| 용도 | 폰트 | CSS 변수 | 비고 |
+|------|-------|----------|------|
+| UI 텍스트 (한글 포함) | Geist Sans | `--font-geist-sans` | 변경 없음 |
+| 셀 숫자 · 메모 · 타이머 | Geist Mono | `--font-geist-mono` | 변경 없음 |
+| **워드마크 · 라틴 디스플레이** | **Instrument Serif 400** | `--font-serif` | **v2 신규, 아래 조건부** |
+
+#### 세리프 추가 규칙 (선택적, 권장)
+
+- **무엇**: `Instrument_Serif`, weight 400 단일, `subsets: ["latin"]`, `display: "swap"`.
+- **왜**: 페이퍼 톤의 인상은 배경색보다 **활자**가 만든다. 산세리프 워드마크는 그대로 두면 여전히 "앱"으로 읽힌다. 단일 웨이트 라틴 서브셋만 로드하므로 추가 payload는 **1 파일 ≈ 25KB woff2** 수준이다.
+- **어디에만**: **라틴 문자열에만.** 구체적으로 딱 두 곳.
+  - `BrandWordmark` (`SUDOKU`)
+  - `AppLogo` (`SUDOKU`)
+- **어디에 쓰면 안 되는가**: **한글에 절대 쓰지 않는다.** Instrument Serif는 한글 글리프가 없어 fallback이 발생하고 줄 높이가 깨진다. 본문·버튼·난이도 라벨·헤딩은 전부 Geist Sans 유지.
+- **성능 가드**: Lighthouse Performance가 99 → 97 미만으로 떨어지면 세리프를 되돌리고 워드마크는 Geist Sans + `tracking-[0.18em]` + `font-normal`로 처리한다. 톤의 90%는 색·괘선·그라데이션 제거에서 이미 나오므로 세리프는 **없어도 스펙을 만족**한다.
+
+```ts
+// src/app/layout.tsx — 추가분만
+import { Instrument_Serif } from "next/font/google";
+
+const instrumentSerif = Instrument_Serif({
+  variable: "--font-serif",
+  weight: "400",
+  subsets: ["latin"],
+  display: "swap",
+});
+// <html className={`${geistSans.variable} ${geistMono.variable} ${instrumentSerif.variable} ...`}>
+```
+
+```css
+/* globals.css — @theme inline 에 1줄 추가 */
+--font-serif: var(--font-serif);
+```
 
 ### 3.2 타이포그래피 스케일
+
+v1에서 변경 없음.
 
 | 토큰명 | 크기 | Line Height | Weight | 용도 |
 |--------|------|-------------|--------|------|
@@ -104,7 +219,7 @@
 
 ## 4. 간격 시스템 (Spacing)
 
-4px 기반 간격 체계. Tailwind 기본 spacing과 호환.
+v1에서 변경 없음. (4px 기반, Tailwind 기본 spacing과 호환)
 
 ### 4.1 기본 간격 스케일
 
@@ -140,56 +255,53 @@
 ```
 보드 전체 너비 (모바일):
 = (cell-size × 9) + (board-gap-thin × 6) + (board-gap-thick × 2) + (board-border-width × 2)
-= (40 × 9) + (1 × 6) + (2 × 2) + (3 × 2)
-= 360 + 6 + 4 + 6
-= 376px → 최적 뷰포트(375px)에 딱 맞음
+= (40 × 9) + (1 × 6) + (2 × 2) + (3 × 2) = 376px → 최적 뷰포트(375px)에 딱 맞음
 
-보드 전체 너비 (태블릿):
-= (48 × 9) + (1 × 6) + (2 × 2) + (3 × 2)
-= 432 + 6 + 4 + 6
-= 448px
-
-보드 전체 너비 (데스크톱):
-= (56 × 9) + (1 × 6) + (2 × 2) + (3 × 2)
-= 504 + 6 + 4 + 6
-= 520px
+태블릿(48px): 448px   데스크톱(56px): 520px
 ```
 
 ---
 
 ## 5. Border Radius (모서리 둥글기)
 
-| 토큰명 | 값 | 용도 |
-|--------|-----|------|
-| `--radius-none` | 0px | 셀 (격자형이므로 둥글기 없음) |
-| `--radius-sm` | 6px | 작은 버튼, 태그 |
-| `--radius-md` | 8px | 카드, 입력 필드 |
-| `--radius-lg` | 10px | 보드 외곽, 모달 |
-| `--radius-xl` | 14px | 큰 카드, 팝오버 |
-| `--radius-full` | 9999px | 원형 (아바타, 배지) |
+**v2에서 기준값이 10px → 6px 로 축소된다.** 인쇄물은 모서리가 덜 둥글다.
+`--radius` 한 줄만 바꾸면 `--radius-sm/md/lg/xl/...` 파생값이 전부 따라온다.
 
-> shadcn/ui의 `--radius` 변수(0.625rem = 10px)를 기반으로 계산됨.
+| 토큰명 | v1 | **v2** | 용도 |
+|--------|-----|--------|------|
+| `--radius` (기준) | 0.625rem (10px) | **0.375rem (6px)** | shadcn 파생 기준 |
+| `--radius-sm` (×0.6) | 6px | **3.6px** | 작은 버튼, 태그 |
+| `--radius-md` (×0.8) | 8px | **4.8px** | 숫자패드 버튼, 입력 필드 |
+| `--radius-lg` (×1.0) | 10px | **6px** | 보드 외곽, 카드, 모달 |
+| `--radius-xl` (×1.4) | 14px | **8.4px** | 난이도 카드, 팝오버 |
+| `--radius-2xl` (×1.8) | 18px | **10.8px** | — |
+| — | — | `0` | 셀 (격자형이므로 둥글기 없음) |
+| `--radius-full` | 9999px | 9999px | 원형 (아바타). **pill 뱃지에는 쓰지 않는다 → §14.2** |
 
 ---
 
 ## 6. 그림자 시스템 (Shadows)
 
-| 토큰명 | 값 | 용도 |
-|--------|-----|------|
-| `--shadow-xs` | `0 1px 2px oklch(0 0 0 / 0.05)` | 미세한 깊이감 |
-| `--shadow-sm` | `0 1px 3px oklch(0 0 0 / 0.08), 0 1px 2px oklch(0 0 0 / 0.04)` | 버튼, 입력 필드 |
-| `--shadow-md` | `0 4px 6px oklch(0 0 0 / 0.07), 0 2px 4px oklch(0 0 0 / 0.04)` | 카드, 보드 |
-| `--shadow-lg` | `0 10px 15px oklch(0 0 0 / 0.08), 0 4px 6px oklch(0 0 0 / 0.04)` | 모달, 팝오버 |
-| `--shadow-xl` | `0 20px 25px oklch(0 0 0 / 0.10), 0 8px 10px oklch(0 0 0 / 0.04)` | 오버레이 |
-| `--shadow-board` | `0 2px 8px oklch(0 0 0 / 0.08), 0 0 0 3px oklch(0.25 0 0)` | 게임 보드 전용 |
-| `--shadow-cell-selected` | `inset 0 0 0 2px oklch(0.55 0.18 250)` | 선택된 셀 인셋 그림자 |
-| `--shadow-numpad` | `0 2px 4px oklch(0 0 0 / 0.06)` | 숫자패드 버튼 |
+**페이퍼 톤에서 그림자는 "떠 있음"이 아니라 "인쇄 자국"이다.** 흐림 반경을 크게 줄이고 오프셋을 1~2px로 고정한다. 글로우·컬러 그림자는 전부 폐기.
 
-> Dark Mode에서는 그림자 대신 보더/글로우로 깊이감 표현. `oklch(0 0 0 / ...)` 투명도를 `oklch(1 0 0 / ...)` 로 반전하여 미세한 글로우 효과 사용.
+| 토큰명 | Light | Dark | 용도 |
+|--------|-------|------|------|
+| `--shadow-xs` | `0 1px 0 oklch(0.24 0.012 65 / 0.05)` | `0 1px 0 oklch(0 0 0 / 0.3)` | 미세한 깊이감 |
+| `--shadow-sm` | `0 1px 2px oklch(0.24 0.012 65 / 0.07)` | `0 1px 2px oklch(0 0 0 / 0.35)` | 버튼, 입력 필드 |
+| `--shadow-md` | `0 1px 3px oklch(0.24 0.012 65 / 0.09)` | `0 1px 3px oklch(0 0 0 / 0.4)` | 카드 |
+| `--shadow-lg` | `0 2px 6px oklch(0.24 0.012 65 / 0.10)` | `0 2px 6px oklch(0 0 0 / 0.45)` | 팝오버 |
+| `--shadow-xl` | `0 8px 24px oklch(0.24 0.012 65 / 0.12), 0 2px 6px oklch(0.24 0.012 65 / 0.06)` | `0 8px 24px oklch(0 0 0 / 0.5), 0 2px 6px oklch(0 0 0 / 0.3)` | 모달 오버레이 |
+| `--shadow-board` | `0 1px 2px oklch(0.24 0.012 65 / 0.10), 0 0 0 2px oklch(0.26 0.012 65)` | `0 1px 2px oklch(0 0 0 / 0.4), 0 0 0 2px oklch(0.78 0.010 85)` | 게임 보드 (잉크 링) |
+| `--shadow-cell-selected` | `inset 0 0 0 2px oklch(0.42 0.09 250)` | `inset 0 0 0 2px oklch(0.72 0.095 250)` | 선택 셀 인셋 링 |
+| `--shadow-numpad` | `0 1px 0 oklch(0.24 0.012 65 / 0.08)` | `0 1px 0 oklch(0 0 0 / 0.35)` | 숫자패드 버튼 (평평하게) |
+
+> `--shadow-cell-selected`는 **장식이 아니라 접근성 장치**다. 선택 셀 배경 대비 5.54:1(라이트)로, 셀 배경색 차이가 미약해도 선택 위치가 항상 읽힌다. 절대 제거 금지. (§9.2, §12)
 
 ---
 
 ## 7. 애니메이션 & 트랜지션
+
+v1에서 변경 없음. 단, **§14의 장식 애니메이션 2종은 폐기**한다 (`animate-text-shimmer`, `animate-float-slow`).
 
 ### 7.1 Duration
 
@@ -209,21 +321,23 @@
 | `--ease-out` | `cubic-bezier(0, 0, 0.2, 1)` | 요소 진입 |
 | `--ease-bounce` | `cubic-bezier(0.34, 1.56, 0.64, 1)` | 바운스 (숫자 입력, 완성 효과) |
 
-### 7.3 주요 애니메이션
+### 7.3 주요 애니메이션 (유지)
 
 | 이름 | 설명 | 트리거 |
 |------|------|--------|
 | `cell-pop` | 숫자 입력 시 scale(0.9→1) 바운스 | 셀에 숫자 입력 |
-| `cell-error-shake` | X축 좌우 흔들림 (3회) | 잘못된 숫자 입력 |
-| `cell-complete-flash` | 배경색 초록 플래시 후 원래로 | 행/열/박스 완성 |
-| `board-complete-celebrate` | 전체 보드 살짝 scale up + 반짝임 | 퍼즐 완성 |
-| `modal-enter` | opacity(0→1) + translateY(20px→0) | 모달 표시 |
-| `modal-exit` | opacity(1→0) + translateY(0→10px) | 모달 닫기 |
-| `numpad-press` | scale(0.95→1) | 숫자패드 버튼 클릭 |
+| `cell-error-shake` | X축 좌우 흔들림 | 잘못된 숫자 입력 |
+| `cell-complete-flash` | 배경 황토 플래시 후 원래로 | 행/열/박스 완성 |
+| `board-complete-celebrate` | 전체 보드 살짝 scale up | 퍼즐 완성 (※ `filter: brightness` 스텝 제거 — §14.6) |
+| `modal-enter` / `modal-exit` | opacity + translateY | 모달 표시/닫기 |
+| `numpad-press` | scale(0.92→1) | 숫자패드 버튼 클릭 |
+| `bounce-in` / `star-scale-in` / `slide-down-fade` | 클리어 모달 연출 | 퍼즐 완성 |
 
 ---
 
 ## 8. Z-Index 스케일
+
+v1에서 변경 없음.
 
 | 토큰명 | 값 | 용도 |
 |--------|-----|------|
@@ -244,6 +358,8 @@
 
 ### 9.1 최소 터치 타겟
 
+v1에서 변경 없음.
+
 | 요소 | 최소 크기 | 권장 크기 |
 |------|----------|----------|
 | 셀 | 40×40px | 48×48px |
@@ -252,110 +368,604 @@
 | 일반 버튼 | 44×36px | 48×40px |
 | 아이콘 버튼 | 44×44px | 48×48px |
 
-### 9.2 색상 대비 (WCAG AA 기준)
+### 9.2 색상 대비 검증표 (WCAG 2.1)
 
-| 조합 | 대비율 | 판정 |
+> 전 조합을 oklch → sRGB 변환 후 WCAG 상대휘도 공식으로 **계산한 실측값**이다.
+> 기준: 본문 텍스트 **4.5:1**, 큰 텍스트(≥24px 또는 ≥18.66px Bold)·UI 컴포넌트/그래픽 **3:1**.
+
+#### 라이트 모드 — 텍스트
+
+| 전경 / 배경 | 대비 | 기준 | 판정 |
+|------|--------|------|------|
+| `--foreground` / `--background` | **15.02:1** | 4.5 | ✅ AAA |
+| `--foreground` / `--card` | **15.78:1** | 4.5 | ✅ AAA |
+| `--muted-foreground` / `--background` | **5.48:1** | 4.5 | ✅ AA |
+| `--muted-foreground` / `--card` | **5.76:1** | 4.5 | ✅ AA |
+| `--sudoku-primary` / `--background` | **7.69:1** | 4.5 | ✅ AAA |
+| `--sudoku-primary-foreground` / `--sudoku-primary` | **7.97:1** | 4.5 | ✅ AAA |
+| `--primary-foreground` / `--destructive` | **7.03:1** | 4.5 | ✅ AAA |
+| `--success` / `--background` | **5.71:1** | 4.5 | ✅ AA |
+| `--warning` / `--background` | **4.88:1** | 4.5 | ✅ AA |
+| `--info` / `--background` | **6.76:1** | 4.5 | ✅ AA |
+| `--destructive` / `--background` | **6.79:1** | 4.5 | ✅ AA |
+
+#### 라이트 모드 — 셀 숫자 (본문 기준 4.5:1)
+
+| 전경 / 배경 | 대비 | 판정 |
 |------|--------|------|
-| cell-given-foreground / cell-given | 14.5:1 | ✅ AAA |
-| cell-default-foreground / cell-default | 16.5:1 | ✅ AAA |
-| cell-error-foreground / cell-error | 4.6:1 | ✅ AA |
-| cell-locked-foreground / cell-locked | 4.8:1 | ✅ AA |
-| sudoku-primary-foreground / sudoku-primary | 7.2:1 | ✅ AAA |
+| `--cell-given-foreground` / `--cell-given` | **16.85:1** | ✅ AAA |
+| `--cell-default-foreground` / `--cell-default` | **7.21:1** | ✅ AAA |
+| `--cell-default-foreground` / `--cell-highlighted` | **6.51:1** | ✅ AAA |
+| `--cell-default-foreground` / `--cell-same-number` | **5.61:1** | ✅ AA |
+| `--cell-selected-foreground` / `--cell-selected` | **11.38:1** | ✅ AAA |
+| `--cell-given-foreground` / `--cell-selected` | **11.38:1** | ✅ AAA |
+| `--cell-error-foreground` / `--cell-error` | **5.34:1** | ✅ AA |
+| `--cell-locked-foreground` / `--cell-locked` | **4.82:1** | ✅ AA |
+| `--cell-given-foreground` / `--cell-completed` | **14.08:1** | ✅ AAA |
+| `--muted-foreground`(메모) / `--cell-default` | **5.84:1** | ✅ AA |
+| `--muted-foreground`(메모) / `--cell-highlighted` | **5.27:1** | ✅ AA |
+
+#### 라이트 모드 — 그래픽/UI (3:1)
+
+| 조합 | 대비 | 판정 |
+|------|--------|------|
+| `--board-border` / `--cell-default` (굵은 괘선) | **15.12:1** | ✅ |
+| `--board-border-thin` / `--cell-default` (얇은 괘선) | **3.02:1** | ✅ (v1 2.24:1 → 개선) |
+| `--input` / `--background` (입력 테두리) | **3.07:1** | ✅ (v1 1.39:1 → 개선) |
+| `--ring` / `--background` (포커스 링) | **7.69:1** | ✅ |
+| `--shadow-cell-selected` 링 / `--cell-selected` | **5.54:1** | ✅ |
+| `--border` / `--background` (장식 구분선) | 1.39:1 | ⚠️ 장식 전용 — 유일한 경계일 땐 `--input` 사용 |
+
+#### 라이트 모드 — 난이도 사다리 (`text-difficulty-*` 소형 텍스트)
+
+| 조합 | 대비 | 판정 |
+|------|--------|------|
+| `--difficulty-easy` / `--background` | **4.82:1** | ✅ AA |
+| `--difficulty-medium` / `--background` | **7.10:1** | ✅ AAA |
+| `--difficulty-hard` / `--background` | **9.93:1** | ✅ AAA |
+| `--difficulty-expert` / `--background` | **14.62:1** | ✅ AAA |
+
+#### 다크 모드
+
+| 전경 / 배경 | 대비 | 판정 |
+|------|--------|------|
+| `--foreground` / `--background` | **14.72:1** | ✅ AAA |
+| `--foreground` / `--card` | **13.17:1** | ✅ AAA |
+| `--muted-foreground` / `--background` | **6.98:1** | ✅ AA |
+| `--muted-foreground` / `--card` | **6.24:1** | ✅ AA |
+| `--sudoku-primary` / `--background` | **7.56:1** | ✅ AAA |
+| `--sudoku-primary-foreground` / `--sudoku-primary` | **7.63:1** | ✅ AAA |
+| `--cell-given-foreground` / `--cell-given` | **13.99:1** | ✅ AAA |
+| `--cell-default-foreground` / `--cell-default` | **8.38:1** | ✅ AAA |
+| `--cell-default-foreground` / `--cell-highlighted` | **6.98:1** | ✅ AAA |
+| `--cell-default-foreground` / `--cell-same-number` | **6.01:1** | ✅ AA |
+| `--cell-selected-foreground` / `--cell-selected` | **8.81:1** | ✅ AAA |
+| `--cell-error-foreground` / `--cell-error` | **5.67:1** | ✅ AA |
+| `--cell-locked-foreground` / `--cell-locked` | **4.92:1** | ✅ AA |
+| `--cell-given-foreground` / `--cell-completed` | **9.91:1** | ✅ AAA |
+| `--muted-foreground`(메모) / `--cell-default` | **6.24:1** | ✅ AA |
+| `--board-border` / `--cell-default` | **8.34:1** | ✅ |
+| `--board-border-thin` / `--cell-default` | **3.29:1** | ✅ (v1 1.81:1 → 개선) |
+| `--input` / `--background` | **3.68:1** | ✅ |
+| `--difficulty-easy` / `--background` | **5.12:1** | ✅ AA |
+| `--difficulty-medium` / `--background` | **7.52:1** | ✅ AAA |
+| `--difficulty-hard` / `--background` | **10.68:1** | ✅ AAA |
+| `--difficulty-expert` / `--background` | **15.64:1** | ✅ AAA |
+| `--success` / `--background` | **7.28:1** | ✅ AAA |
+| `--warning` / `--background` | **8.59:1** | ✅ AAA |
+| `--info` / `--background` | **7.56:1** | ✅ AAA |
+| `--destructive` / `--background` | **6.06:1** | ✅ AA |
+| `--primary-foreground` / `--destructive` | **6.12:1** | ✅ AA |
+
+#### 셀 상태 배경끼리의 대비는 3:1을 만족하지 않는다 — 의도된 것
+
+| 인접 상태 배경쌍 (Light) | 대비 |
+|------|--------|
+| selected / default | 1.48:1 |
+| same-number / default | 1.28:1 |
+| highlighted / default | 1.11:1 |
+| error / default | 1.36:1 |
+| locked / default | 1.21:1 |
+
+WCAG 1.4.11은 **상태를 색만으로 전달할 때** 3:1을 요구한다. 셀 상태 배경은 **보조 신호**이고,
+각 상태는 색 외의 수단으로 반드시 중복 표시된다(§12). 배경끼리 3:1을 강제하면 보드가
+체스판처럼 보여 퍼즐 가독성이 무너지므로, **색 이외 신호를 의무화**하는 쪽을 택했다.
 
 ### 9.3 포커스 표시
 
 - 모든 인터랙티브 요소에 `focus-visible` 링 표시
-- 포커스 링: `2px solid var(--sudoku-accent)` + `2px offset`
+- 포커스 링: `2px solid var(--ring)` + `2px offset` (대비 7.69:1 / 7.56:1)
 - 키보드 네비게이션: 보드 내 화살표 키 이동 지원
 
 ---
 
 ## 10. 아이콘 체계
 
-**Lucide React** 사용 (프로젝트 이미 설치됨).
+**Lucide React** 사용. `strokeWidth`는 **1.75 기본** (v1의 2~2.5 → 인쇄 라인에 맞춰 얇게).
 
-| 용도 | 아이콘 | 크기 |
-|------|--------|------|
-| 잠금 칸 | `Lock` | 16px |
-| 힌트 | `Lightbulb` | 20px |
-| 되돌리기 | `Undo2` | 20px |
-| 지우기 | `Eraser` | 20px |
-| 메모 모드 | `PenLine` | 20px |
-| 일시정지 | `Pause` | 20px |
-| 타이머 | `Clock` | 16px |
-| 홈 | `Home` | 24px |
-| 랭킹 | `Trophy` | 24px |
-| 설정 | `Settings` | 24px |
-| 프로필 | `User` | 24px |
-| 뒤로가기 | `ChevronLeft` | 24px |
-| 닫기 | `X` | 20px |
-| 성공 체크 | `Check` | 24px |
-| 별점 | `Star` | 20px |
-| 로그인 (Google) | 커스텀 SVG | 20px |
-| 로그인 (Naver) | 커스텀 SVG | 20px |
+| 용도 | 아이콘 | 크기 | v2 비고 |
+|------|--------|------|---------|
+| 잠금 칸 | `Lock` | 16px | 유지 |
+| 힌트 | `Lightbulb` | 20px | 유지 |
+| 되돌리기 | `Undo2` | 20px | 유지 |
+| 지우기 | `Eraser` | 20px | 유지 |
+| 메모 모드 | `PenLine` | 20px | 유지 |
+| 일시정지 | `Pause` | 20px | 유지 |
+| 타이머 | `Clock` | 16px | 유지 |
+| 홈 / 랭킹 / 설정 / 프로필 | `Home` `Trophy` `Settings` `User` | 24px | 유지 |
+| 뒤로가기 / 닫기 / 체크 | `ChevronLeft` `X` `Check` | 20~24px | 유지 |
+| 별점 (클리어 등급) | `Star` | 20px | 유지 — **클리어 등급 전용** |
+| 로그인 (Google/Naver) | 커스텀 SVG | 20px | 유지 (브랜드 색 예외 허용) |
+| ~~장식 스파클~~ | ~~`Sparkles`~~ | — | **폐기 (§14.2)** |
+| ~~난이도 상징~~ | ~~`Sprout` `Flame` `Zap` `Crown`~~ | — | **폐기 → pip 게이지 (§14.3)** |
+
+> ★ 아이콘은 **클리어 등급(3개)에만** 쓴다. 난이도 구분에 ★를 쓰면 두 의미가 충돌하므로 난이도는 **사각 pip**을 쓴다. (§14.3)
 
 ---
 
 ## 11. Tailwind CSS v4 토큰 매핑
 
-`globals.css`의 `@theme inline` 블록과 `:root` / `.dark` 에서 CSS 변수로 정의.
-Tailwind 클래스에서 직접 사용 가능:
+`@theme inline` 블록은 **변경 없다.** v2는 `:root` / `.dark` 의 값만 교체하므로
+`bg-cell-default`, `text-difficulty-hard` 같은 기존 유틸리티 클래스는 전부 그대로 동작한다.
 
-```css
-/* 사용 예시 */
-.cell { background: var(--cell-default); }
-.cell-selected { background: var(--cell-selected); }
-
-/* Tailwind 클래스 매핑 */
-bg-[--cell-default]
-bg-[--cell-selected]
-text-[--cell-error-foreground]
-shadow-[--shadow-board]
-```
-
-또는 `@theme` 블록에서 Tailwind 유틸리티로 매핑:
+`@theme inline` 에 추가되는 것은 §3.1의 세리프 1줄뿐이다.
 
 ```css
 @theme inline {
-  --color-sudoku-primary: var(--sudoku-primary);
-  --color-cell-default: var(--cell-default);
-  /* → bg-sudoku-primary, bg-cell-default 등으로 사용 */
+  /* ...기존 유지... */
+  --font-serif: var(--font-serif);   /* v2 신규 (세리프 채택 시) */
 }
 ```
 
 ---
 
-## 12. 컴포넌트 스타일 가이드 (Quick Reference)
+## 12. 셀 상태 구분 방식 (페이퍼 톤)
 
-### 12.1 버튼 스타일
+**원칙: 모든 셀 상태는 "색 + 색이 아닌 신호" 두 겹으로 표현한다.**
+색 대비가 낮아진 만큼 비색상 신호가 실제 판별을 책임진다.
+
+| 상태 | 색 신호 | **비색상 신호 (필수)** | 구현 위치 |
+|------|---------|----------------------|-----------|
+| `default` | 종이 배경 | — | 이미 구현됨 |
+| `given` | 검정 잉크 | **font-weight 700** | 이미 구현됨 (`Cell.tsx` textClass) |
+| `filled` | 파란 볼펜 잉크 | font-weight 500 + given과 색상(hue) 자체가 다름 | 이미 구현됨 |
+| `selected` | 파란 음영 (진함) | **inset 2px 잉크 링** (`--shadow-cell-selected`, 5.54:1) + z-index 상승 | 이미 구현됨 |
+| `same-number` | 파란 음영 (옅음) | **font-weight 700** | 이미 구현됨 (`isSameNumber && !isSelected && "font-bold"`) |
+| `highlighted` | **무채색** 음영 | 색상축이 다름 — same-number(파랑)와 hue로 분리 | 토큰 값 교체만 |
+| `error` | 빨간 배경 + 빨간 잉크 | **밑줄** + `cell-error-shake` + `aria-invalid` | **신규 1줄 → 아래** |
+| `locked` | 회색 배경 | **대각 빗금 패턴** + `Lock` 아이콘 + `cursor-not-allowed` | **신규 유틸 → 아래** |
+| `completed` | 황토 플래시 | 500ms 일시 효과 (정보 아님) | 토큰 값 교체만 |
+| `memo` | 회색 소형 숫자 | 3×3 격자 위치 | 이미 구현됨 |
+
+**selected / same-number / highlighted 3종은 서로 다른 3개 축으로 분리된다:**
+
+| | 배경 색상축 | 배경 진하기 | 링 | 숫자 굵기 |
+|---|---|---|---|---|
+| selected | 파랑 | **진함** (0.86) | **있음 (2px)** | 상속 |
+| same-number | 파랑 | 중간 (0.905) | 없음 | **700** |
+| highlighted | **무채색** | 옅음 (0.955) | 없음 | 상속 |
+
+### 12.1 필요한 컴포넌트 변경 (2건, 각 1~2줄)
+
+**(1) 오류 셀 밑줄** — `src/components/game/Cell.tsx` textClass:
+
+```ts
+if (cell.isError) return "text-cell-error-foreground underline decoration-2 underline-offset-4";
+```
+
+**(2) 잠금 칸 빗금** — `globals.css` 유틸 추가 + `Cell.tsx` className에 조건부 1줄:
+
+```css
+/* 잠금 칸 대각 빗금 — 색 없이 "막힌 칸"임을 전달 */
+.cell-hatch {
+  background-image: repeating-linear-gradient(
+    45deg,
+    transparent 0 3px,
+    color-mix(in oklch, var(--cell-locked-foreground) 22%, transparent) 3px 4px
+  );
+}
+```
+
+```ts
+// Cell.tsx — 기존 cell.isLocked && "opacity-80" 을 아래로 교체
+cell.isLocked && "cell-hatch",
+```
+
+> `opacity-80`은 제거한다. 페이퍼 톤에서는 투명도로 상태를 표현하지 않는다(빗금이 대신한다).
+
+---
+
+## 13. v1 → v2 토큰 마이그레이션 대조표
+
+> **`@theme inline` 블록과 토큰 이름은 전혀 건드리지 않는다.**
+> 아래 값들만 `:root` / `.dark` 에서 교체하면 된다.
+
+### 13.1 Light (`:root`)
+
+| 토큰 | v1 (기존) | **v2 (신규)** |
+|------|-----------|---------------|
+| `--background` | `oklch(1 0 0)` | `oklch(0.968 0.008 85)` |
+| `--foreground` | `oklch(0.145 0 0)` | `oklch(0.24 0.012 65)` |
+| `--card` | `oklch(1 0 0)` | `oklch(0.985 0.006 85)` |
+| `--card-foreground` | `oklch(0.145 0 0)` | `oklch(0.24 0.012 65)` |
+| `--popover` | `oklch(1 0 0)` | `oklch(0.985 0.006 85)` |
+| `--popover-foreground` | `oklch(0.145 0 0)` | `oklch(0.24 0.012 65)` |
+| `--primary` | `oklch(0.205 0 0)` | `oklch(0.24 0.012 65)` |
+| `--primary-foreground` | `oklch(0.985 0 0)` | `oklch(0.98 0.005 85)` |
+| `--secondary` | `oklch(0.97 0 0)` | `oklch(0.935 0.007 85)` |
+| `--secondary-foreground` | `oklch(0.205 0 0)` | `oklch(0.24 0.012 65)` |
+| `--muted` | `oklch(0.97 0 0)` | `oklch(0.935 0.007 85)` |
+| `--muted-foreground` | `oklch(0.556 0 0)` | `oklch(0.50 0.010 65)` |
+| `--accent` | `oklch(0.97 0 0)` | `oklch(0.925 0.008 85)` |
+| `--accent-foreground` | `oklch(0.205 0 0)` | `oklch(0.24 0.012 65)` |
+| `--destructive` | `oklch(0.577 0.245 27.325)` | `oklch(0.47 0.17 28)` |
+| `--border` | `oklch(0.922 0 0)` | `oklch(0.86 0.010 85)` |
+| `--input` | `oklch(0.922 0 0)` | `oklch(0.64 0.008 80)` |
+| `--ring` | `oklch(0.708 0 0)` | `oklch(0.42 0.09 250)` |
+| `--radius` | `0.625rem` | `0.375rem` |
+| `--sudoku-primary` | `oklch(0.55 0.18 250)` | `oklch(0.42 0.09 250)` |
+| `--sudoku-primary-foreground` | `oklch(0.98 0 0)` | `oklch(0.98 0.005 85)` |
+| `--sudoku-accent` | `oklch(0.65 0.15 250)` | `oklch(0.52 0.08 250)` |
+| `--cell-default` | `oklch(1 0 0)` | `oklch(0.99 0.004 85)` |
+| `--cell-default-foreground` | `oklch(0.25 0 0)` | `oklch(0.45 0.10 250)` |
+| `--cell-given` | `oklch(0.97 0 0)` | `oklch(0.99 0.004 85)` |
+| `--cell-given-foreground` | `oklch(0.15 0 0)` | `oklch(0.22 0.012 65)` |
+| `--cell-selected` | `oklch(0.88 0.08 250)` | `oklch(0.86 0.055 250)` |
+| `--cell-selected-foreground` | `oklch(0.20 0 0)` | `oklch(0.22 0.012 65)` |
+| `--cell-highlighted` | `oklch(0.93 0.04 250)` | `oklch(0.955 0.005 85)` |
+| `--cell-same-number` | `oklch(0.90 0.06 250)` | `oklch(0.905 0.045 250)` |
+| `--cell-error` | `oklch(0.90 0.10 25)` | `oklch(0.895 0.055 30)` |
+| `--cell-error-foreground` | `oklch(0.50 0.20 25)` | `oklch(0.47 0.17 28)` |
+| `--cell-locked` | `oklch(0.94 0 0)` | `oklch(0.925 0.005 85)` |
+| `--cell-locked-foreground` | `oklch(0.55 0 0)` | `oklch(0.50 0.008 65)` |
+| `--cell-completed` | `oklch(0.90 0.10 145)` | `oklch(0.93 0.045 80)` |
+| `--board-border` | `oklch(0.25 0 0)` | `oklch(0.26 0.012 65)` |
+| `--board-border-thin` | `oklch(0.80 0 0)` | `oklch(0.64 0.008 80)` |
+| `--board-bg` | `oklch(0.97 0 0)` | `oklch(0.968 0.008 85)` |
+| `--difficulty-easy` | `oklch(0.72 0.16 145)` 초록 | `oklch(0.53 0.010 65)` |
+| `--difficulty-medium` | `oklch(0.75 0.15 85)` 노랑 | `oklch(0.44 0.012 65)` |
+| `--difficulty-hard` | `oklch(0.68 0.18 50)` 주황 | `oklch(0.36 0.014 65)` |
+| `--difficulty-expert` | `oklch(0.60 0.20 25)` 빨강 | `oklch(0.25 0.016 65)` |
+| `--success` | `oklch(0.72 0.16 145)` | `oklch(0.48 0.09 150)` |
+| `--warning` | `oklch(0.75 0.15 85)` | `oklch(0.53 0.09 75)` |
+| `--info` | `oklch(0.65 0.15 250)` | `oklch(0.45 0.09 250)` |
+| `--shadow-board` | `0 2px 8px …/0.08, 0 0 0 3px oklch(0.25 0 0)` | `0 1px 2px oklch(0.24 0.012 65 / 0.10), 0 0 0 2px oklch(0.26 0.012 65)` |
+| `--shadow-cell-selected` | `inset 0 0 0 2px oklch(0.55 0.18 250)` | `inset 0 0 0 2px oklch(0.42 0.09 250)` |
+| `--shadow-numpad` | `0 2px 4px oklch(0 0 0 / 0.06)` | `0 1px 0 oklch(0.24 0.012 65 / 0.08)` |
+| `--shadow-xl` | `0 20px 25px …/0.10, 0 8px 10px …/0.04` | `0 8px 24px oklch(0.24 0.012 65 / 0.12), 0 2px 6px oklch(0.24 0.012 65 / 0.06)` |
+
+간격 / 타이포 / duration / easing / z-index 토큰은 **전부 v1 그대로**.
+
+### 13.2 Dark (`.dark`)
+
+| 토큰 | v1 (기존) | **v2 (신규)** |
+|------|-----------|---------------|
+| `--background` | `oklch(0.145 0 0)` | `oklch(0.185 0.008 70)` |
+| `--foreground` | `oklch(0.985 0 0)` | `oklch(0.92 0.012 85)` |
+| `--card` | `oklch(0.205 0 0)` | `oklch(0.235 0.008 70)` |
+| `--card-foreground` | `oklch(0.985 0 0)` | `oklch(0.92 0.012 85)` |
+| `--popover` | `oklch(0.205 0 0)` | `oklch(0.235 0.008 70)` |
+| `--popover-foreground` | `oklch(0.985 0 0)` | `oklch(0.92 0.012 85)` |
+| `--primary` | `oklch(0.922 0 0)` | `oklch(0.92 0.012 85)` |
+| `--primary-foreground` | `oklch(0.205 0 0)` | `oklch(0.18 0.010 70)` |
+| `--secondary` | `oklch(0.269 0 0)` | `oklch(0.285 0.008 70)` |
+| `--secondary-foreground` | `oklch(0.985 0 0)` | `oklch(0.92 0.012 85)` |
+| `--muted` | `oklch(0.269 0 0)` | `oklch(0.285 0.008 70)` |
+| `--muted-foreground` | `oklch(0.708 0 0)` | `oklch(0.70 0.010 80)` |
+| `--accent` | `oklch(0.269 0 0)` | `oklch(0.30 0.008 70)` |
+| `--accent-foreground` | `oklch(0.985 0 0)` | `oklch(0.92 0.012 85)` |
+| `--destructive` | `oklch(0.704 0.191 22.216)` | `oklch(0.68 0.15 28)` |
+| `--border` | `oklch(1 0 0 / 10%)` | `oklch(0.34 0.008 70)` |
+| `--input` | `oklch(1 0 0 / 15%)` | `oklch(0.54 0.008 70)` |
+| `--ring` | `oklch(0.556 0 0)` | `oklch(0.72 0.095 250)` |
+| `--sudoku-primary` | `oklch(0.68 0.16 250)` | `oklch(0.72 0.095 250)` |
+| `--sudoku-primary-foreground` | `oklch(0.98 0 0)` | `oklch(0.18 0.010 70)` |
+| `--sudoku-accent` | `oklch(0.55 0.13 250)` | `oklch(0.62 0.085 250)` |
+| `--cell-default` | `oklch(0.22 0 0)` | `oklch(0.235 0.008 70)` |
+| `--cell-default-foreground` | `oklch(0.92 0 0)` | `oklch(0.78 0.09 250)` |
+| `--cell-given` | `oklch(0.26 0 0)` | `oklch(0.235 0.008 70)` |
+| `--cell-given-foreground` | `oklch(0.95 0 0)` | `oklch(0.94 0.008 85)` |
+| `--cell-selected` | `oklch(0.35 0.10 250)` | `oklch(0.375 0.075 250)` |
+| `--cell-selected-foreground` | `oklch(0.95 0 0)` | `oklch(0.95 0.008 85)` |
+| `--cell-highlighted` | `oklch(0.28 0.06 250)` | `oklch(0.295 0.005 70)` |
+| `--cell-same-number` | `oklch(0.32 0.08 250)` | `oklch(0.335 0.06 250)` |
+| `--cell-error` | `oklch(0.30 0.10 25)` | `oklch(0.325 0.08 28)` |
+| `--cell-error-foreground` | `oklch(0.70 0.18 25)` | `oklch(0.76 0.14 28)` |
+| `--cell-locked` | `oklch(0.24 0 0)` | `oklch(0.205 0.005 70)` |
+| `--cell-locked-foreground` | `oklch(0.60 0 0)` | `oklch(0.62 0.008 70)` |
+| `--cell-completed` | `oklch(0.35 0.10 145)` | `oklch(0.34 0.05 80)` |
+| `--board-border` | `oklch(0.80 0 0)` | `oklch(0.78 0.010 85)` |
+| `--board-border-thin` | `oklch(0.35 0 0)` | `oklch(0.54 0.008 70)` |
+| `--board-bg` | `oklch(0.18 0 0)` | `oklch(0.185 0.008 70)` |
+| `--difficulty-easy` | `oklch(0.68 0.18 145)` | `oklch(0.62 0.010 85)` |
+| `--difficulty-medium` | `oklch(0.72 0.17 85)` | `oklch(0.72 0.010 85)` |
+| `--difficulty-hard` | `oklch(0.65 0.20 50)` | `oklch(0.82 0.010 85)` |
+| `--difficulty-expert` | `oklch(0.58 0.22 25)` | `oklch(0.94 0.010 85)` |
+| `--success` | `oklch(0.65 0.14 145)` | `oklch(0.70 0.10 150)` |
+| `--warning` | `oklch(0.68 0.13 85)` | `oklch(0.76 0.095 75)` |
+| `--info` | `oklch(0.58 0.13 250)` | `oklch(0.72 0.09 250)` |
+| `--shadow-board` | `0 2px 8px …/0.3, 0 0 0 3px oklch(0.80 0 0)` | `0 1px 2px oklch(0 0 0 / 0.4), 0 0 0 2px oklch(0.78 0.010 85)` |
+| `--shadow-cell-selected` | `inset 0 0 0 2px oklch(0.68 0.16 250)` | `inset 0 0 0 2px oklch(0.72 0.095 250)` |
+| `--shadow-numpad` | `0 2px 4px oklch(0 0 0 / 0.2)` | `0 1px 0 oklch(0 0 0 / 0.35)` |
+| `--shadow-xl` | `0 20px 25px …/0.30, 0 8px 10px …/0.15` | `0 8px 24px oklch(0 0 0 / 0.5), 0 2px 6px oklch(0 0 0 / 0.3)` |
+
+> **다크 모드의 "페이퍼" 번역**: 흰 종이를 어둡게 반전하는 대신 **갱지 뒷면 / 흑지(black paper)** 로 해석한다.
+> hue 70의 따뜻한 흑갈색(`0.185 0.008 70`)이 종이가 되고, 인쇄 잉크는 **흰 잉크**(`0.92 0.012 85`)로 뒤집힌다.
+> 볼펜 파랑은 어두운 지면에서 읽히도록 밝기를 올리되(`0.78 0.09 250`) 채도는 라이트와 동일 수준으로 억제해 네온이 되지 않게 한다.
+> 난이도 사다리도 방향만 뒤집혀 **밝을수록 어렵다**로 유지된다.
+
+### 13.3 그 외 1줄 변경
+
+| 파일 | 변경 |
+|------|------|
+| `src/app/layout.tsx` | `viewport.themeColor: "#09090b"` → `"#15120f"` (다크 갱지) |
+| `src/app/layout.tsx` | Instrument Serif 추가 (§3.1, 세리프 채택 시) |
+
+---
+
+## 14. 장식 요소 처리 지침
+
+v1의 "AI 느낌"은 토큰보다 **장식 요소**가 만들었다. 아래는 요소별 처리 방안이다.
+
+### 14.1 배경 — 메시 그라데이션 → 모눈종이
+
+**삭제**: `.home-mesh-bg` (globals.css 521-536) 및 `.dark .home-mesh-bg` 전체.
+**삭제**: `.sudoku-grid-bg` (540-551) — 아래 `.paper-bg`로 통합.
+
+**신규**: 종이 자체를 표현하는 단일 클래스. 퍼센트 기반이 아닌 **고정 24px 모눈**이라 리사이즈 시 리플로우가 없다.
+
+```css
+/* 모눈종이 지면 — 그라데이션 없음, 색 없음 */
+.paper-bg {
+  background-color: var(--background);
+  background-image:
+    linear-gradient(to right, oklch(0.45 0.01 70 / 0.05) 1px, transparent 1px),
+    linear-gradient(to bottom, oklch(0.45 0.01 70 / 0.05) 1px, transparent 1px);
+  background-size: 24px 24px;
+}
+
+.dark .paper-bg {
+  background-image:
+    linear-gradient(to right, oklch(0.85 0.01 85 / 0.045) 1px, transparent 1px),
+    linear-gradient(to bottom, oklch(0.85 0.01 85 / 0.045) 1px, transparent 1px);
+}
+
+/* 모바일 성능: 모눈은 페인트 비용이 낮아 768px 미만에서도 유지해도 된다.
+   단, 저사양에서 스크롤 저더가 보이면 아래 한 줄로 비활성화. */
+@media (max-width: 359px) {
+  .paper-bg { background-image: none; }
+}
+```
+
+**`AppLayout.tsx` 변경** — 배경 레이어 2개 → 1개:
+
+```tsx
+{showAmbientBg && (
+  <div aria-hidden="true" className="paper-bg pointer-events-none absolute inset-0 -z-10" />
+)}
+```
+
+> `Header.tsx`의 `bg-background/70 backdrop-blur-xl` → **`bg-background border-b border-border`** 로 교체한다. 종이 위에 반투명 유리가 떠 있으면 페이퍼 톤이 즉시 깨진다. 블러 제거는 모바일 스크롤 성능에도 이득이다.
+
+### 14.2 워드마크 & 뱃지
+
+**삭제**: `.text-gradient-brand` (585-596), `.animate-text-shimmer` + `@keyframes shimmer` (621-641), `.animate-float-slow` + `@keyframes float-slow` (612-619), `@media (forced-colors)` 폴백 블록(645-653 — 대상 클래스가 사라지므로 함께 삭제).
+
+**`BrandWordmark.tsx`** — 시머 그라데이션 + 가운뎃점 구분 폐기:
+
+| 항목 | v1 | **v2** |
+|------|-----|--------|
+| 문자열 | `S · U · D · O · K · U` | `SUDOKU` |
+| 색 | 시머 그라데이션 (파랑→주황→빨강 순환) | **`text-foreground` 단색 잉크** |
+| 폰트 | `font-mono font-black` | **`font-[family-name:var(--font-serif)] font-normal`** (세리프 미채택 시 `font-sans font-normal`) |
+| 자간 | `tracking-[0.18em]` | `tracking-[0.14em]` |
+| 애니메이션 | shimmer 6s 무한 | **없음** |
+| 하단 장식 | — | 선택: 워드마크 아래 `border-b border-border` 1px 괘선 (제목 밑줄) |
+
+**`AppLogo.tsx`** — 그라데이션 점 삭제:
+
+```tsx
+// 삭제: <span className="size-1.5 rounded-full bg-gradient-to-br from-sudoku-primary via-difficulty-hard to-difficulty-expert ..." />
+// 대체: 없음. 워드마크만 남긴다. 장식이 꼭 필요하면 잉크색 정사각 2×2px.
+```
+
+**스파클 pill 뱃지** (`HomeContent.tsx` 33-38) — **삭제**.
+`Sparkles` 아이콘 + `rounded-full` + `bg-sudoku-primary/10` + `backdrop-blur-sm` 조합은 v2 금지 목록 3개를 동시에 위반한다.
+
+대체안 — 문제집 표지의 **간행 정보 줄**:
+
+```tsx
+<p className="mb-4 font-mono text-(length:--text-small) tracking-[0.2em] uppercase text-muted-foreground">
+  DAILY PUZZLE · NO.{stageNo}
+</p>
+```
+
+pill 없음, 아이콘 없음, 배경 없음. 대문자 모노 + 넓은 자간만으로 인쇄물 캡션이 된다.
+
+### 14.3 난이도 카드
+
+**삭제**: `.gradient-easy/medium/hard/expert` (553-582), `.card-glow-easy/medium/hard/expert` (598-610).
+
+**`difficulty-data.ts` 변경** — 3개 필드 교체:
+
+```ts
+// 삭제: gradientClass, glowClass, icon (Sprout/Flame/Zap/Crown)
+// 추가:
+/** 난이도 등급 1~4 — pip 게이지 채움 개수 */
+level: 1 | 2 | 3 | 4;
+/** 텍스트/눈금 색 클래스 */
+toneClass: string;   // "text-difficulty-easy" | ... | "text-difficulty-expert"
+```
+
+**`DifficultyCard.tsx` 좌측 사이드바** — 그라데이션 면 → 종이 + 세로 괘선:
+
+| 항목 | v1 | **v2** |
+|------|-----|--------|
+| 배경 | `gradientClass` (컬러 그라데이션) | **없음 (카드 배경 그대로)** |
+| 구분 | 없음 (색면이 구분) | **`border-r border-border`** 세로 괘선 |
+| 상단 | `#01` 흰 모노 텍스트 | `01` — `font-mono text-muted-foreground` |
+| 중앙 | 컬러 아이콘 (Sprout 등) | **pip 게이지 (아래)** |
+| 호버 | `card-glow-*` 컬러 글로우 | **`hover:bg-accent`** 만. translate/scale/shadow 전부 제거 |
+
+**pip 게이지 명세** — 난이도를 색이 아니라 **개수**로 표현한다:
+
+```
+쉬움    ■ □ □ □
+보통    ■ ■ □ □
+어려움  ■ ■ ■ □
+전문가  ■ ■ ■ ■
+```
+
+| 속성 | 값 |
+|------|-----|
+| 개별 pip 크기 | 6×6px |
+| 간격 | 3px |
+| 배치 | 가로 1행 4개 (사이드바 폭 72px에 여유) |
+| 채움 pip | `bg-current` + 부모에 `toneClass` |
+| 빈 pip | `border border-current opacity-40`, 배경 없음 |
+| 모서리 | `rounded-none` — 정사각 (인쇄 눈금) |
+| 접근성 | 부모에 `aria-hidden`, 난이도는 카드 `aria-label`의 텍스트가 전달 |
+
+> **왜 ★가 아니라 ■인가**: ★는 이미 **클리어 등급(3개)** 에 쓰이고 있다(`StarRating`, `DifficultyCard` 우측). 난이도에도 ★를 쓰면 같은 카드 안에 의미가 다른 별이 두 벌 생긴다. 정사각 pip은 스도쿠 격자와도 시각적으로 맞는다.
+
+**카드 전체 스타일**:
+
+| 속성 | v1 | **v2** |
+|------|-----|--------|
+| 배경 | `bg-card/80 backdrop-blur-sm` | **`bg-card`** (블러 제거) |
+| 보더 | `border-border/60` | **`border-border`** (실선) |
+| 모서리 | `rounded-[var(--radius-xl)]` = 14px | 동일 토큰 → 자동으로 8.4px |
+| 호버 | `-translate-y-1` + `shadow-xl` + 컬러 글로우 | **`hover:bg-accent`** 만 |
+| 잠금 | `opacity-70` | **`.cell-hatch` 빗금 + `text-muted-foreground`** (투명도 대신 §12 규칙 일관 적용) |
+| 호버 화살표 | `ArrowUpRight` in `bg-foreground` 원형 | 유지하되 `rounded-none`, 배경 없이 `text-muted-foreground` |
+
+### 14.4 랭킹 포디움
+
+**`RankingPodium.tsx`** — 컨테이너 장식 2개 **삭제**:
+- 상단 그라데이션 액센트 라인 (`bg-gradient-to-r from-transparent via-sudoku-primary/60`)
+- 배경 글로우 (`bg-gradient-to-br from-warning/30 ... blur-2xl`)
+
+대체: 컨테이너를 **표(表)** 로 바꾼다.
+
+| 항목 | v1 | **v2** |
+|------|-----|--------|
+| 컨테이너 | `rounded-2xl bg-card/80 shadow-lg backdrop-blur-md` + 글로우 2겹 | `rounded-[var(--radius-lg)] border border-border bg-card` |
+| 상단 | 그라데이션 헤어라인 | **`border-b border-border` + `TOP 3` 모노 캡션** |
+| 순위 표시 | 🥇🥈🥉 이모지 | **`#1` `#2` `#3` 모노 숫자** (`font-mono`, `text-muted-foreground`) |
+| 아바타 테두리 | 금/은/동 컬러 | **잉크 명도 사다리** (아래) |
+| 1위 강조 | 크기(56px) + 금색 | **크기(56px) + `font-bold` + 테두리 2px** — 색 아님 |
+
+**`ranking-utils.ts` 변경**:
+
+```ts
+// MEDAL_EMOJI 삭제 — 이모지는 페이퍼 톤과 충돌한다.
+// 대신 순위 숫자를 그대로 렌더한다: `#${rank}`
+
+// MEDAL_COLORS → 잉크 명도 사다리로 교체 (다크 모드 대응을 위해 var() 참조)
+export const MEDAL_COLORS = {
+  1: "var(--foreground)",        // 가장 진한 잉크
+  2: "var(--muted-foreground)",
+  3: "var(--board-border-thin)",
+} as const;
+```
+
+> `var()` 참조로 바꾸면 다크 모드에서 자동 반전된다. 기존 리터럴 oklch 값은 라이트 전용이라 다크에서 대비가 무너지고 있었다 — v2에서 함께 해소된다.
+
+**`RankingList.tsx` / `DifficultyTabs.tsx`**:
+- 활성 탭 인디케이터: `bg-difficulty-*` → **`bg-foreground`** (2px 잉크 밑줄). 난이도별로 색이 달라질 이유가 없다.
+- 내 순위 하이라이트: 배경색 대신 **좌측 3px `border-l-foreground` + `font-semibold`**.
+- 행 구분: `border-b border-border` 1px 괘선 (성적표 느낌).
+
+### 14.5 로그인 배너 / 이어하기 배너
+
+**`LoginBanner.tsx`** — `bg-gradient-to-r from-sudoku-primary/15 via-...` + `backdrop-blur-md` **삭제**:
+
+| 속성 | **v2** |
+|------|--------|
+| 컨테이너 | `rounded-[var(--radius-md)] border border-border bg-card` |
+| 좌측 강조 | `border-l-[3px] border-l-sudoku-primary` (한 줄 잉크 표시) |
+| 아이콘 박스 | 배경 제거. `LogIn` 아이콘만 `text-muted-foreground` |
+| CTA | `rounded-full` → `rounded-[var(--radius-sm)]`, `bg-sudoku-primary` 유지 (7.97:1) |
+
+`ContinueBanner.tsx`도 동일 규칙 적용 (그라데이션/블러 제거, 좌측 잉크 바 + 괘선).
+
+### 14.6 기타 정리
+
+| 대상 | 조치 |
+|------|------|
+| `Header.tsx` `backdrop-blur-xl` | 제거 → `bg-background border-b border-border` |
+| `board-complete-celebrate` 의 `filter: brightness(1.1)` | 제거 (scale만 유지). 종이는 빛나지 않는다 |
+| `BottomNav` 활성 표시 | 색 대신 **상단 2px 잉크 바 + `font-semibold`** |
+| 모든 `bg-*/80`, `border-*/60` 등 알파 표면 | 불투명 실색으로 교체 |
+| `PauseOverlay` blur | **유지** — 기능적 블러(퍼즐 가리기)이므로 예외 |
+
+---
+
+## 15. 컴포넌트 스타일 가이드 (Quick Reference)
+
+### 15.1 버튼 스타일
 
 | 변형 | 배경 | 텍스트 | 보더 | 호버 |
 |------|------|--------|------|------|
-| Primary | `--sudoku-primary` | `--sudoku-primary-foreground` | none | opacity 0.9 |
-| Secondary | `--secondary` | `--secondary-foreground` | none | opacity 0.8 |
-| Ghost | transparent | `--foreground` | none | `--accent` bg |
-| Outline | transparent | `--foreground` | `--border` | `--accent` bg |
-| Destructive | `--destructive` | white | none | opacity 0.9 |
+| Primary | `--sudoku-primary` | `--sudoku-primary-foreground` | none | `--sudoku-accent` 배경 |
+| Secondary | `--secondary` | `--secondary-foreground` | none | `--accent` 배경 |
+| Ghost | transparent | `--foreground` | none | `--accent` 배경 |
+| Outline | transparent | `--foreground` | **1px `--input`** (3:1) | `--accent` 배경 |
+| Destructive | `--destructive` | `--primary-foreground` | none | opacity 0.9 |
 
-### 12.2 카드 스타일
+> v1의 `hover: opacity 0.9`는 페이퍼 톤에서 색이 바래 보인다. **배경 토큰 교체**로 호버를 표현한다.
+
+### 15.2 카드 스타일
 
 ```
-배경: var(--card)
+배경: var(--card)          — 알파 없음, 블러 없음
 보더: 1px solid var(--border)
-모서리: var(--radius-lg) = 10px
-그림자: var(--shadow-md)
-패딩: var(--space-4) = 16px
+모서리: var(--radius-lg)   = 6px
+그림자: var(--shadow-sm)   — md 이상은 모달/팝오버 전용
+패딩: var(--space-4)       = 16px
 ```
 
-### 12.3 숫자패드 버튼 스타일
+### 15.3 숫자패드 버튼 스타일
 
 ```
 크기: 48×48px (최소 44px 터치 타겟)
 배경: var(--card)
-텍스트: var(--foreground), font-size: var(--text-numpad)
-모서리: var(--radius-md) = 8px
-그림자: var(--shadow-numpad)
+보더: 1px solid var(--border)     ← v2 신규. 그림자만으론 종이 위에서 경계가 안 보인다
+텍스트: var(--foreground), font-size: var(--text-numpad), font-mono
+모서리: var(--radius-md) = 4.8px
+그림자: var(--shadow-numpad)      — 1px 오프셋, 흐림 없음
 호버: var(--accent) 배경
-활성: scale(0.95), var(--sudoku-primary) 배경
-비활성(9개 모두 배치됨): opacity 0.3
+활성: scale(0.92→1), var(--sudoku-primary) 배경 + var(--sudoku-primary-foreground) 텍스트
+비활성(9개 모두 배치됨): opacity 0.35 + var(--muted) 배경
+```
+
+---
+
+## 16. 구현 체크리스트 (Frontend 인계용)
+
+```
+[ ] globals.css :root 값 교체              → §13.1
+[ ] globals.css .dark 값 교체              → §13.2
+[ ] globals.css .paper-bg 추가             → §14.1
+[ ] globals.css .cell-hatch 추가           → §12.1
+[ ] globals.css 삭제: .home-mesh-bg, .sudoku-grid-bg, .gradient-*,
+    .card-glow-*, .text-gradient-brand, .animate-text-shimmer,
+    .animate-float-slow, @keyframes shimmer, @keyframes float-slow,
+    @media(forced-colors) 폴백           → §14.1, §14.2, §14.3
+[ ] AppLayout.tsx 배경 레이어 1개로       → §14.1
+[ ] Header.tsx backdrop-blur 제거          → §14.1
+[ ] BrandWordmark.tsx 단색 + 세리프        → §14.2
+[ ] AppLogo.tsx 그라데이션 점 삭제         → §14.2
+[ ] HomeContent.tsx 스파클 뱃지 → 간행 캡션 → §14.2
+[ ] difficulty-data.ts level/toneClass     → §14.3
+[ ] DifficultyCard.tsx pip 게이지 + 괘선   → §14.3
+[ ] Cell.tsx 오류 밑줄 + 빗금 (2줄)        → §12.1
+[ ] NumberPad.tsx 버튼 보더 1px 추가       → §15.3
+[ ] RankingPodium.tsx 글로우 2겹 삭제      → §14.4
+[ ] ranking-utils.ts MEDAL_* 교체          → §14.4
+[ ] DifficultyTabs/RankingList 잉크 밑줄   → §14.4
+[ ] LoginBanner/ContinueBanner 평면화      → §14.5
+[ ] layout.tsx themeColor "#15120f"        → §13.3
+[ ] layout.tsx Instrument Serif (선택)     → §3.1
+[ ] Lighthouse 재측정: A11y ≥93, Perf ≥97
 ```

--- a/docs/design/game.md
+++ b/docs/design/game.md
@@ -4,6 +4,26 @@
 
 ---
 
+## 0. v2 변경 요약 (페이퍼 톤, 2026-08)
+
+**목표: 문제집을 펼친 한 페이지.** 셀 상태는 `cell-states.md` v2, 토큰은 `design-system.md` §13.
+
+| 요소 | v1 | **v2** |
+|------|-----|--------|
+| 보드 배경 | 흰색 | 종이색 `--board-bg` |
+| 굵은 괘선 | `--board-border` 3px 링 | 값 교체(잉크) + `--shadow-board` 링 **3px → 2px** |
+| 얇은 괘선 | `oklch(0.80 0 0)` (2.24:1 ❌) | **`oklch(0.64 0.008 80)` (3.02:1 ✅)** — 괘선은 필수 구조 정보 |
+| 셀 모서리 | 0 | 0 (유지) |
+| 숫자패드 버튼 | `bg-card` + 그림자만 | **`bg-card` + `border border-border` 추가** — 종이 위에서 그림자만으론 경계가 안 보인다 |
+| 숫자패드 그림자 | `0 2px 4px` 흐림 | `0 1px 0` 오프셋 (평평한 인쇄) |
+| 숫자패드 비활성 | `opacity-30` | `opacity-35` + `bg-muted` |
+| 도구바 아이콘 | `strokeWidth` 2~2.5 | **1.75** (인쇄 라인 두께) |
+| 난이도 라벨(GameHeader) | 무지개 `text-difficulty-*` | 동일 토큰, 값이 잉크 명도 사다리로 교체됨 → 코드 변경 없음 |
+| `PauseOverlay` 블러 | `blur(12px)` | **유지** — 퍼즐을 가리는 기능적 블러이므로 예외 |
+| `board-complete-celebrate` | scale + `filter: brightness(1.1)` | **brightness 스텝 제거**, scale만. 종이는 빛나지 않는다 |
+
+---
+
 ## 1. 와이어프레임 (375px 모바일)
 
 ```

--- a/docs/design/home.md
+++ b/docs/design/home.md
@@ -2,6 +2,77 @@
 
 > 앱의 메인 진입점. 난이도를 선택하여 게임을 시작하는 화면.
 
+> **v2 — 페이퍼 톤 (2026-08).** 아래 §0을 먼저 적용한 뒤 나머지 절을 읽는다.
+> 토큰/장식 근거는 `design-system.md` §14 참조.
+
+---
+
+## 0. v2 변경 요약 (페이퍼 톤)
+
+### 0.1 히어로
+
+| 요소 | v1 | **v2** |
+|------|-----|--------|
+| 배경 | `.home-mesh-bg` 메시 그라데이션 4겹 + `.sudoku-grid-bg` | **`.paper-bg` 모눈종이 1겹** |
+| Eyebrow | `Sparkles` 아이콘 + pill 뱃지 + `backdrop-blur` | **간행 캡션** — `DAILY PUZZLE · NO.{n}`, `font-mono`, `tracking-[0.2em]`, `uppercase`, `text-muted-foreground`, 배경·보더·아이콘 없음 |
+| 타이틀 | `S · U · D · O · K · U` 시머 그라데이션 | **`SUDOKU`** 단색 `text-foreground`, 세리프(선택), `tracking-[0.14em]`, 애니메이션 없음 |
+| 타이틀 밑줄 | — | 선택: `border-b border-border` 1px 괘선 |
+
+### 0.2 난이도 카드 — 색 → pip 게이지
+
+**난이도는 색으로 구분하지 않는다.** `.gradient-*` / `.card-glow-*` 를 전부 삭제하고
+좌측 사이드바를 **종이 + 세로 괘선 + 정사각 pip 게이지**로 바꾼다.
+
+```
+┌────────┬──────────────────────────────────┐
+│   01   │  쉬움                  ⏱ 03:24  │
+│        │  EASY                  ★★★      │
+│ ■□□□   │                                  │
+└────────┴──────────────────────────────────┘
+   ↑ 세로 괘선(border-r border-border)이 구분, 색면 아님
+```
+
+| 난이도 | pip | `level` | 톤 토큰 |
+|--------|-----|:-------:|---------|
+| 쉬움 | `■□□□` | 1 | `--difficulty-easy` |
+| 보통 | `■■□□` | 2 | `--difficulty-medium` |
+| 어려움 | `■■■□` | 3 | `--difficulty-hard` |
+| 전문가 | `■■■■` | 4 | `--difficulty-expert` |
+
+**pip 명세**: 6×6px, 간격 3px, 가로 1행, `rounded-none`.
+채움 = `bg-current`(부모에 `toneClass`), 빈 칸 = `border border-current opacity-40`.
+컨테이너에 `aria-hidden` — 난이도는 카드 `aria-label` 텍스트가 전달한다.
+
+> **★를 쓰지 않는 이유**: ★는 카드 우측의 **클리어 등급(3개)** 에 이미 쓰인다.
+> 난이도까지 ★로 표시하면 한 카드 안에 의미가 다른 별이 두 벌 생긴다.
+
+`difficulty-data.ts`에서 `gradientClass` · `glowClass` · `icon`(Sprout/Flame/Zap/Crown) 3필드를
+삭제하고 `level: 1|2|3|4` + `toneClass: string` 2필드로 교체한다.
+
+### 0.3 카드 스타일 (§3.2 를 아래로 대체)
+
+| 속성 | v1 | **v2** |
+|------|-----|--------|
+| 배경 | `bg-card/80 backdrop-blur-sm` | **`bg-card`** (알파·블러 제거) |
+| 보더 | `border-border/60` | **`border-border`** 실선 |
+| 모서리 | `--radius-xl` = 14px | 동일 토큰 → 자동 8.4px |
+| 그림자 | `shadow-sm` → 호버 `shadow-xl` | `--shadow-sm` 고정 |
+| 호버 | `-translate-y-1` + 컬러 글로우 | **`hover:bg-accent`** 만 |
+| 활성 | `active:scale-[0.99]` | 유지 |
+| 잠금 | `opacity-70` | **`.cell-hatch` 빗금 + `text-muted-foreground`** |
+| 좌측 사이드바 | 컬러 그라데이션 면 | 배경 없음 + `border-r border-border` |
+| 호버 화살표 | `bg-foreground` 원형 배지 | `rounded-none`, 배경 없이 `text-muted-foreground` |
+
+### 0.4 이어하기 배너 (§4 를 아래로 대체)
+
+| 속성 | **v2** |
+|------|--------|
+| 배경 | `--card` (그라데이션·알파 없음) |
+| 보더 | `1px solid --border` |
+| 좌측 강조 | `border-l-[3px] border-l-sudoku-primary` |
+| 모서리 | `--radius-md` |
+| CTA | Ghost, `--sudoku-primary` 텍스트 (7.69:1) |
+
 ---
 
 ## 1. 와이어프레임 (375px 모바일)

--- a/docs/design/layout.md
+++ b/docs/design/layout.md
@@ -5,6 +5,24 @@
 
 ---
 
+## 0. v2 변경 요약 (페이퍼 톤, 2026-08)
+
+**유리(glassmorphism)를 걷어내고 종이로 되돌린다.** 근거: `design-system.md` §14.1 / §14.6.
+
+| 요소 | v1 | **v2** |
+|------|-----|--------|
+| Header 배경 | `bg-background/70 backdrop-blur-xl` | **`bg-background` + `border-b border-border`** |
+| BottomNav 배경 | 반투명 + 블러 | **`bg-background` + `border-t border-border`** |
+| BottomNav 활성 표시 | 아이콘 색상 변경 | **상단 2px 잉크 바(`bg-foreground`) + `font-semibold`** + 아이콘 `text-foreground` |
+| BottomNav 비활성 | — | `text-muted-foreground` (5.48:1) |
+| 앰비언트 배경 | `.home-mesh-bg` + `.sudoku-grid-bg` 2겹 | **`.paper-bg` 1겹** (모눈종이 24px) |
+| 로고 | `SUDOKU` + 그라데이션 점 | `SUDOKU` 단색 잉크, 점 삭제 |
+
+> 블러 제거는 톤뿐 아니라 **모바일 스크롤 성능**에도 이득이다
+> (sticky + `backdrop-filter`는 매 프레임 재합성을 유발한다).
+
+---
+
 ## 1. 전체 레이아웃 구조
 
 ### 1.1 와이어프레임

--- a/docs/design/ranking.md
+++ b/docs/design/ranking.md
@@ -2,6 +2,79 @@
 
 > 난이도별 클리어 기록을 순위로 표시하는 페이지.
 
+> **v2 — 페이퍼 톤 (2026-08).** 아래 §0을 먼저 적용한 뒤 나머지 절을 읽는다.
+> 근거는 `design-system.md` §14.4 / §14.5.
+
+---
+
+## 0. v2 변경 요약 (페이퍼 톤)
+
+**은유: 화려한 시상대가 아니라 게시판에 붙은 성적표.**
+
+### 0.1 포디움 (§4 대체)
+
+**삭제 2건** — `RankingPodium.tsx`의 장식 레이어:
+- 상단 그라데이션 액센트 라인 (`bg-gradient-to-r from-transparent via-sudoku-primary/60`)
+- 배경 글로우 (`bg-gradient-to-br from-warning/30 ... blur-2xl`)
+
+| 항목 | v1 | **v2** |
+|------|-----|--------|
+| 컨테이너 | `rounded-2xl bg-card/80 shadow-lg backdrop-blur-md` | `rounded-[var(--radius-lg)] border border-border bg-card` |
+| 상단 | 그라데이션 헤어라인 | `border-b border-border` + `TOP 3` 모노 캡션 (`tracking-[0.2em]`, `uppercase`) |
+| 순위 표시 | 🥇🥈🥉 이모지 | **`#1` `#2` `#3`** — `font-mono text-muted-foreground` |
+| 아바타 테두리 | 금/은/동 리터럴 색 | **잉크 명도 사다리** (아래) |
+| 1위 강조 | 크기 56px + 금색 | 크기 56px + `font-bold` + 테두리 2px — **색 아님** |
+
+```ts
+// ranking-utils.ts
+// MEDAL_EMOJI 삭제 (이모지는 페이퍼 톤과 충돌)
+export const MEDAL_COLORS = {
+  1: "var(--foreground)",         // 가장 진한 잉크
+  2: "var(--muted-foreground)",
+  3: "var(--board-border-thin)",
+} as const;
+```
+
+> v1의 `MEDAL_COLORS`는 리터럴 oklch 라이트 전용 값이라 다크 모드에서 대비가 무너졌다.
+> `var()` 참조로 바꾸면 두 모드에서 자동 반전된다 — 접근성 버그 동시 해소.
+
+### 0.2 난이도 필터 탭 (§3.1 인디케이터 항목 대체)
+
+| 속성 | v1 | **v2** |
+|------|-----|--------|
+| 활성 인디케이터 | 하단 2px, `--difficulty-*` 난이도별 색 | **하단 2px `bg-foreground`** (잉크 밑줄, 전 탭 동일) |
+| 활성 탭 텍스트 | `--foreground` weight 600 | 유지 |
+| 비활성 탭 텍스트 | `--muted-foreground` | 유지 (5.48:1) |
+
+`ranking-utils.ts`의 `DifficultyTab.activeClass` 필드는 값이 전부 같아지므로 **삭제**하고
+인디케이터를 컴포넌트에 하드코딩한다.
+
+### 0.3 랭킹 리스트
+
+| 항목 | **v2** |
+|------|--------|
+| 행 구분 | `border-b border-border` 1px 괘선 (성적표) |
+| 내 순위 하이라이트 | 배경색 대신 **`border-l-[3px] border-l-foreground` + `font-semibold`** |
+| 순위 숫자 | `font-mono`, `tabular-nums` |
+| 기록 시간 | `font-mono`, `tabular-nums` |
+
+### 0.4 비로그인 배너 (§2 대체)
+
+**삭제**: `bg-gradient-to-r from-sudoku-primary/15 via-sudoku-primary/10 to-transparent`, `backdrop-blur-md`.
+
+| 속성 | **v2** |
+|------|--------|
+| 컨테이너 | `rounded-[var(--radius-md)] border border-border bg-card` |
+| 좌측 강조 | `border-l-[3px] border-l-sudoku-primary` |
+| 아이콘 | `LogIn` 16px, `text-muted-foreground`, **배경 박스 없음** |
+| 텍스트 | 14px, `--foreground` (15.02:1) |
+| CTA | `rounded-[var(--radius-sm)]`, `bg-sudoku-primary` + `text-sudoku-primary-foreground` (7.97:1) |
+
+### 0.5 빈 상태 / 에러
+
+`RankingEmpty` · `RankingError` — 컬러 일러스트나 그라데이션 금지.
+아이콘 1개(`text-muted-foreground`) + 문구 + Ghost 버튼. 배경 없음.
+
 ---
 
 ## 1. 와이어프레임 (375px 모바일)

--- a/src/app/HomeContent.tsx
+++ b/src/app/HomeContent.tsx
@@ -2,7 +2,7 @@
 
 import { useCallback } from "react";
 import { useRouter } from "next/navigation";
-import { Sparkles } from "lucide-react";
+import { STAGE_RANGES } from "@/types/game";
 import { useGameStore } from "@/stores/game-store";
 import {
   DifficultyCard,
@@ -11,6 +11,9 @@ import {
 } from "@/components/home";
 import type { DifficultyItem } from "@/components/home";
 import { BrandWordmark } from "@/components/layout";
+
+/** 간행 캡션에 표시할 총 스테이지 수 */
+const TOTAL_STAGES = STAGE_RANGES[STAGE_RANGES.length - 1].endStage;
 
 const HomeContent = () => {
   const router = useRouter();
@@ -29,16 +32,13 @@ const HomeContent = () => {
       <div className="relative flex flex-1 flex-col px-4 py-8 md:px-6 md:py-12">
         {/* ── 히어로 ── */}
         <header className="mx-auto mb-10 w-full max-w-[760px] text-center md:mb-14">
-          {/* Eyebrow */}
-          <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-sudoku-primary/25 bg-sudoku-primary/10 px-3 py-1 backdrop-blur-sm">
-            <Sparkles className="size-3.5 text-sudoku-primary" />
-            <span className="text-(length:--text-small) font-medium tracking-wide text-sudoku-primary">
-              매일 새로운 퍼즐
-            </span>
-          </div>
+          {/* 간행 정보 줄 — pill·아이콘·배경 없이 대문자 모노 + 넓은 자간만 */}
+          <p className="mb-4 font-mono text-(length:--text-small) tracking-[0.2em] uppercase text-muted-foreground">
+            Daily Puzzle · {TOTAL_STAGES} Stages
+          </p>
 
-          {/* 메인 타이틀 */}
-          <h1>
+          {/* 메인 타이틀 — 아래 1px 괘선이 표제 밑줄 역할 */}
+          <h1 className="mx-auto max-w-[420px] border-b border-border pb-4">
             <BrandWordmark size="lg" />
           </h1>
         </header>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -102,75 +102,77 @@
 }
 
 :root {
-  /* ── shadcn/ui 기본 ── */
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
-  --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.87 0 0);
-  --chart-2: oklch(0.556 0 0);
-  --chart-3: oklch(0.439 0 0);
-  --chart-4: oklch(0.371 0 0);
-  --chart-5: oklch(0.269 0 0);
-  --radius: 0.625rem;
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+  /* ── shadcn/ui 기본 (페이퍼 톤 v2 — 따뜻한 오프화이트 종이 + 잉크) ── */
+  --background: oklch(0.968 0.008 85);
+  --foreground: oklch(0.24 0.012 65);
+  --card: oklch(0.985 0.006 85);
+  --card-foreground: oklch(0.24 0.012 65);
+  --popover: oklch(0.985 0.006 85);
+  --popover-foreground: oklch(0.24 0.012 65);
+  --primary: oklch(0.24 0.012 65);
+  --primary-foreground: oklch(0.98 0.005 85);
+  --secondary: oklch(0.935 0.007 85);
+  --secondary-foreground: oklch(0.24 0.012 65);
+  --muted: oklch(0.935 0.007 85);
+  --muted-foreground: oklch(0.50 0.010 65);
+  --accent: oklch(0.925 0.008 85);
+  --accent-foreground: oklch(0.24 0.012 65);
+  --destructive: oklch(0.47 0.17 28);
+  --border: oklch(0.86 0.010 85);
+  /* 입력 필드/outline 테두리 — 유일한 경계 표시이므로 border보다 진하게(3.07:1) */
+  --input: oklch(0.64 0.008 80);
+  --ring: oklch(0.42 0.09 250);
+  --chart-1: oklch(0.86 0.008 80);
+  --chart-2: oklch(0.66 0.008 80);
+  --chart-3: oklch(0.52 0.010 70);
+  --chart-4: oklch(0.40 0.012 70);
+  --chart-5: oklch(0.28 0.014 65);
+  --radius: 0.375rem;
+  --sidebar: oklch(0.985 0.006 85);
+  --sidebar-foreground: oklch(0.24 0.012 65);
+  --sidebar-primary: oklch(0.24 0.012 65);
+  --sidebar-primary-foreground: oklch(0.98 0.005 85);
+  --sidebar-accent: oklch(0.925 0.008 85);
+  --sidebar-accent-foreground: oklch(0.24 0.012 65);
+  --sidebar-border: oklch(0.86 0.010 85);
+  --sidebar-ring: oklch(0.42 0.09 250);
 
-  /* ── 🖌 스도쿠 브랜드 색상 (Light) ── */
-  --sudoku-primary: oklch(0.55 0.18 250);
-  --sudoku-primary-foreground: oklch(0.98 0 0);
-  --sudoku-accent: oklch(0.65 0.15 250);
+  /* ── 🖌 스도쿠 브랜드 색상 (Light) — 펜 잉크 블루 ── */
+  --sudoku-primary: oklch(0.42 0.09 250);
+  --sudoku-primary-foreground: oklch(0.98 0.005 85);
+  --sudoku-accent: oklch(0.52 0.08 250);
 
   /* ── 🖌 셀 상태 색상 (Light) ── */
-  --cell-default: oklch(1 0 0);
-  --cell-default-foreground: oklch(0.25 0 0);
-  --cell-given: oklch(0.97 0 0);
-  --cell-given-foreground: oklch(0.15 0 0);
-  --cell-selected: oklch(0.88 0.08 250);
-  --cell-selected-foreground: oklch(0.20 0 0);
-  --cell-highlighted: oklch(0.93 0.04 250);
-  --cell-same-number: oklch(0.90 0.06 250);
-  --cell-error: oklch(0.90 0.10 25);
-  --cell-error-foreground: oklch(0.50 0.20 25);
-  --cell-locked: oklch(0.94 0 0);
-  --cell-locked-foreground: oklch(0.55 0 0);
-  --cell-completed: oklch(0.90 0.10 145);
+  --cell-default: oklch(0.99 0.004 85);
+  --cell-default-foreground: oklch(0.45 0.10 250);
+  /* given은 default와 같은 배경 — 인쇄된 문제와 빈 칸의 종이는 같다 */
+  --cell-given: oklch(0.99 0.004 85);
+  --cell-given-foreground: oklch(0.22 0.012 65);
+  --cell-selected: oklch(0.86 0.055 250);
+  --cell-selected-foreground: oklch(0.22 0.012 65);
+  --cell-highlighted: oklch(0.955 0.005 85);
+  --cell-same-number: oklch(0.905 0.045 250);
+  --cell-error: oklch(0.895 0.055 30);
+  --cell-error-foreground: oklch(0.47 0.17 28);
+  --cell-locked: oklch(0.925 0.005 85);
+  --cell-locked-foreground: oklch(0.50 0.008 65);
+  --cell-completed: oklch(0.93 0.045 80);
 
   /* ── 🖌 보드 색상 (Light) ── */
-  --board-border: oklch(0.25 0 0);
-  --board-border-thin: oklch(0.80 0 0);
-  --board-bg: oklch(0.97 0 0);
+  --board-border: oklch(0.26 0.012 65);
+  --board-border-thin: oklch(0.64 0.008 80);
+  --board-bg: oklch(0.968 0.008 85);
 
-  /* ── 🖌 난이도 색상 ── */
-  --difficulty-easy: oklch(0.72 0.16 145);
-  --difficulty-medium: oklch(0.75 0.15 85);
-  --difficulty-hard: oklch(0.68 0.18 50);
-  --difficulty-expert: oklch(0.60 0.20 25);
+  /* ── 🖌 난이도 색상 — 무채색 잉크 명도 사다리 (진할수록 어렵다) ── */
+  --difficulty-easy: oklch(0.53 0.010 65);
+  --difficulty-medium: oklch(0.44 0.012 65);
+  --difficulty-hard: oklch(0.36 0.014 65);
+  --difficulty-expert: oklch(0.25 0.016 65);
 
   /* ── 🖌 기능 색상 (Light) ── */
-  --success: oklch(0.72 0.16 145);
-  --warning: oklch(0.75 0.15 85);
-  --info: oklch(0.65 0.15 250);
+  --success: oklch(0.48 0.09 150);
+  --warning: oklch(0.53 0.09 75);
+  --info: oklch(0.45 0.09 250);
 
   /* ── 🖌 게임 보드 간격 ── */
   --cell-size: 40px;
@@ -197,11 +199,11 @@
   --text-numpad: 24px;
   --text-timer: 20px;
 
-  /* ── 🖌 그림자 (Light) ── */
-  --shadow-board: 0 2px 8px oklch(0 0 0 / 0.08), 0 0 0 3px oklch(0.25 0 0);
-  --shadow-cell-selected: inset 0 0 0 2px oklch(0.55 0.18 250);
-  --shadow-numpad: 0 2px 4px oklch(0 0 0 / 0.06);
-  --shadow-xl: 0 20px 25px oklch(0 0 0 / 0.10), 0 8px 10px oklch(0 0 0 / 0.04);
+  /* ── 🖌 그림자 (Light) — 인쇄 자국. 오프셋 1~2px, 글로우 없음 ── */
+  --shadow-board: 0 1px 2px oklch(0.24 0.012 65 / 0.10), 0 0 0 2px oklch(0.26 0.012 65);
+  --shadow-cell-selected: inset 0 0 0 2px oklch(0.42 0.09 250);
+  --shadow-numpad: 0 1px 0 oklch(0.24 0.012 65 / 0.08);
+  --shadow-xl: 0 8px 24px oklch(0.24 0.012 65 / 0.12), 0 2px 6px oklch(0.24 0.012 65 / 0.06);
 
   /* ── 🖌 애니메이션 duration ── */
   --duration-fast: 100ms;
@@ -228,81 +230,82 @@
   --z-toast: 80;
 }
 
+/* 다크 모드 = 갱지 뒷면 / 흑지. 종이는 따뜻한 흑갈색(hue 70), 잉크는 흰 잉크로 반전된다. */
 .dark {
   /* ── shadcn/ui 기본 ── */
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.87 0 0);
-  --chart-2: oklch(0.556 0 0);
-  --chart-3: oklch(0.439 0 0);
-  --chart-4: oklch(0.371 0 0);
-  --chart-5: oklch(0.269 0 0);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  --background: oklch(0.185 0.008 70);
+  --foreground: oklch(0.92 0.012 85);
+  --card: oklch(0.235 0.008 70);
+  --card-foreground: oklch(0.92 0.012 85);
+  --popover: oklch(0.235 0.008 70);
+  --popover-foreground: oklch(0.92 0.012 85);
+  --primary: oklch(0.92 0.012 85);
+  --primary-foreground: oklch(0.18 0.010 70);
+  --secondary: oklch(0.285 0.008 70);
+  --secondary-foreground: oklch(0.92 0.012 85);
+  --muted: oklch(0.285 0.008 70);
+  --muted-foreground: oklch(0.70 0.010 80);
+  --accent: oklch(0.30 0.008 70);
+  --accent-foreground: oklch(0.92 0.012 85);
+  --destructive: oklch(0.68 0.15 28);
+  --border: oklch(0.34 0.008 70);
+  --input: oklch(0.54 0.008 70);
+  --ring: oklch(0.72 0.095 250);
+  --chart-1: oklch(0.30 0.008 70);
+  --chart-2: oklch(0.46 0.008 70);
+  --chart-3: oklch(0.60 0.010 75);
+  --chart-4: oklch(0.74 0.010 80);
+  --chart-5: oklch(0.88 0.012 85);
+  --sidebar: oklch(0.235 0.008 70);
+  --sidebar-foreground: oklch(0.92 0.012 85);
+  --sidebar-primary: oklch(0.92 0.012 85);
+  --sidebar-primary-foreground: oklch(0.18 0.010 70);
+  --sidebar-accent: oklch(0.30 0.008 70);
+  --sidebar-accent-foreground: oklch(0.92 0.012 85);
+  --sidebar-border: oklch(0.34 0.008 70);
+  --sidebar-ring: oklch(0.72 0.095 250);
 
   /* ── 🖌 스도쿠 브랜드 색상 (Dark) ── */
-  --sudoku-primary: oklch(0.68 0.16 250);
-  --sudoku-primary-foreground: oklch(0.98 0 0);
-  --sudoku-accent: oklch(0.55 0.13 250);
+  --sudoku-primary: oklch(0.72 0.095 250);
+  --sudoku-primary-foreground: oklch(0.18 0.010 70);
+  --sudoku-accent: oklch(0.62 0.085 250);
 
   /* ── 🖌 셀 상태 색상 (Dark) ── */
-  --cell-default: oklch(0.22 0 0);
-  --cell-default-foreground: oklch(0.92 0 0);
-  --cell-given: oklch(0.26 0 0);
-  --cell-given-foreground: oklch(0.95 0 0);
-  --cell-selected: oklch(0.35 0.10 250);
-  --cell-selected-foreground: oklch(0.95 0 0);
-  --cell-highlighted: oklch(0.28 0.06 250);
-  --cell-same-number: oklch(0.32 0.08 250);
-  --cell-error: oklch(0.30 0.10 25);
-  --cell-error-foreground: oklch(0.70 0.18 25);
-  --cell-locked: oklch(0.24 0 0);
-  --cell-locked-foreground: oklch(0.60 0 0);
-  --cell-completed: oklch(0.35 0.10 145);
+  --cell-default: oklch(0.235 0.008 70);
+  --cell-default-foreground: oklch(0.78 0.09 250);
+  --cell-given: oklch(0.235 0.008 70);
+  --cell-given-foreground: oklch(0.94 0.008 85);
+  --cell-selected: oklch(0.375 0.075 250);
+  --cell-selected-foreground: oklch(0.95 0.008 85);
+  --cell-highlighted: oklch(0.295 0.005 70);
+  --cell-same-number: oklch(0.335 0.06 250);
+  --cell-error: oklch(0.325 0.08 28);
+  --cell-error-foreground: oklch(0.76 0.14 28);
+  --cell-locked: oklch(0.205 0.005 70);
+  --cell-locked-foreground: oklch(0.62 0.008 70);
+  --cell-completed: oklch(0.34 0.05 80);
 
   /* ── 🖌 보드 색상 (Dark) ── */
-  --board-border: oklch(0.80 0 0);
-  --board-border-thin: oklch(0.35 0 0);
-  --board-bg: oklch(0.18 0 0);
+  --board-border: oklch(0.78 0.010 85);
+  --board-border-thin: oklch(0.54 0.008 70);
+  --board-bg: oklch(0.185 0.008 70);
 
   /* ── 🖌 기능 색상 (Dark) ── */
-  --success: oklch(0.65 0.14 145);
-  --warning: oklch(0.68 0.13 85);
-  --info: oklch(0.58 0.13 250);
+  --success: oklch(0.70 0.10 150);
+  --warning: oklch(0.76 0.095 75);
+  --info: oklch(0.72 0.09 250);
 
-  /* ── 🖌 난이도 색상 (Dark) — 어두운 배경에서 채도/명도 보정 ── */
-  --difficulty-easy: oklch(0.68 0.18 145);
-  --difficulty-medium: oklch(0.72 0.17 85);
-  --difficulty-hard: oklch(0.65 0.20 50);
-  --difficulty-expert: oklch(0.58 0.22 25);
+  /* ── 🖌 난이도 색상 (Dark) — 방향만 반전, 밝을수록 어렵다 ── */
+  --difficulty-easy: oklch(0.62 0.010 85);
+  --difficulty-medium: oklch(0.72 0.010 85);
+  --difficulty-hard: oklch(0.82 0.010 85);
+  --difficulty-expert: oklch(0.94 0.010 85);
 
-  /* ── 🖌 그림자 (Dark → 글로우 효과) ── */
-  --shadow-board: 0 2px 8px oklch(0 0 0 / 0.3), 0 0 0 3px oklch(0.80 0 0);
-  --shadow-cell-selected: inset 0 0 0 2px oklch(0.68 0.16 250);
-  --shadow-numpad: 0 2px 4px oklch(0 0 0 / 0.2);
-  --shadow-xl: 0 20px 25px oklch(0 0 0 / 0.30), 0 8px 10px oklch(0 0 0 / 0.15);
+  /* ── 🖌 그림자 (Dark) ── */
+  --shadow-board: 0 1px 2px oklch(0 0 0 / 0.4), 0 0 0 2px oklch(0.78 0.010 85);
+  --shadow-cell-selected: inset 0 0 0 2px oklch(0.72 0.095 250);
+  --shadow-numpad: 0 1px 0 oklch(0 0 0 / 0.35);
+  --shadow-xl: 0 8px 24px oklch(0 0 0 / 0.5), 0 2px 6px oklch(0 0 0 / 0.3);
 }
 
 /* ── 🖌 반응형 브레이크포인트 CSS 변수 오버라이드 ── */
@@ -508,146 +511,42 @@
   }
   50% {
     transform: scale(1.02);
-    filter: brightness(1.1);
   }
   100% {
     transform: scale(1);
-    filter: brightness(1);
   }
 }
 
-/* ── 🖌 홈 화면 데코레이션 ── */
+/* ── 🖌 페이퍼 톤 유틸리티 ── */
 
-/* 그라디언트 메쉬 배경 */
-.home-mesh-bg {
-  background:
-    radial-gradient(circle at 15% 20%, oklch(0.88 0.12 250 / 0.55), transparent 45%),
-    radial-gradient(circle at 85% 15%, oklch(0.85 0.14 320 / 0.45), transparent 50%),
-    radial-gradient(circle at 75% 85%, oklch(0.86 0.13 30 / 0.40), transparent 55%),
-    radial-gradient(circle at 20% 90%, oklch(0.88 0.11 180 / 0.40), transparent 50%);
-}
-
-.dark .home-mesh-bg {
-  background:
-    radial-gradient(circle at 15% 20%, oklch(0.40 0.18 260 / 0.55), transparent 45%),
-    radial-gradient(circle at 85% 15%, oklch(0.38 0.18 320 / 0.45), transparent 50%),
-    radial-gradient(circle at 75% 85%, oklch(0.40 0.18 30 / 0.40), transparent 55%),
-    radial-gradient(circle at 20% 90%, oklch(0.38 0.16 180 / 0.40), transparent 50%);
-}
-
-/* 9x9 스도쿠 그리드 데코 (배경)
- * 모바일에서는 backdrop-blur 중첩과 함께 스크롤 저더를 유발할 수 있어 768px 미만 비활성화. */
-.sudoku-grid-bg {
+/* 모눈종이 지면 — 그라데이션 없음, 색 없음.
+ * 고정 24px 모눈이라 리사이즈 시 리플로우가 없다. */
+.paper-bg {
+  background-color: var(--background);
   background-image:
-    linear-gradient(to right, color-mix(in oklch, var(--sudoku-primary) 6%, transparent) 1px, transparent 1px),
-    linear-gradient(to bottom, color-mix(in oklch, var(--sudoku-primary) 6%, transparent) 1px, transparent 1px);
-  background-size: calc(100% / 9) calc(100% / 9);
+    linear-gradient(to right, oklch(0.45 0.01 70 / 0.05) 1px, transparent 1px),
+    linear-gradient(to bottom, oklch(0.45 0.01 70 / 0.05) 1px, transparent 1px);
+  background-size: 24px 24px;
 }
 
-@media (max-width: 767px) {
-  .sudoku-grid-bg {
+.dark .paper-bg {
+  background-image:
+    linear-gradient(to right, oklch(0.85 0.01 85 / 0.045) 1px, transparent 1px),
+    linear-gradient(to bottom, oklch(0.85 0.01 85 / 0.045) 1px, transparent 1px);
+}
+
+/* 초소형 뷰포트에서는 모눈 페인트 비용을 아낀다 */
+@media (max-width: 359px) {
+  .paper-bg {
     background-image: none;
   }
 }
 
-/* 난이도별 그라디언트 — 두 번째 스톱은 어둡게 색을 섞어 깊이감 부여
- * (color-mix로 var(--difficulty-*) 토큰 기반이라 다크모드 자동 보정) */
-.gradient-easy {
-  background: linear-gradient(
-    135deg,
-    var(--difficulty-easy),
-    color-mix(in oklch, var(--difficulty-easy) 70%, black)
+/* 잠금 칸 대각 빗금 — 색 없이 "막힌 칸"임을 전달 (색각이상 대응 필수 신호) */
+.cell-hatch {
+  background-image: repeating-linear-gradient(
+    45deg,
+    transparent 0 3px,
+    color-mix(in oklch, var(--cell-locked-foreground) 22%, transparent) 3px 4px
   );
-}
-.gradient-medium {
-  background: linear-gradient(
-    135deg,
-    var(--difficulty-medium),
-    color-mix(in oklch, var(--difficulty-medium) 70%, black)
-  );
-}
-.gradient-hard {
-  background: linear-gradient(
-    135deg,
-    var(--difficulty-hard),
-    color-mix(in oklch, var(--difficulty-hard) 70%, black)
-  );
-}
-.gradient-expert {
-  background: linear-gradient(
-    135deg,
-    var(--difficulty-expert),
-    color-mix(in oklch, var(--difficulty-expert) 70%, black)
-  );
-}
-
-/* 텍스트 그라디언트 */
-.text-gradient-brand {
-  background: linear-gradient(
-    135deg,
-    var(--sudoku-primary) 0%,
-    var(--difficulty-hard) 50%,
-    var(--difficulty-expert) 100%
-  );
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
-  color: transparent;
-}
-
-/* 카드 호버 글로우 — 난이도 토큰 기반으로 다크모드도 자동 보정 */
-.card-glow-easy:hover {
-  box-shadow: 0 16px 48px color-mix(in oklch, var(--difficulty-easy) 30%, transparent);
-}
-.card-glow-medium:hover {
-  box-shadow: 0 16px 48px color-mix(in oklch, var(--difficulty-medium) 30%, transparent);
-}
-.card-glow-hard:hover {
-  box-shadow: 0 16px 48px color-mix(in oklch, var(--difficulty-hard) 30%, transparent);
-}
-.card-glow-expert:hover {
-  box-shadow: 0 16px 48px color-mix(in oklch, var(--difficulty-expert) 30%, transparent);
-}
-
-@keyframes float-slow {
-  0%, 100% { transform: translateY(0px); }
-  50% { transform: translateY(-8px); }
-}
-
-.animate-float-slow {
-  animation: float-slow 6s ease-in-out infinite;
-}
-
-@keyframes shimmer {
-  0% { background-position: 0% 50%; }
-  100% { background-position: 200% 50%; }
-}
-
-.animate-text-shimmer {
-  background: linear-gradient(
-    90deg,
-    var(--sudoku-primary) 0%,
-    var(--difficulty-hard) 25%,
-    var(--difficulty-expert) 50%,
-    var(--difficulty-hard) 75%,
-    var(--sudoku-primary) 100%
-  );
-  background-size: 200% auto;
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
-  color: transparent;
-  animation: shimmer 6s linear infinite;
-}
-
-/* Windows 고대비 모드 등 forced-colors 환경에서는
- * background-clip: text 패턴이 텍스트를 보이지 않게 만들 수 있어 폴백 처리. */
-@media (forced-colors: active) {
-  .animate-text-shimmer,
-  .text-gradient-brand {
-    background: none;
-    -webkit-text-fill-color: currentColor;
-    color: CanvasText;
-    animation: none;
-  }
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import Providers from "@/components/providers";
+import { THEME_COLOR, THEME_INIT_SCRIPT } from "@/lib/theme";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -52,7 +53,8 @@ export const viewport: Viewport = {
   initialScale: 1,
   maximumScale: 1,
   userScalable: false,
-  themeColor: "#15120f",
+  // 단일 값(라이트)으로 두고, 다크일 때는 초기화 스크립트/ThemeToggle이 meta를 갱신한다.
+  themeColor: THEME_COLOR.light,
 };
 
 export default function RootLayout({
@@ -64,10 +66,16 @@ export default function RootLayout({
     <html
       lang="ko"
       className={`${geistSans.variable} ${geistMono.variable} h-full antialiased`}
+      // 초기화 스크립트가 첫 페인트 전에 dark 클래스를 붙이므로 서버 HTML과 어긋난다 (의도된 것)
+      suppressHydrationWarning
     >
+      <head>
+        {/* 첫 페인트 전에 dark 클래스를 심어 새로고침 시 라이트 번쩍임(FOUC)을 막는다 */}
+        <script dangerouslySetInnerHTML={{ __html: THEME_INIT_SCRIPT }} />
+      </head>
       <body className="min-h-full flex flex-col">
-          <Providers>{children}</Providers>
-        </body>
+        <Providers>{children}</Providers>
+      </body>
     </html>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -52,7 +52,7 @@ export const viewport: Viewport = {
   initialScale: 1,
   maximumScale: 1,
   userScalable: false,
-  themeColor: "#09090b",
+  themeColor: "#15120f",
 };
 
 export default function RootLayout({

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -54,10 +54,10 @@ const LoginContent = () => {
       <div className="flex flex-1 items-center justify-center px-6 py-10 lg:gap-16">
         {/* 좌측 일러스트 영역 (≥1024px만 표시) */}
         <div className="hidden lg:flex lg:flex-col lg:items-center lg:gap-6">
-          <div className="flex size-32 items-center justify-center rounded-3xl bg-gradient-to-br from-sudoku-primary/20 via-sudoku-primary/10 to-transparent backdrop-blur-sm">
+          <div className="flex size-32 items-center justify-center rounded-[var(--radius-lg)] border border-border bg-card">
             <Grid3X3
-              className="size-20 text-sudoku-primary"
-              strokeWidth={1.5}
+              className="size-20 text-muted-foreground"
+              strokeWidth={1.25}
             />
           </div>
           <div className="text-center">
@@ -73,15 +73,15 @@ const LoginContent = () => {
           className={
             "flex w-full flex-col items-center " +
             /* ≥768px: 카드 UI */
-            "md:w-100 md:rounded-2xl md:border md:border-border/60 md:bg-card/80 md:p-8 md:shadow-xl md:backdrop-blur-xl"
+            "md:w-100 md:rounded-[var(--radius-lg)] md:border md:border-border md:bg-card md:p-8"
           }
         >
           {/* 로고 & 텍스트 (PC 2컬럼에서는 숨김) */}
           <div className="flex flex-col items-center lg:hidden">
-            <div className="flex size-20 items-center justify-center rounded-2xl bg-gradient-to-br from-sudoku-primary/20 via-sudoku-primary/10 to-transparent">
+            <div className="flex size-20 items-center justify-center rounded-[var(--radius-lg)] border border-border bg-card">
               <Grid3X3
-                className="size-12 text-sudoku-primary"
-                strokeWidth={1.5}
+                className="size-12 text-muted-foreground"
+                strokeWidth={1.25}
               />
             </div>
             <h2 className="mt-4">

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,4 +1,5 @@
 import type { MetadataRoute } from "next";
+import { THEME_COLOR } from "@/lib/theme";
 
 export default function manifest(): MetadataRoute.Manifest {
   return {
@@ -7,8 +8,8 @@ export default function manifest(): MetadataRoute.Manifest {
     description: "스도쿠 웹앱 — Next.js 15 PWA",
     start_url: "/",
     display: "standalone",
-    theme_color: "#09090b",
-    background_color: "#09090b",
+    theme_color: THEME_COLOR.light,
+    background_color: THEME_COLOR.light,
     icons: [
       { src: "/icons/icon-192x192.png", sizes: "192x192", type: "image/png", purpose: "any" },
       { src: "/icons/icon-192x192.png", sizes: "192x192", type: "image/png", purpose: "maskable" },

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -18,7 +18,7 @@ const PrivacyPage = () => {
           시행일: {UPDATED_AT}
         </p>
 
-        <div className="mt-8 space-y-8 text-sm leading-relaxed text-foreground/90">
+        <div className="mt-8 space-y-8 text-sm leading-relaxed text-foreground">
           <p>
             Sudoku(이하 “서비스”)는 이용자의 개인정보를 소중히 다루며, 아래와
             같이 최소한의 정보만 수집·이용합니다. 본 서비스는 개인이 운영하는

--- a/src/components/game/Cell.tsx
+++ b/src/components/game/Cell.tsx
@@ -81,7 +81,9 @@ const Cell = memo(
 
     // ── 텍스트 색상 결정 ──
     const textClass = useMemo(() => {
-      if (cell.isError) return "text-cell-error-foreground";
+      // 밑줄 = 오류의 비색상 신호 (빨간펜 체크)
+      if (cell.isError)
+        return "text-cell-error-foreground underline decoration-2 underline-offset-4";
       if (isSelected) return "text-cell-selected-foreground";
       if (cell.isGiven) return "text-cell-given-foreground font-bold";
       return "text-cell-default-foreground";
@@ -131,7 +133,7 @@ const Cell = memo(
           <div className="flex flex-col items-center gap-0.5">
             <Lock
               className="size-5 text-cell-locked-foreground"
-              strokeWidth={2.5}
+              strokeWidth={1.75}
               aria-hidden="true"
             />
           </div>
@@ -183,8 +185,8 @@ const Cell = memo(
           "transition-[background-color,box-shadow] duration-(--duration-fast) ease-out",
           /* 커서 */
           cell.isLocked ? "cursor-not-allowed" : cell.isGiven ? "cursor-default" : "cursor-pointer",
-          /* 잠금 셀 */
-          cell.isLocked && "opacity-80",
+          /* 잠금 셀 — 빗금 패턴이 투명도를 대신한다 (색 없이 "막힌 칸" 전달) */
+          cell.isLocked && "cell-hatch",
         )}
       >
         {renderContent()}

--- a/src/components/game/ClearModal.tsx
+++ b/src/components/game/ClearModal.tsx
@@ -116,7 +116,7 @@ const StarRating = memo(({ stars, baseDelay }: StarRatingProps) => (
         className={
           i <= stars
             ? "text-warning fill-warning"
-            : "text-muted fill-muted"
+            : "text-muted-foreground fill-transparent"
         }
         style={{
           animation: `star-scale-in 200ms ease-out ${baseDelay + (i - 1) * 100}ms both`,
@@ -307,7 +307,7 @@ const ClearModal = () => {
           "max-[374px]:w-[calc(100vw_-_32px)] " +
           "min-[768px]:max-w-[420px] " +
           "max-h-[90vh] overflow-y-auto " +
-          "bg-card border border-border rounded-xl " +
+          "bg-card border border-border rounded-[var(--radius-lg)] " +
           "py-8 px-6 " +
           "flex flex-col items-center " +
           "max-[374px]:py-6 max-[374px]:px-4 " +
@@ -390,7 +390,7 @@ const ClearModal = () => {
           <div
             className={
               "w-full mb-6 flex items-center gap-3 " +
-              "bg-success/10 border border-success/30 " +
+              "border border-border bg-secondary " +
               "rounded-[var(--radius-md)] py-3 px-4"
             }
             style={{
@@ -420,7 +420,7 @@ const ClearModal = () => {
           <Button
             ref={primaryBtnRef}
             variant="default"
-            className="h-12 w-full gap-2 text-base bg-sudoku-primary hover:bg-sudoku-primary/90"
+            className="h-12 w-full gap-2 text-base bg-sudoku-primary hover:bg-sudoku-accent"
             onClick={handleNextStage}
           >
             <Play size={16} />

--- a/src/components/game/GameHeader.tsx
+++ b/src/components/game/GameHeader.tsx
@@ -99,9 +99,9 @@ const GameHeader = ({ children }: GameHeaderProps) => {
       }
     >
       {isPaused ? (
-        <Play size={20} strokeWidth={2} />
+        <Play size={20} strokeWidth={1.75} />
       ) : (
-        <Pause size={20} strokeWidth={2} />
+        <Pause size={20} strokeWidth={1.75} />
       )}
     </button>
   ) : undefined;

--- a/src/components/game/LockedCellPopover.tsx
+++ b/src/components/game/LockedCellPopover.tsx
@@ -85,7 +85,7 @@ const LockedCellPopover = ({
             "bg-secondary px-4 py-2 " +
             "text-(length:--text-caption) font-medium text-secondary-foreground " +
             "transition-colors duration-(--duration-fast) " +
-            "hover:bg-secondary/80 " +
+            "hover:bg-secondary " +
             "cursor-pointer"
           }
         >

--- a/src/components/game/NumberPad.tsx
+++ b/src/components/game/NumberPad.tsx
@@ -157,7 +157,7 @@ const NumberPad = ({ className = "" }: NumberPadProps) => {
           "flex items-center justify-center " +
           "w-[var(--numpad-button-size)] h-[var(--numpad-button-size)] " +
           "rounded-[var(--radius-md)] " +
-          "cursor-pointer bg-card shadow-[var(--shadow-numpad)] " +
+          "cursor-pointer border border-border bg-card shadow-[var(--shadow-numpad)] " +
           "text-muted-foreground " +
           "transition-colors duration-[var(--duration-fast)] " +
           "hover:bg-accent " +
@@ -165,7 +165,7 @@ const NumberPad = ({ className = "" }: NumberPadProps) => {
           "disabled:opacity-40 disabled:pointer-events-none"
         }
       >
-        <Delete size={20} strokeWidth={2} />
+        <Delete size={20} strokeWidth={1.75} />
       </button>
     </div>
   );
@@ -206,8 +206,8 @@ const DigitButton = memo(({ digit, isComplete, disabled, onPress }: DigitButtonP
         "font-mono text-(length:--text-numpad) font-medium " +
         "transition-colors duration-[var(--duration-fast)] " +
         (isComplete
-          ? "opacity-30 bg-muted text-muted-foreground pointer-events-none "
-          : "cursor-pointer bg-card text-foreground shadow-[var(--shadow-numpad)] " +
+          ? "opacity-35 border border-border bg-muted text-muted-foreground pointer-events-none "
+          : "cursor-pointer border border-border bg-card text-foreground shadow-[var(--shadow-numpad)] " +
             "hover:bg-accent " +
             "active:animate-numpad-press active:bg-sudoku-primary active:text-sudoku-primary-foreground " +
             "disabled:opacity-40 disabled:pointer-events-none ")

--- a/src/components/game/Toolbar.tsx
+++ b/src/components/game/Toolbar.tsx
@@ -41,7 +41,7 @@ const ToolButton = memo(
         (disabled
           ? "opacity-40 pointer-events-none text-muted-foreground "
           : active
-            ? "cursor-pointer bg-sudoku-primary/10 text-sudoku-primary "
+            ? "cursor-pointer bg-sudoku-primary text-sudoku-primary-foreground font-semibold "
             : "cursor-pointer text-muted-foreground hover:bg-accent ")
       }
     >
@@ -143,26 +143,26 @@ const Toolbar = ({ className = "" }: ToolbarProps) => {
       aria-label="게임 도구"
     >
       <ToolButton
-        icon={<Undo2 size={20} />}
+        icon={<Undo2 size={20} strokeWidth={1.75} />}
         label="되돌리기"
         disabled={!canUndo}
         onClick={handleUndo}
       />
       <ToolButton
-        icon={<Eraser size={20} />}
+        icon={<Eraser size={20} strokeWidth={1.75} />}
         label="지우기"
         disabled={!canErase}
         onClick={handleErase}
       />
       <ToolButton
-        icon={<PenLine size={20} />}
+        icon={<PenLine size={20} strokeWidth={1.75} />}
         label="메모"
         active={isNoteMode}
         disabled={isComplete || isPaused}
         onClick={handleToggleMemo}
       />
       <ToolButton
-        icon={<Lightbulb size={20} />}
+        icon={<Lightbulb size={20} strokeWidth={1.75} />}
         label={`힌트(${hintsRemaining})`}
         disabled={!canHint}
         onClick={handleHint}

--- a/src/components/home/ContinueBanner.tsx
+++ b/src/components/home/ContinueBanner.tsx
@@ -62,19 +62,19 @@ const BannerSkeleton = () => (
     className={
       "flex w-full items-center justify-between " +
       "rounded-[var(--radius-lg)] " +
-      "border border-border/30 bg-muted/20 " +
+      "border border-border bg-muted " +
       "p-4 mb-4 animate-pulse"
     }
     aria-hidden="true"
   >
     <div className="flex items-center gap-3">
-      <div className="size-5 rounded-sm bg-muted/40" />
+      <div className="size-5 rounded-sm bg-border" />
       <div className="flex flex-col gap-1.5">
-        <div className="h-3.5 w-32 rounded bg-muted/40" />
-        <div className="h-3 w-44 rounded bg-muted/40" />
+        <div className="h-3.5 w-32 rounded bg-border" />
+        <div className="h-3 w-44 rounded bg-border" />
       </div>
     </div>
-    <div className="h-4 w-16 rounded bg-muted/40" />
+    <div className="h-4 w-16 rounded bg-border" />
   </div>
 );
 
@@ -141,17 +141,20 @@ const ContinueBanner = () => {
       aria-label={`진행 중인 게임 이어하기 — ${difficultyLabel}, ${formatTime(timer)} 경과, ${progress}% 완료`}
       className={
         "flex w-full items-center justify-between " +
-        "rounded-[var(--radius-lg)] " +
-        "border border-sudoku-primary/25 bg-sudoku-primary/12 " +
+        "rounded-[var(--radius-md)] " +
+        "border border-border border-l-[3px] border-l-sudoku-primary bg-card " +
         "p-4 mb-4 " +
         "transition-colors duration-(--duration-fast) " +
-        "hover:bg-sudoku-primary/15 " +
+        "hover:bg-accent " +
         "cursor-pointer"
       }
     >
       {/* 좌측: 아이콘 + 정보 */}
       <div className="flex items-center gap-3 min-w-0">
-        <ClipboardList className="size-5 shrink-0 text-sudoku-primary" />
+        <ClipboardList
+          className="size-5 shrink-0 text-muted-foreground"
+          strokeWidth={1.75}
+        />
         <div className="flex flex-col items-start gap-0.5 min-w-0">
           <span className="text-(length:--text-caption) font-medium text-foreground">
             진행 중인 게임이 있습니다
@@ -170,7 +173,7 @@ const ContinueBanner = () => {
         }
       >
         이어하기
-        <ChevronRight className="size-4" />
+        <ChevronRight className="size-4" strokeWidth={1.75} />
       </div>
     </button>
   );

--- a/src/components/home/DifficultyCard.tsx
+++ b/src/components/home/DifficultyCard.tsx
@@ -28,35 +28,51 @@ const UnlockedInfo = ({
   stars: number | null;
 }) => (
   <div className="flex flex-col items-end gap-1.5">
-    <div className="flex items-center gap-1.5 rounded-full bg-background/60 px-2 py-0.5 backdrop-blur-sm">
-      <Clock className="size-3 text-muted-foreground" />
-      <span className="font-mono text-(length:--text-small) font-medium text-foreground">
+    <div className="flex items-center gap-1.5">
+      <Clock className="size-3 text-muted-foreground" strokeWidth={1.75} />
+      <span className="font-mono tabular-nums text-(length:--text-small) font-medium text-foreground">
         {bestTime !== null ? formatTime(bestTime) : "—"}
       </span>
     </div>
 
     <div className="flex items-center gap-0.5">
-      {stars !== null
-        ? Array.from({ length: 3 }, (_, i) => (
-            <Star
-              key={i}
-              className={`size-3.5 ${
-                i < stars
-                  ? "fill-warning text-warning"
-                  : "text-muted-foreground/30"
-              }`}
-            />
-          ))
-        : Array.from({ length: 3 }, (_, i) => (
-            <Star key={i} className="size-3.5 text-muted-foreground/30" />
-          ))}
+      {Array.from({ length: 3 }, (_, i) => (
+        <Star
+          key={i}
+          strokeWidth={1.75}
+          className={`size-3.5 ${
+            i < (stars ?? 0) ? "fill-warning text-warning" : "text-muted-foreground"
+          }`}
+        />
+      ))}
     </div>
+  </div>
+);
+
+/**
+ * 난이도 pip 게이지 (■■□□)
+ *
+ * 난이도를 색이 아니라 **개수**로 전달한다.
+ * ★은 카드 우측 클리어 등급에 이미 쓰이므로 정사각 pip을 쓴다.
+ * 난이도 정보는 카드 aria-label이 전달하므로 aria-hidden.
+ */
+const LevelPips = ({ level }: { level: 1 | 2 | 3 | 4 }) => (
+  <div className="flex gap-[3px]" aria-hidden="true">
+    {Array.from({ length: 4 }, (_, i) => (
+      <span
+        key={i}
+        className={
+          "size-1.5 rounded-none " +
+          (i < level ? "bg-current" : "border border-current opacity-40")
+        }
+      />
+    ))}
   </div>
 );
 
 const LockedInfo = ({ condition }: { condition: string }) => (
   <div className="flex flex-col items-end gap-1">
-    <Lock className="size-5 text-muted-foreground" />
+    <Lock className="size-5 text-muted-foreground" strokeWidth={1.75} />
     <span className="text-(length:--text-small) text-muted-foreground">
       {condition}
     </span>
@@ -76,7 +92,6 @@ const DifficultyCard = ({
     onPress(difficulty);
   };
 
-  const { gradientClass, glowClass } = difficulty;
   const orderLabel = String(index + 1).padStart(2, "0");
 
   return (
@@ -90,40 +105,27 @@ const DifficultyCard = ({
       }
       className={
         "group relative flex h-[120px] md:h-[140px] w-full items-stretch overflow-hidden " +
-        "rounded-[var(--radius-xl)] border border-border/60 " +
-        "bg-card/80 backdrop-blur-sm " +
-        "transition-all duration-(--duration-normal) " +
+        "rounded-[var(--radius-xl)] border border-border bg-card " +
+        "transition-colors duration-(--duration-normal) " +
         "cursor-pointer text-left " +
         (isLocked
-          ? "opacity-70 "
-          : "shadow-sm hover:-translate-y-1 hover:shadow-xl active:translate-y-0 active:scale-[0.99] " +
-            glowClass +
-            " ")
+          ? "cell-hatch text-muted-foreground "
+          : "shadow-sm hover:bg-accent active:scale-[0.99] ")
       }
     >
-      {/* 좌측 컬러 그라디언트 사이드바 */}
+      {/* 좌측 사이드바 — 색면이 아니라 세로 괄선이 구분한다 */}
       <div
         className={
-          "relative flex w-[72px] shrink-0 flex-col items-center justify-center gap-1.5 md:w-[88px] " +
-          (isLocked ? "bg-muted" : gradientClass)
+          "relative flex w-[72px] shrink-0 flex-col items-center justify-center gap-2 " +
+          "border-r border-border md:w-[88px] " +
+          (isLocked ? "text-muted-foreground" : difficulty.toneClass)
         }
         aria-hidden="true"
       >
-        <span
-          className={
-            "font-mono text-(length:--text-small) font-bold tracking-wider " +
-            (isLocked ? "text-muted-foreground" : "text-white/80")
-          }
-        >
-          #{orderLabel}
+        <span className="font-mono tabular-nums text-(length:--text-small) tracking-wider text-muted-foreground">
+          {orderLabel}
         </span>
-        <difficulty.icon
-          className={
-            "size-7 md:size-8 " +
-            (isLocked ? "text-muted-foreground" : "text-white drop-shadow-sm")
-          }
-          strokeWidth={2.25}
-        />
+        <LevelPips level={difficulty.level} />
       </div>
 
       {/* 콘텐츠 영역 */}
@@ -140,9 +142,7 @@ const DifficultyCard = ({
           <span
             className={
               "font-mono text-(length:--text-small) tracking-wider uppercase " +
-              (isLocked
-                ? "text-muted-foreground/70"
-                : "text-muted-foreground")
+              "text-muted-foreground"
             }
           >
             {difficulty.labelEn}
@@ -161,12 +161,12 @@ const DifficultyCard = ({
             aria-hidden="true"
             className={
               "absolute right-3 top-3 flex size-7 items-center justify-center " +
-              "rounded-full bg-foreground/0 text-foreground/0 " +
-              "transition-all duration-(--duration-normal) " +
-              "group-hover:bg-foreground group-hover:text-background"
+              "rounded-none text-transparent " +
+              "transition-colors duration-(--duration-normal) " +
+              "group-hover:text-muted-foreground"
             }
           >
-            <ArrowUpRight className="size-4" />
+            <ArrowUpRight className="size-4" strokeWidth={1.75} />
           </div>
         )}
       </div>

--- a/src/components/home/difficulty-data.ts
+++ b/src/components/home/difficulty-data.ts
@@ -5,8 +5,6 @@
  * UX 플로우: docs/design/ux-flow.md §3.1 해금 조건
  */
 
-import { Sprout, Flame, Zap, Crown, type LucideIcon } from "lucide-react";
-
 // ────────────────────────────────────────
 // Types
 // ────────────────────────────────────────
@@ -18,14 +16,10 @@ export interface DifficultyItem {
   label: string;
   /** 영문명 */
   labelEn: string;
-  /** 좌측 인디케이터 Tailwind 배경 클래스 */
-  indicatorClass: string;
-  /** 난이도 상징 아이콘 (lucide-react) */
-  icon: LucideIcon;
-  /** 카드 좌측 사이드바 그라디언트 클래스 (globals.css 정의) */
-  gradientClass: string;
-  /** 카드 호버 시 글로우 그림자 클래스 (globals.css 정의) */
-  glowClass: string;
+  /** 난이도 등급 1~4 — pip 게이지(■■□□) 채움 개수 */
+  level: 1 | 2 | 3 | 4;
+  /** 텍스트/눈금 잉크 톤 클래스 */
+  toneClass: string;
   /** 해금 조건 텍스트 (null이면 항상 해금) */
   unlockCondition: string | null;
   /** 게임 시작 시 사용할 첫 번째 스테이지 번호 */
@@ -55,10 +49,8 @@ export const DIFFICULTIES: readonly DifficultyItem[] = [
     id: "easy",
     label: "쉬움",
     labelEn: "Easy",
-    indicatorClass: "bg-difficulty-easy",
-    icon: Sprout,
-    gradientClass: "gradient-easy",
-    glowClass: "card-glow-easy",
+    level: 1,
+    toneClass: "text-difficulty-easy",
     unlockCondition: null,
     startStage: 1,
   },
@@ -66,10 +58,8 @@ export const DIFFICULTIES: readonly DifficultyItem[] = [
     id: "medium",
     label: "보통",
     labelEn: "Medium",
-    indicatorClass: "bg-difficulty-medium",
-    icon: Flame,
-    gradientClass: "gradient-medium",
-    glowClass: "card-glow-medium",
+    level: 2,
+    toneClass: "text-difficulty-medium",
     unlockCondition: "쉬움 클리어 시 해금",
     startStage: 11,
   },
@@ -77,10 +67,8 @@ export const DIFFICULTIES: readonly DifficultyItem[] = [
     id: "hard",
     label: "어려움",
     labelEn: "Hard",
-    indicatorClass: "bg-difficulty-hard",
-    icon: Zap,
-    gradientClass: "gradient-hard",
-    glowClass: "card-glow-hard",
+    level: 3,
+    toneClass: "text-difficulty-hard",
     unlockCondition: "보통 클리어 시 해금",
     startStage: 21,
   },
@@ -88,10 +76,8 @@ export const DIFFICULTIES: readonly DifficultyItem[] = [
     id: "expert",
     label: "전문가",
     labelEn: "Expert",
-    indicatorClass: "bg-difficulty-expert",
-    icon: Crown,
-    gradientClass: "gradient-expert",
-    glowClass: "card-glow-expert",
+    level: 4,
+    toneClass: "text-difficulty-expert",
     unlockCondition: "어려움 클리어 시 해금",
     startStage: 31,
   },

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -61,18 +61,12 @@ const AppLayout = ({
 
   return (
     <div className="relative flex min-h-dvh flex-col overflow-hidden">
-      {/* ── 전역 ambient 배경 (게임 외) ── */}
+      {/* ── 전역 모눈종이 배경 (게임 외) ── */}
       {showAmbientBg && (
-        <>
-          <div
-            aria-hidden="true"
-            className="home-mesh-bg pointer-events-none absolute inset-0 -z-10"
-          />
-          <div
-            aria-hidden="true"
-            className="sudoku-grid-bg pointer-events-none absolute inset-0 -z-10 opacity-50"
-          />
-        </>
+        <div
+          aria-hidden="true"
+          className="paper-bg pointer-events-none absolute inset-0 -z-10"
+        />
       )}
 
       <Header

--- a/src/components/layout/AppLogo.tsx
+++ b/src/components/layout/AppLogo.tsx
@@ -4,14 +4,10 @@ import Link from "next/link";
 const AppLogo = () => (
   <Link
     href="/"
-    className="group flex h-11 items-center gap-1.5 font-mono text-base font-black tracking-[0.2em] text-foreground"
+    className="flex h-11 items-center font-[family-name:var(--font-geist-sans)] text-base font-normal tracking-[0.14em] text-foreground"
     aria-label="스도쿠 홈"
   >
-    <span>SUDOKU</span>
-    <span
-      aria-hidden="true"
-      className="size-1.5 rounded-full bg-gradient-to-br from-sudoku-primary via-difficulty-hard to-difficulty-expert transition-transform duration-(--duration-normal) group-hover:scale-150"
-    />
+    SUDOKU
   </Link>
 );
 

--- a/src/components/layout/AuthButton.tsx
+++ b/src/components/layout/AuthButton.tsx
@@ -3,7 +3,8 @@
 import Link from "next/link";
 import { LogOut } from "lucide-react";
 import { useAuth } from "@/hooks";
-import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { buttonVariants } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuTrigger,
@@ -71,13 +72,15 @@ const AuthButton = () => {
   }
 
   return (
-    <Button
-      render={<Link href="/login" />}
-      className="h-11 rounded-[var(--radius-sm)] px-4"
-      aria-label="로그인"
+    // 실제로 /login으로 이동하는 네비게이션이므로 <a> 시맨틱이 맞다.
+    // Base UI Button은 nativeButton 기본 true라 <a>를 렌더하면 경고가 나므로,
+    // 스타일만 buttonVariants로 재사용한다 (shadcn link-as-button 패턴).
+    <Link
+      href="/login"
+      className={cn(buttonVariants(), "h-11 rounded-[var(--radius-sm)] px-4")}
     >
       로그인
-    </Button>
+    </Link>
   );
 };
 

--- a/src/components/layout/AuthButton.tsx
+++ b/src/components/layout/AuthButton.tsx
@@ -73,7 +73,7 @@ const AuthButton = () => {
   return (
     <Button
       render={<Link href="/login" />}
-      className="h-11 rounded-full px-4"
+      className="h-11 rounded-[var(--radius-sm)] px-4"
       aria-label="로그인"
     >
       로그인

--- a/src/components/layout/BottomNav.tsx
+++ b/src/components/layout/BottomNav.tsx
@@ -30,20 +30,25 @@ const BottomNav = () => {
               key={href}
               href={href}
               className={
-                "flex flex-1 flex-col items-center justify-center gap-0.5 " +
+                "relative flex flex-1 flex-col items-center justify-center gap-0.5 " +
                 "h-16 min-h-[44px] " +
                 "transition-colors duration-100 active:scale-95 " +
                 (isActive
-                  ? "text-sudoku-primary"
+                  ? "font-semibold text-foreground"
                   : "text-muted-foreground")
               }
               aria-label={ariaLabel}
               aria-current={isActive ? "page" : undefined}
             >
-              <Icon className="size-6" />
-              <span className="text-[11px] font-medium max-[374px]:hidden">
-                {label}
-              </span>
+              {/* 활성 표시 — 색이 아니라 상단 2px 잉크 바 */}
+              {isActive && (
+                <span
+                  aria-hidden="true"
+                  className="absolute inset-x-0 top-0 h-0.5 bg-foreground"
+                />
+              )}
+              <Icon className="size-6" strokeWidth={1.75} />
+              <span className="text-[11px] max-[374px]:hidden">{label}</span>
             </Link>
           );
         })}

--- a/src/components/layout/BrandWordmark.tsx
+++ b/src/components/layout/BrandWordmark.tsx
@@ -1,8 +1,13 @@
 /**
- * 브랜드 워드마크 — `S · U · D · O · K · U` 시머 그라디언트 타이틀
+ * 브랜드 워드마크 — `SUDOKU` 단색 잉크 타이틀
  *
- * 홈/로그인 등 여러 곳에서 동일한 모노 + 트래킹 + 시머 조합을 쓰므로
+ * 홈/로그인 등 여러 곳에서 동일한 자간 조합을 쓰므로
  * 단일 컴포넌트로 추출하여 톤 일관성을 보장한다.
+ *
+ * 페이퍼 톤(v2): 그라데이션·시머 없음. 넓은 자간의 단색 활자만으로
+ * 인쇄물 표제를 표현한다.
+ *
+ * @see docs/design/design-system.md §14.2
  */
 
 import { cn } from "@/lib/utils";
@@ -14,20 +19,21 @@ interface BrandWordmarkProps {
 }
 
 const SIZE_CLASSES: Record<NonNullable<BrandWordmarkProps["size"]>, string> = {
-  sm: "text-lg tracking-[0.18em]",
-  md: "text-xl tracking-[0.18em]",
-  lg: "text-[clamp(1.4rem,5vw,2.75rem)] tracking-[0.1em]",
+  sm: "text-lg",
+  md: "text-xl",
+  lg: "text-[clamp(1.75rem,7vw,3rem)]",
 };
 
 const BrandWordmark = ({ size = "md", className }: BrandWordmarkProps) => (
   <span
     className={cn(
-      "animate-text-shimmer font-mono font-black whitespace-nowrap",
+      "font-[family-name:var(--font-geist-sans)] font-normal",
+      "tracking-[0.14em] whitespace-nowrap text-foreground",
       SIZE_CLASSES[size],
       className,
     )}
   >
-    S · U · D · O · K · U
+    SUDOKU
   </span>
 );
 

--- a/src/components/layout/DesktopNav.tsx
+++ b/src/components/layout/DesktopNav.tsx
@@ -21,14 +21,14 @@ const DesktopNav = () => {
             key={href}
             href={href}
             className={
-              "flex h-9 items-center gap-1.5 rounded-full px-3.5 text-sm font-medium transition-all duration-(--duration-normal) " +
+              "flex h-9 items-center gap-1.5 rounded-[var(--radius-sm)] px-3.5 text-sm transition-colors duration-(--duration-normal) " +
               (isActive
-                ? "bg-sudoku-primary/12 text-sudoku-primary ring-1 ring-sudoku-primary/25"
-                : "text-muted-foreground hover:bg-foreground/5 hover:text-foreground")
+                ? "bg-secondary font-semibold text-foreground"
+                : "font-medium text-muted-foreground hover:bg-accent hover:text-foreground")
             }
             aria-current={isActive ? "page" : undefined}
           >
-            <Icon className="size-4" />
+            <Icon className="size-4" strokeWidth={1.75} />
             {label}
           </Link>
         );

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -4,6 +4,7 @@ import AppLogo from "./AppLogo";
 import BackButton from "./BackButton";
 import AuthButton from "./AuthButton";
 import DesktopNav from "./DesktopNav";
+import ThemeToggle from "./ThemeToggle";
 
 // ────────────────────────────────────────
 // Types
@@ -40,7 +41,12 @@ const resolveSlots = (
           </div>
         ),
         center: null,
-        right: <AuthButton />,
+        right: (
+          <div className="flex items-center gap-1">
+            <ThemeToggle />
+            <AuthButton />
+          </div>
+        ),
       };
 
     case "game":
@@ -63,7 +69,12 @@ const resolveSlots = (
             랭킹
           </span>
         ),
-        right: <AuthButton />,
+        right: (
+          <div className="flex items-center gap-1">
+            <ThemeToggle />
+            <AuthButton />
+          </div>
+        ),
       };
 
     case "login":
@@ -74,7 +85,8 @@ const resolveSlots = (
             로그인
           </span>
         ),
-        right: <div className="size-11" />,
+        // BackButton과 같은 44px이라 중앙 타이틀 정렬을 그대로 유지한다
+        right: <ThemeToggle />,
       };
   }
 };

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -93,8 +93,8 @@ const Header = ({ variant, centerContent, rightContent }: HeaderProps) => {
   return (
     <header
       className={
-        "sticky top-0 z-[var(--z-header)] border-b border-border/40 " +
-        "bg-background/70 backdrop-blur-xl " +
+        "sticky top-0 z-[var(--z-header)] border-b border-border " +
+        "bg-background " +
         "h-14 md:h-16 " +
         "pt-[env(safe-area-inset-top)]"
       }

--- a/src/components/layout/ThemeToggle.tsx
+++ b/src/components/layout/ThemeToggle.tsx
@@ -1,0 +1,50 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Moon, Sun } from "lucide-react";
+import { syncThemeColorMeta } from "@/lib/theme";
+
+/**
+ * 라이트/다크 2단계 토글.
+ * 최초 상태는 layout.tsx의 blocking 인라인 스크립트가 이미 <html>에 심어놨으므로
+ * 여기서는 읽어서 뒤집기만 한다.
+ *
+ * ponytail: next-themes 대신 직접 구현. system/light/dark 3단계는 과설계라 생략.
+ */
+const ThemeToggle = () => {
+  // 서버는 테마를 모른다 → 초기값을 false로 두어 첫 클라이언트 렌더가 서버 HTML과 일치하게 하고
+  // (하이드레이션 경고 방지), 실제 값은 마운트 후 effect에서 채운다.
+  // 아이콘 자체는 상태가 아니라 CSS dark: 변형으로 그려서 마운트 전에도 올바르게 보인다.
+  const [isDark, setIsDark] = useState(false);
+
+  useEffect(() => {
+    setIsDark(document.documentElement.classList.contains("dark"));
+  }, []);
+
+  const toggle = () => {
+    // 진짜 출처는 <html>의 클래스 — React state를 뒤집으면 배칭 중에 어긋난다
+    const next = document.documentElement.classList.toggle("dark");
+    syncThemeColorMeta(next);
+    try {
+      localStorage.setItem("theme", next ? "dark" : "light");
+    } catch {
+      // Safari 프라이빗 모드 등 — 저장 실패해도 이번 세션 전환은 유효하다
+    }
+    setIsDark(next);
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      className="flex size-11 shrink-0 items-center justify-center rounded-md text-foreground transition-colors duration-100 hover:bg-accent"
+      aria-label={isDark ? "라이트 모드로 전환" : "다크 모드로 전환"}
+      aria-pressed={isDark}
+    >
+      <Moon className="size-5 dark:hidden" strokeWidth={1.75} />
+      <Sun className="hidden size-5 dark:block" strokeWidth={1.75} />
+    </button>
+  );
+};
+
+export default ThemeToggle;

--- a/src/components/layout/ThemeToggle.tsx
+++ b/src/components/layout/ThemeToggle.tsx
@@ -1,8 +1,20 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useSyncExternalStore } from "react";
 import { Moon, Sun } from "lucide-react";
 import { syncThemeColorMeta } from "@/lib/theme";
+
+/** <html>의 dark 클래스 변화를 구독 (테마의 진짜 출처는 DOM) */
+const subscribe = (onChange: () => void) => {
+  const observer = new MutationObserver(onChange);
+  observer.observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ["class"],
+  });
+  return () => observer.disconnect();
+};
+
+const isDarkNow = () => document.documentElement.classList.contains("dark");
 
 /**
  * 라이트/다크 2단계 토글.
@@ -12,17 +24,13 @@ import { syncThemeColorMeta } from "@/lib/theme";
  * ponytail: next-themes 대신 직접 구현. system/light/dark 3단계는 과설계라 생략.
  */
 const ThemeToggle = () => {
-  // 서버는 테마를 모른다 → 초기값을 false로 두어 첫 클라이언트 렌더가 서버 HTML과 일치하게 하고
-  // (하이드레이션 경고 방지), 실제 값은 마운트 후 effect에서 채운다.
-  // 아이콘 자체는 상태가 아니라 CSS dark: 변형으로 그려서 마운트 전에도 올바르게 보인다.
-  const [isDark, setIsDark] = useState(false);
-
-  useEffect(() => {
-    setIsDark(document.documentElement.classList.contains("dark"));
-  }, []);
+  // DOM을 구독한다. 서버 스냅샷은 false — 서버는 테마를 모르므로 첫 렌더를
+  // 서버 HTML과 일치시켜 하이드레이션 경고를 피한다.
+  // 아이콘은 상태가 아니라 CSS dark: 변형으로 그려서 마운트 전에도 올바르게 보인다.
+  const isDark = useSyncExternalStore(subscribe, isDarkNow, () => false);
 
   const toggle = () => {
-    // 진짜 출처는 <html>의 클래스 — React state를 뒤집으면 배칭 중에 어긋난다
+    // 진짜 출처는 <html>의 클래스 — 구독이 알아서 리렌더를 유발한다
     const next = document.documentElement.classList.toggle("dark");
     syncThemeColorMeta(next);
     try {
@@ -30,7 +38,6 @@ const ThemeToggle = () => {
     } catch {
       // Safari 프라이빗 모드 등 — 저장 실패해도 이번 세션 전환은 유효하다
     }
-    setIsDark(next);
   };
 
   return (

--- a/src/components/layout/index.ts
+++ b/src/components/layout/index.ts
@@ -5,6 +5,7 @@ export { default as AppLogo } from "./AppLogo";
 export { default as BackButton } from "./BackButton";
 export { default as AuthButton } from "./AuthButton";
 export { default as DesktopNav } from "./DesktopNav";
+export { default as ThemeToggle } from "./ThemeToggle";
 export { default as BrandWordmark } from "./BrandWordmark";
 export type { HeaderVariant } from "./Header";
 export { navItems, BOTTOM_NAV_HIDDEN_PATHS } from "./nav-items";

--- a/src/components/ranking/DifficultyTabs.tsx
+++ b/src/components/ranking/DifficultyTabs.tsx
@@ -21,10 +21,7 @@ interface DifficultyTabsProps {
 
 const DifficultyTabs = ({ activeId, onChange }: DifficultyTabsProps) => {
   return (
-    <div
-      className="mx-4 flex gap-1.5 rounded-full border border-border/60 bg-card/70 p-1.5 backdrop-blur-md"
-      role="tablist"
-    >
+    <div className="mx-4 flex border-b border-border" role="tablist">
       {DIFFICULTY_TABS.map((tab) => {
         const isActive = tab.id === activeId;
 
@@ -35,22 +32,20 @@ const DifficultyTabs = ({ activeId, onChange }: DifficultyTabsProps) => {
             aria-selected={isActive}
             onClick={() => onChange(tab)}
             className={cn(
-              "relative flex flex-1 cursor-pointer items-center justify-center gap-1.5 rounded-full py-2 text-sm font-semibold transition-all duration-(--duration-normal)",
+              "relative flex min-h-[44px] flex-1 cursor-pointer items-center justify-center py-2 text-sm transition-colors duration-(--duration-normal)",
               isActive
-                ? "bg-sudoku-primary/12 text-sudoku-primary ring-1 ring-sudoku-primary/25 shadow-sm"
-                : "text-muted-foreground hover:bg-foreground/5 hover:text-foreground",
+                ? "font-semibold text-foreground"
+                : "font-medium text-muted-foreground hover:text-foreground",
             )}
           >
-            {/* 활성 도트 인디케이터 */}
-            <span
-              className={cn(
-                "size-1.5 rounded-full transition-opacity",
-                tab.activeClass,
-                isActive ? "opacity-100" : "opacity-40",
-              )}
-              aria-hidden="true"
-            />
             {tab.label}
+            {/* 활성 인디케이터 — 난이도별 색이 아니라 하단 2px 잉크 밑줄 */}
+            {isActive && (
+              <span
+                aria-hidden="true"
+                className="absolute inset-x-0 -bottom-px h-0.5 bg-foreground"
+              />
+            )}
           </button>
         );
       })}

--- a/src/components/ranking/LoginBanner.tsx
+++ b/src/components/ranking/LoginBanner.tsx
@@ -11,16 +11,18 @@ import { LogIn } from "lucide-react";
 
 const LoginBanner = () => {
   return (
-    <div className="mx-4 flex items-center gap-3 rounded-2xl border border-sudoku-primary/25 bg-gradient-to-r from-sudoku-primary/15 via-sudoku-primary/10 to-transparent px-4 py-3 backdrop-blur-md">
-      <div className="flex size-9 shrink-0 items-center justify-center rounded-xl bg-sudoku-primary/15">
-        <LogIn className="size-4 text-sudoku-primary" />
-      </div>
+    <div className="mx-4 flex items-center gap-3 rounded-[var(--radius-md)] border border-border border-l-[3px] border-l-sudoku-primary bg-card px-4 py-3">
+      <LogIn
+        className="size-4 shrink-0 text-muted-foreground"
+        strokeWidth={1.75}
+        aria-hidden="true"
+      />
       <p className="flex-1 text-sm text-foreground">
         로그인하면 기록을 저장할 수 있어요
       </p>
       <Link
         href="/login"
-        className="shrink-0 rounded-full bg-sudoku-primary px-3 py-1.5 text-xs font-semibold text-sudoku-primary-foreground shadow-sm transition-all hover:opacity-90"
+        className="flex min-h-[36px] shrink-0 items-center rounded-[var(--radius-sm)] bg-sudoku-primary px-3 text-xs font-semibold text-sudoku-primary-foreground transition-colors hover:bg-sudoku-accent"
       >
         로그인
       </Link>

--- a/src/components/ranking/RankingAvatar.tsx
+++ b/src/components/ranking/RankingAvatar.tsx
@@ -16,11 +16,19 @@ interface RankingAvatarProps {
   name: string;
   /** 크기 (px) */
   size: number;
-  /** 보더 색상 (메달 색상 등) */
+  /** 보더 색상 (순위 잉크 사다리 등) */
   borderColor?: string;
+  /** 보더 두께 (px). 1위 강조는 색이 아니라 두께로 표현한다 */
+  borderWidth?: number;
 }
 
-const RankingAvatar = ({ image, name, size, borderColor }: RankingAvatarProps) => {
+const RankingAvatar = ({
+  image,
+  name,
+  size,
+  borderColor,
+  borderWidth = 1,
+}: RankingAvatarProps) => {
   const initial = name.charAt(0).toUpperCase() || "U";
   const sizeStyle = { width: size, height: size };
 
@@ -31,7 +39,7 @@ const RankingAvatar = ({ image, name, size, borderColor }: RankingAvatarProps) =
       )}
       style={{
         ...sizeStyle,
-        border: borderColor ? `2px solid ${borderColor}` : undefined,
+        border: borderColor ? `${borderWidth}px solid ${borderColor}` : undefined,
       }}
     >
       {image ? (

--- a/src/components/ranking/RankingEmpty.tsx
+++ b/src/components/ranking/RankingEmpty.tsx
@@ -12,16 +12,18 @@ import { Trophy } from "lucide-react";
 const RankingEmpty = () => {
   return (
     <div className="flex flex-col items-center gap-3 py-16">
-      <div className="flex size-16 items-center justify-center rounded-2xl bg-gradient-to-br from-warning/20 via-sudoku-primary/10 to-transparent backdrop-blur-sm">
-        <Trophy className="size-8 text-warning" strokeWidth={1.75} />
-      </div>
+      <Trophy
+        className="size-8 text-muted-foreground"
+        strokeWidth={1.75}
+        aria-hidden="true"
+      />
       <p className="mt-1 text-base font-semibold">아직 기록이 없습니다</p>
       <p className="text-sm text-muted-foreground">
         첫 번째 도전자가 되어보세요!
       </p>
       <Link
         href="/"
-        className="mt-3 inline-flex items-center gap-1.5 rounded-full bg-sudoku-primary px-5 py-2 text-sm font-semibold text-sudoku-primary-foreground shadow-md transition-all hover:opacity-90 hover:shadow-lg"
+        className="mt-3 inline-flex min-h-[44px] items-center gap-1.5 rounded-[var(--radius-sm)] border border-input px-5 text-sm font-semibold text-foreground transition-colors hover:bg-accent"
       >
         게임 시작하기
       </Link>

--- a/src/components/ranking/RankingError.tsx
+++ b/src/components/ranking/RankingError.tsx
@@ -17,7 +17,7 @@ interface RankingErrorProps {
 const RankingError = ({ onRetry }: RankingErrorProps) => {
   return (
     <div className="flex flex-col items-center gap-3 py-16">
-      <AlertCircle className="size-12 text-muted-foreground" />
+      <AlertCircle className="size-12 text-muted-foreground" strokeWidth={1.75} />
       <p className="text-sm text-muted-foreground">
         랭킹을 불러올 수 없습니다
       </p>

--- a/src/components/ranking/RankingList.tsx
+++ b/src/components/ranking/RankingList.tsx
@@ -35,28 +35,19 @@ const RankingListItem = ({
   return (
     <div
       className={cn(
-        "relative flex items-center gap-3 px-4 py-3 transition-colors duration-(--duration-normal) hover:bg-foreground/5",
-        "border-b border-border/40 last:border-b-0",
-        isMe &&
-          "bg-gradient-to-r from-sudoku-primary/10 via-sudoku-primary/5 to-transparent",
+        "relative flex items-center gap-3 px-4 py-3 transition-colors duration-(--duration-normal) hover:bg-accent",
+        // 행 구분 = 1px 괘선 (성적표)
+        "border-b border-border last:border-b-0",
+        // 내 순위 강조 = 배경색이 아니라 좌측 3px 잉크 바 + 굵기
+        isMe && "border-l-[3px] border-l-foreground pl-[13px] font-semibold",
       )}
       style={{ minHeight: 64 }}
     >
-      {/* 본인 액센트 바 */}
-      {isMe && (
-        <div
-          aria-hidden="true"
-          className="absolute inset-y-2 left-0 w-0.5 rounded-full bg-sudoku-primary"
-        />
-      )}
-
       {/* 순위 */}
       <span
         className={cn(
-          "flex size-8 shrink-0 items-center justify-center rounded-lg font-mono text-sm font-bold",
-          isMe
-            ? "bg-sudoku-primary text-sudoku-primary-foreground"
-            : "bg-foreground/5 text-foreground",
+          "flex size-8 shrink-0 items-center justify-center font-mono tabular-nums text-sm text-foreground",
+          isMe && "font-bold",
         )}
       >
         {entry.rank}
@@ -74,7 +65,7 @@ const RankingListItem = ({
         <p className="truncate text-sm font-medium">
           {entry.displayName}
           {isMe && (
-            <span className="ml-1.5 rounded-full bg-sudoku-primary/15 px-1.5 py-0.5 text-[10px] font-bold text-sudoku-primary">
+            <span className="ml-1.5 rounded-[var(--radius-sm)] border border-border px-1.5 py-0.5 font-mono text-[10px] font-bold tracking-wider text-foreground">
               ME
             </span>
           )}
@@ -86,7 +77,7 @@ const RankingListItem = ({
 
       {/* 시간 + 별점 */}
       <div className="flex shrink-0 flex-col items-end gap-0.5">
-        <span className="font-mono text-sm font-semibold">
+        <span className="font-mono tabular-nums text-sm font-semibold">
           {formatTime(entry.clearTime)}
         </span>
         <StarRating stars={entry.stars} size={12} />
@@ -99,7 +90,7 @@ const RankingList = ({ rankings, currentUserId }: RankingListProps) => {
   if (rankings.length === 0) return null;
 
   return (
-    <div className="mx-4 overflow-hidden rounded-2xl border border-border/60 bg-card/70 shadow-sm backdrop-blur-md">
+    <div className="mx-4 overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card">
       {rankings.map((entry) => (
         <RankingListItem
           key={entry.userId}

--- a/src/components/ranking/RankingPodium.tsx
+++ b/src/components/ranking/RankingPodium.tsx
@@ -10,7 +10,7 @@
 "use client";
 
 import type { RankingEntry } from "@/types/ranking";
-import { formatTime, MEDAL_COLORS, MEDAL_EMOJI } from "./ranking-utils";
+import { formatTime, MEDAL_COLORS } from "./ranking-utils";
 import RankingAvatar from "./RankingAvatar";
 import StarRating from "./StarRating";
 
@@ -25,25 +25,27 @@ const PODIUM_ORDER = [1, 0, 2] as const;
 const PodiumItem = ({ entry, rank }: { entry: RankingEntry; rank: 1 | 2 | 3 }) => {
   const isFirst = rank === 1;
   const avatarSize = isFirst ? 56 : 44;
-  const medalColor = MEDAL_COLORS[rank];
-  const medal = MEDAL_EMOJI[rank];
 
   return (
     <div
       className="flex flex-1 flex-col items-center gap-1"
       style={{ paddingTop: isFirst ? 0 : 20 }}
     >
-      {/* 메달 */}
-      <span className="text-lg" aria-label={`${rank}위`}>
-        {medal}
+      {/* 순위 — 이모지 대신 모노 숫자 */}
+      <span
+        className="font-mono tabular-nums text-sm text-muted-foreground"
+        aria-label={`${rank}위`}
+      >
+        #{rank}
       </span>
 
-      {/* 아바타 */}
+      {/* 아바타 — 테두리는 잉크 명도 사다리, 1위만 2px */}
       <RankingAvatar
         image={entry.profileImage}
         name={entry.displayName}
         size={avatarSize}
-        borderColor={medalColor}
+        borderColor={MEDAL_COLORS[rank]}
+        borderWidth={isFirst ? 2 : 1}
       />
 
       {/* 닉네임 */}
@@ -58,7 +60,7 @@ const PodiumItem = ({ entry, rank }: { entry: RankingEntry; rank: 1 | 2 | 3 }) =
       </p>
 
       {/* 시간 + 별점 */}
-      <p className="font-mono text-xs text-muted-foreground">
+      <p className="font-mono tabular-nums text-xs text-muted-foreground">
         {formatTime(entry.clearTime)}
       </p>
       <StarRating stars={entry.stars} size={12} />
@@ -72,21 +74,15 @@ const RankingPodium = ({ rankings }: RankingPodiumProps) => {
 
   return (
     <div
-      className="relative mx-4 overflow-hidden rounded-2xl border border-border/60 bg-card/80 p-5 shadow-lg backdrop-blur-md"
+      className="mx-4 overflow-hidden rounded-[var(--radius-lg)] border border-border bg-card"
       style={{ minHeight: 180 }}
     >
-      {/* 상단 그라디언트 액센트 라인 */}
-      <div
-        aria-hidden="true"
-        className="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-sudoku-primary/60 to-transparent"
-      />
-      {/* 배경 글로우 */}
-      <div
-        aria-hidden="true"
-        className="pointer-events-none absolute -top-12 left-1/2 size-40 -translate-x-1/2 rounded-full bg-gradient-to-br from-warning/30 via-sudoku-primary/25 to-transparent blur-2xl"
-      />
+      {/* 표 머리 — 괘선 + 모노 캡션 */}
+      <p className="border-b border-border px-4 py-2 font-mono text-(length:--text-small) tracking-[0.2em] uppercase text-muted-foreground">
+        Top 3
+      </p>
 
-      <div className="relative flex items-end justify-center">
+      <div className="flex items-end justify-center p-5">
         {PODIUM_ORDER.map((index) => {
           const entry = top3[index];
           if (!entry) return <div key={index} className="flex-1" />;

--- a/src/components/ranking/RankingSkeleton.tsx
+++ b/src/components/ranking/RankingSkeleton.tsx
@@ -12,7 +12,7 @@ const SkeletonBox = ({ className }: { className?: string }) => (
 
 /** 포디움 스켈레톤 */
 const PodiumSkeleton = () => (
-  <div className="mx-4 flex items-end justify-center gap-4 rounded-lg bg-card p-5" style={{ minHeight: 180 }}>
+  <div className="mx-4 flex items-end justify-center gap-4 rounded-[var(--radius-lg)] border border-border bg-card p-5" style={{ minHeight: 180 }}>
     {/* 2위 */}
     <div className="flex flex-1 flex-col items-center gap-2 pt-5">
       <SkeletonBox className="size-11 rounded-full" />

--- a/src/components/ranking/StarRating.tsx
+++ b/src/components/ranking/StarRating.tsx
@@ -27,7 +27,7 @@ const StarRating = ({ stars, max = 3, size = 14 }: StarRatingProps) => {
           className={
             i < stars
               ? "fill-warning text-warning"
-              : "fill-transparent text-muted"
+              : "fill-transparent text-muted-foreground"
           }
         />
       ))}

--- a/src/components/ranking/ranking-utils.ts
+++ b/src/components/ranking/ranking-utils.ts
@@ -12,15 +12,13 @@ export interface DifficultyTab {
   label: string;
   /** 대표 스테이지 번호 (API 조회용) */
   stage: number;
-  /** 활성 인디케이터 Tailwind 색상 클래스 */
-  activeClass: string;
 }
 
 export const DIFFICULTY_TABS: readonly DifficultyTab[] = [
-  { id: "easy", label: "쉬움", stage: 1, activeClass: "bg-difficulty-easy" },
-  { id: "medium", label: "보통", stage: 11, activeClass: "bg-difficulty-medium" },
-  { id: "hard", label: "어려움", stage: 21, activeClass: "bg-difficulty-hard" },
-  { id: "expert", label: "전문가", stage: 31, activeClass: "bg-difficulty-expert" },
+  { id: "easy", label: "쉬움", stage: 1 },
+  { id: "medium", label: "보통", stage: 11 },
+  { id: "hard", label: "어려움", stage: 21 },
+  { id: "expert", label: "전문가", stage: 31 },
 ] as const;
 
 // ─── 시간 포맷 ────────────────────────────────────────
@@ -43,16 +41,17 @@ export const formatDate = (isoString: string): string => {
   return `${y}.${m}.${day}`;
 };
 
-// ─── 메달 색상 ────────────────────────────────────────
+// ─── 순위 테두리 ────────────────────────────────────────
 
+/**
+ * 아바타 테두리 — 금/은/동 대신 잉크 명도 사다리.
+ *
+ * 리터럴 oklch로 두면 라이트 전용 값이 되어 다크 모드에서 대비가 무너진다.
+ * `var()` 참조로 두면 두 모드에서 자동 반전된다.
+ */
 export const MEDAL_COLORS = {
-  1: "oklch(0.80 0.15 85)",   // 금
-  2: "oklch(0.75 0.02 250)",  // 은
-  3: "oklch(0.65 0.10 55)",   // 동
+  1: "var(--foreground)",
+  2: "var(--muted-foreground)",
+  3: "var(--board-border-thin)",
 } as const;
 
-export const MEDAL_EMOJI = {
-  1: "\uD83E\uDD47",
-  2: "\uD83E\uDD48",
-  3: "\uD83E\uDD49",
-} as const;

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,25 @@
+/**
+ * 테마 상수 + 초기화 스크립트.
+ * globals.css의 `--background` oklch 값을 sRGB hex로 변환한 것 —
+ * 모바일 브라우저 상단 크롬/PWA 상태바가 지면 색과 이어지도록 한다.
+ *
+ * light: oklch(0.968 0.008 85)  → #f7f4ee
+ * dark : oklch(0.185 0.008 70)  → #15120f
+ */
+export const THEME_COLOR = {
+  light: "#f7f4ee",
+  dark: "#15120f",
+} as const;
+
+/** <meta name="theme-color">를 현재 테마에 맞춰 갱신 */
+export const syncThemeColorMeta = (isDark: boolean) => {
+  document
+    .querySelector('meta[name="theme-color"]')
+    ?.setAttribute("content", isDark ? THEME_COLOR.dark : THEME_COLOR.light);
+};
+
+/**
+ * 첫 페인트 전에 실행되는 blocking 스크립트 (FOUC 방지).
+ * 저장된 선택이 없으면 시스템 설정을 따른다.
+ */
+export const THEME_INIT_SCRIPT = `try{var t=localStorage.getItem('theme');if(t==='dark'||(!t&&matchMedia('(prefers-color-scheme:dark)').matches)){document.documentElement.classList.add('dark');var m=document.querySelector('meta[name="theme-color"]');if(m)m.setAttribute('content','${THEME_COLOR.dark}')}}catch(e){}`;


### PR DESCRIPTION
현재 UI가 "AI 느낌이 강하다"(메시 그라데이션 · 무지개 색 · 그라데이션 텍스트)는 피드백에 따라,
Design 에이전트가 작성한 **페이퍼/퍼즐북 톤 스펙(v2)** 을 구현했습니다.
스펙 문서(`docs/design/*`)와 구현이 한 PR에 함께 들어갑니다.

관련: Epic #2 (디자인 시스템) · Epic #5 (게임 UI)

---

## 1. 변경 요약

### 토큰 — 이름은 그대로, 값만 교체
`:root` / `.dark` 의 값만 바꿨습니다. **토큰 이름과 `@theme inline` 블록은 한 줄도 건드리지 않아**
`bg-cell-default`, `text-difficulty-hard` 같은 기존 유틸리티가 전부 그대로 동작합니다.

| 축 | 값 |
|----|-----|
| 종이 / 잉크 (주축) | hue 65~85, chroma 0.004~0.016 — 배경 · 표면 · 텍스트 · 괘선 전부 |
| 펜 잉크 블루 (보조축) | hue 250 — 유저 입력 · 선택 · 같은 숫자 |
| 첨삭 레드 (예외축) | hue 28~30 — **오류 한 곳에만** |

- 난이도: 무지개(초록/노랑/주황/빨강) → **무채색 잉크 명도 사다리** (다크는 방향 반전, 밝을수록 어려움)
- `--radius` 10px → **6px** (한 줄 변경으로 `--radius-sm/md/lg/xl` 파생값 전부 따라옴)
- 그림자: 글로우·컬러 그림자 폐기, 오프셋 1~2px "인쇄 자국"
- 다크 모드는 흰 종이의 반전이 아니라 **갱지 뒷면 / 흑지**로 번역 (hue 70 따뜻한 흑갈색 + 흰 잉크)

### 삭제한 장식 요소

| 삭제 | 대체 |
|------|------|
| `.home-mesh-bg` (4겹 radial-gradient) + `.sudoku-grid-bg` | `.paper-bg` 모눈종이 **1겹** (고정 24px, 리사이즈 리플로우 없음) |
| `.gradient-easy/medium/hard/expert` | 없음 — 사이드바는 종이 + 세로 괘선 |
| `.card-glow-easy/medium/hard/expert` | `hover:bg-accent` |
| `.text-gradient-brand`, `.animate-text-shimmer` + `@keyframes shimmer` | 단색 잉크 워드마크 |
| `.animate-float-slow` + `@keyframes float-slow` | 없음 (미사용) |
| `@media (forced-colors)` 폴백 블록 | 대상 클래스가 사라져 함께 삭제 |
| `Sparkles` pill 뱃지 | 간행 캡션 `DAILY PUZZLE · 50 STAGES` |
| `AppLogo` 그라데이션 점 | 삭제 |
| `RankingPodium` 그라데이션 헤어라인 + `blur-2xl` 글로우 | `border-b` 괘선 + `TOP 3` 모노 캡션 |
| `Header` `backdrop-blur-xl` + `bg-background/70` | `bg-background` + `border-b border-border` |
| `board-complete-celebrate`의 `filter: brightness(1.1)` | scale만 유지 |
| `MEDAL_EMOJI` (🥇🥈🥉) | `#1` `#2` `#3` 모노 숫자 |

**잔재 확인**: `home-mesh-bg` / `sudoku-grid-bg` / `gradient-*` / `card-glow-*` / `text-gradient-brand` /
`animate-text-shimmer` / `animate-float-slow` / `gradientClass` / `glowClass` / `MEDAL_EMOJI` /
`activeClass` / `indicatorClass` 전부 grep 0건입니다.
`src/` 에 남은 `backdrop-blur`는 `PauseOverlay`(퍼즐을 가리는 기능적 블러, 스펙상 예외)와
shadcn `dialog` 오버레이 스크림 둘뿐입니다.

---

## 2. 셀 상태 구분 방식 — 색 + 색이 아닌 신호 2겹

배경 색차가 얕아진 만큼 **실제 판별은 비색상 신호가 책임**집니다.

| 상태 | 색 신호 | 비색상 신호 |
|------|---------|------------|
| given | 검정 잉크 (16.85:1) | **font-weight 700** |
| filled | 파란 볼펜 잉크 (7.21:1) | weight 500 + given과 hue 자체가 다름 |
| selected | 파란 음영 (가장 진함) | **inset 2px 잉크 링** (배경 대비 5.54:1) |
| same-number | 파란 음영 (중간) | **font-bold** |
| highlighted | **무채색** 음영 (가장 옅음) | 색상축이 다름 — same-number(파랑)와 hue로 분리 |
| error | 빨간 배경 + 빨간 잉크 | **밑줄(신규)** + shake + `aria-invalid` |
| locked | 회색 배경 | **`.cell-hatch` 대각 빗금(신규)** + `Lock` 아이콘 + `cursor-not-allowed` |

`opacity-80`으로 잠금을 표현하던 방식은 제거하고 빗금으로 대체했습니다(투명도로 상태를 표현하지 않음).

**회색조 검증**: 렌더에 `filter: grayscale(1)`를 걸고 6개 상태를 동시에 띄워 확인했습니다.
selected(가장 어두운 배경 + 링) → same-number(Bold) → highlighted(가장 옅음) 순으로 갈리고,
error는 밑줄, locked는 빗금+아이콘으로 **색 없이도 전부 구별**됩니다.

---

## 3. 접근성

Lighthouse Accessibility 93점 회귀 없음을 목표로 작업했고, 대비는 오히려 개선됩니다.

| 항목 | 이전 | 이후 |
|------|------|------|
| 얇은 괘선 / 셀 배경 | 2.24:1 ❌ | **3.02:1** ✅ (괘선은 필수 구조 정보) |
| 입력 필드 테두리 (`--input`) | 1.39:1 ❌ | **3.07:1** ✅ |
| `MEDAL_COLORS` 다크 모드 | 라이트 전용 리터럴 oklch → 대비 붕괴 🐞 | `var()` 참조 → 두 모드 자동 반전 ✅ |
| 빈 별점 | `text-muted` on `bg-muted` → 사실상 안 보임 🐞 | `text-muted-foreground` ✅ |
| 개인정보처리방침 본문 | `text-foreground/90` (color-mix 알파) | `text-foreground` 실색 ✅ |

- 색으로만 상태를 전달하던 곳을 전부 형태 신호로 이중화: BottomNav / DifficultyTabs 활성 표시는
  **상단·하단 2px 잉크 바 + `font-semibold`**, 내 순위 하이라이트는 **좌측 3px 잉크 바 + `font-semibold`**
- 난이도는 색이 아니라 **pip 게이지 개수**(`■□□□` ~ `■■■■`)로 전달. 게이지는 `aria-hidden`이고
  난이도 정보는 카드 `aria-label` 텍스트가 담당합니다. (★는 클리어 등급 전용이라 의미 충돌을 피해 ■ 사용)
- 터치 타겟 유지: 숫자패드 48px, BottomNav 64px, 난이도 탭에 `min-h-[44px]` 추가
- 아이콘 `strokeWidth` 2~2.5 → **1.75** (인쇄 라인 두께)

---

## 4. 세리프(Instrument Serif) — **미채택**

`docs/design/design-system.md` §3.1이 "번들·성능 부담이 크다고 판단되면 Geist Sans + 넓은 자간으로
대체하라"는 탈출구를 명시했고, 그쪽을 택했습니다.

**사유**: 이 앱은 이미 **Geist Sans · Geist Mono · Noto Sans KR 3종**을 싣고 있습니다.
라틴 6글자가 2곳(`BrandWordmark`, `AppLogo`)에 나오는 것을 위해 4번째 패밀리를 더하는 것은
PWA 페이로드 대비 이득이 낮다고 판단했습니다. 스펙도 "톤의 90%는 색·괘선·그라데이션 제거에서
이미 나오므로 세리프는 없어도 스펙을 만족"이라고 적고 있습니다.

**대체**: `font-[family-name:var(--font-geist-sans)]` + `tracking-[0.14em]` + `font-normal`.
`font-sans`를 쓰지 않은 이유는 `@theme inline`의 `--font-sans`가 자기 참조라 비어 있어
Noto Sans KR로 떨어지기 때문입니다. (§16.1에 기록)

---

## 5. 화면별 확인 결과

프로덕션 빌드(`next start`)를 띄우고, **실제 375px 뷰포트**(Windows Chrome이 창 폭을 클램프하므로
동일 오리진 iframe 하니스로 진짜 375px를 만들어 사용)에서 **라이트/다크를 나란히** 렌더해 확인했습니다.

| 화면 | 라이트 | 다크 | 결과 |
|------|:-----:|:----:|------|
| 홈 `/` | ✅ | ✅ | 모눈종이 지면 + 단색 잉크 워드마크 + 표제 밑줄 괘선. 난이도 카드는 세로 괘선으로 나뉘고 pip 게이지가 `■□□□`~`■■■■`로 정확히 표시됨 |
| 게임 `/game?stage=1` | ✅ | ✅ | 문제집 한 페이지처럼 읽힘. 얇은 괘선이 이전보다 뚜렷하고, 인쇄 잉크(굵은 검정/흰색)와 볼펜(파랑)이 명확히 갈림 |
| 셀 상태 `/game?stage=41` | ✅ | ✅ | 오류(밑줄) · 잠김(빗금+자물쇠) · 선택(2px 링) · 같은 숫자(Bold) · 하이라이트(무채색) · 초기값(Bold) 6종 동시 확인. **회색조에서도 전부 구별됨** |
| 랭킹 `/ranking` | ✅ | ✅ | 포디움이 시상대 → 성적표 표(表)로. `TOP 3` 캡션 + `#1` 모노 숫자 + 잉크 명도 테두리. 탭은 잉크 밑줄 |
| 로그인 `/login` | ✅ | ✅ | 그라데이션 아이콘 박스 → 괘선 카드. OAuth 브랜드 색은 예외로 유지 |
| 개인정보처리방침 `/privacy` | ✅ | ✅ | 알파 본문색 제거 후 두 모드 모두 정상 대비 |
| 클리어 모달 | ✅ | — | 실제로 퍼즐을 자동으로 풀어 모달을 띄워 확인. 종이 카드 + `bg-muted` 정보 패널 + 잉크 CTA |

레이아웃은 **모바일 375px / 데스크톱 1280px 양쪽** 확인했고, 가로 오버플로 0(`scrollWidth === innerWidth`)입니다.

---

## 6. 테스트

```
pnpm build  ✅ 통과 (13/13 static pages)
pnpm test   ✅ 367 passed (18 files)
pnpm lint   ✅ 0 errors
```

diff: **+389 / -505** (순 -116줄). 토큰 값 교체로 되는 것은 컴포넌트를 다시 쓰지 않았고,
실제로 재작성한 것은 스펙이 지목한 `DifficultyCard` 사이드바(pip 게이지) 정도입니다.

---

## 7. 스펙과 다르게 구현한 3건

`docs/design/design-system.md` **§16.1**에 표로 기록해 두었습니다.

1. **Instrument Serif 미채택** → Geist Sans + 넓은 자간 (위 §4)
2. **간행 캡션**: `DAILY PUZZLE · NO.{stageNo}` → `DAILY PUZZLE · 50 STAGES`.
   홈 히어로는 특정 스테이지에 묶이지 않아 `stageNo`가 존재하지 않고, 진행 중 스테이지는
   바로 아래 `ContinueBanner`가 이미 표시합니다.
3. **`--shadow-xs/sm/md/lg` 토큰 미추가**: Tailwind v4의 `shadow-*` 유틸리티는 빌드 타임에
   값을 인라인하므로 `:root` 재정의를 읽지 않습니다. 실제로 `var()`로 참조되는
   `--shadow-board` · `--shadow-cell-selected` · `--shadow-numpad` · `--shadow-xl` 4개만 유지했습니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
