### PR TITLE
[Backend] fix/api-clear-completed-at — 클리어 API가 실제 클리어 시각을 저장하도록

### DIFF
--- a/__tests__/api/completed-at.test.ts
+++ b/__tests__/api/completed-at.test.ts
@@ -1,0 +1,61 @@
+/**
+ * completedAt 검증 테스트
+ * — /api/game/clear와 /api/game/sync가 공유하는 신뢰 경계라 경계값만 확인한다.
+ */
+import { describe, expect, it } from "vitest";
+import { validateCompletedAt, validateGuestRecord } from "@/lib/api/guest";
+import {
+  MAX_COMPLETED_AT_AGE_MS,
+  MAX_COMPLETED_AT_FUTURE_SKEW_MS,
+} from "@/types/guest";
+
+const iso = (offsetMs: number) => new Date(Date.now() + offsetMs).toISOString();
+
+describe("validateCompletedAt", () => {
+  it("정상 ISO 8601은 통과한다", () => {
+    expect(validateCompletedAt(iso(-60_000))).toBeNull();
+  });
+
+  it("문자열이 아니거나 파싱 불가면 거부한다", () => {
+    expect(validateCompletedAt(undefined)).toBeTruthy();
+    expect(validateCompletedAt(Date.now())).toBeTruthy();
+    expect(validateCompletedAt("나중에")).toBeTruthy();
+  });
+
+  it("허용 스큐 이내의 미래는 통과, 초과하면 거부한다", () => {
+    expect(
+      validateCompletedAt(iso(MAX_COMPLETED_AT_FUTURE_SKEW_MS - 60_000)),
+    ).toBeNull();
+    expect(
+      validateCompletedAt(iso(MAX_COMPLETED_AT_FUTURE_SKEW_MS + 60_000)),
+    ).toBeTruthy();
+  });
+
+  it("오래된 오프라인 기록은 통과, 상한을 넘으면 거부한다", () => {
+    expect(
+      validateCompletedAt(iso(-MAX_COMPLETED_AT_AGE_MS + 86_400_000)),
+    ).toBeNull();
+    expect(
+      validateCompletedAt(iso(-MAX_COMPLETED_AT_AGE_MS - 86_400_000)),
+    ).toBeTruthy();
+    expect(validateCompletedAt(new Date(0).toISOString())).toBeTruthy();
+  });
+
+  it("게스트 기록 검증도 같은 규칙을 쓴다", () => {
+    const record = {
+      id: "a",
+      stage: 1,
+      clearTime: 100,
+      hintsUsed: 0,
+      stars: 3,
+      completedAt: iso(0),
+    };
+    expect(validateGuestRecord(record).isValid).toBe(true);
+    expect(
+      validateGuestRecord({
+        ...record,
+        completedAt: iso(MAX_COMPLETED_AT_FUTURE_SKEW_MS + 60_000),
+      }).isValid,
+    ).toBe(false);
+  });
+});

--- a/src/app/api/game/clear/route.ts
+++ b/src/app/api/game/clear/route.ts
@@ -4,7 +4,7 @@
  * 로그인 사용자의 게임 클리어 기록을 저장한다.
  *
  * - 인증 필수 (requireAuth)
- * - 요청 본문: { stage, clearTime, hintsUsed, stars }
+ * - 요청 본문: { stage, clearTime, hintsUsed, stars, completedAt? }
  * - 유효성 검증 후 GameRecord 테이블에 저장
  * - 개인 최고 기록 여부를 함께 응답
  *
@@ -13,6 +13,7 @@
 
 import { NextResponse } from "next/server";
 import { requireAuth } from "@/lib/auth/helpers";
+import { validateCompletedAt } from "@/lib/api/guest";
 import { prisma } from "@/lib/prisma";
 import type { ApiResponse } from "@/types/api";
 import type { GameClearRequest, GameClearResponseData } from "@/types/ranking";
@@ -84,6 +85,14 @@ const validateClearRequest = (
     };
   }
 
+  // completedAt: 선택 필드 — 없으면 서버 수신 시각으로 폴백 (하위 호환)
+  if (b.completedAt !== undefined) {
+    const completedAtError = validateCompletedAt(b.completedAt);
+    if (completedAtError) {
+      return { valid: false, error: completedAtError };
+    }
+  }
+
   return {
     valid: true,
     data: {
@@ -91,6 +100,7 @@ const validateClearRequest = (
       clearTime: b.clearTime,
       hintsUsed: b.hintsUsed,
       stars: b.stars,
+      completedAt: b.completedAt as string | undefined,
     },
   };
 };
@@ -127,7 +137,7 @@ export const POST = async (req: Request) => {
     );
   }
 
-  const { stage, clearTime, hintsUsed, stars } = validation.data;
+  const { stage, clearTime, hintsUsed, stars, completedAt } = validation.data;
   const userId = session.user.id;
 
   try {
@@ -139,7 +149,8 @@ export const POST = async (req: Request) => {
         clearTime,
         hintsUsed,
         stars,
-        completedAt: new Date(),
+        // 클라이언트가 실제 클리어 시각을 보내면 그 값, 없으면 서버 수신 시각
+        completedAt: completedAt ? new Date(completedAt) : new Date(),
       },
       select: { id: true },
     });

--- a/src/lib/api/guest.ts
+++ b/src/lib/api/guest.ts
@@ -21,6 +21,8 @@ import {
   MIN_STARS,
   MAX_STARS,
   GUEST_MAX_RECORDS,
+  MAX_COMPLETED_AT_FUTURE_SKEW_MS,
+  MAX_COMPLETED_AT_AGE_MS,
 } from "@/types/guest";
 
 // ─── 세션 판별 ────────────────────────────────────────
@@ -50,6 +52,40 @@ export const isAuthenticated = (
 };
 
 // ─── 유효성 검증 ──────────────────────────────────────
+
+/**
+ * 클리어 일시(ISO 8601 문자열) 검증 — 실패 시 사유, 통과 시 null
+ *
+ * /api/game/sync(게스트 기록)와 /api/game/clear(오프라인 큐 flush) 양쪽에서
+ * 같은 규칙을 쓴다. 두 경로가 다른 규칙을 쓰면 같은 컬럼(GameRecord.completedAt)에
+ * 신뢰 수준이 다른 값이 섞인다.
+ *
+ * ponytail: 서버는 실제 클리어 시각을 알 수 없다. 이건 "말이 되는 범위"만 거르는
+ * sanity check이지 위조 방지가 아니다. 랭킹 타이브레이커가 `completedAt asc`
+ * (= 이른 쪽이 유리)라 조작 이득 방향은 과거인데, 오프라인 큐가 오래 남을 수 있어
+ * 과거 상한을 좁힐 수 없다. 정밀한 방지가 필요하면 서버가 발급한 세션에
+ * 게임 시작 시각을 담아 대조하는 방식으로 올려야 한다.
+ */
+export const validateCompletedAt = (value: unknown): string | null => {
+  if (typeof value !== "string") {
+    return "클리어 일시가 문자열이 아닙니다";
+  }
+
+  const time = new Date(value).getTime();
+  if (Number.isNaN(time)) {
+    return "클리어 일시가 유효한 날짜가 아닙니다";
+  }
+
+  const now = Date.now();
+  if (time > now + MAX_COMPLETED_AT_FUTURE_SKEW_MS) {
+    return "클리어 일시가 미래입니다";
+  }
+  if (time < now - MAX_COMPLETED_AT_AGE_MS) {
+    return "클리어 일시가 너무 오래되었습니다";
+  }
+
+  return null;
+};
 
 /**
  * 개별 게스트 기록의 유효성을 검증
@@ -124,19 +160,10 @@ export const validateGuestRecord = (
     };
   }
 
-  // completedAt: 유효한 ISO 8601 날짜
-  if (typeof r.completedAt !== "string") {
-    return { isValid: false, reason: "클리어 일시가 문자열이 아닙니다" };
-  }
-
-  const date = new Date(r.completedAt);
-  if (isNaN(date.getTime())) {
-    return { isValid: false, reason: "클리어 일시가 유효한 날짜가 아닙니다" };
-  }
-
-  // 미래 날짜 방지 (1분 여유)
-  if (date.getTime() > Date.now() + 60_000) {
-    return { isValid: false, reason: "클리어 일시가 미래입니다" };
+  // completedAt: 유효한 ISO 8601 날짜 (clear 경로와 동일 규칙)
+  const completedAtError = validateCompletedAt(r.completedAt);
+  if (completedAtError) {
+    return { isValid: false, reason: completedAtError };
   }
 
   return { isValid: true };

--- a/src/types/guest.ts
+++ b/src/types/guest.ts
@@ -129,3 +129,19 @@ export const MIN_STARS = 1;
 
 /** 최대 별점 */
 export const MAX_STARS = 3;
+
+/**
+ * 클리어 일시로 허용하는 최대 미래 오차 (5분)
+ *
+ * 클라이언트 시계는 NTP 동기화가 안 되면 수 분씩 어긋난다.
+ * 너무 빡빡하면 정상 기록이 반려된다.
+ */
+export const MAX_COMPLETED_AT_FUTURE_SKEW_MS = 5 * 60_000;
+
+/**
+ * 클리어 일시로 허용하는 최대 과거 (365일)
+ *
+ * 오프라인 큐(offline-clear-store)와 게스트 기록은 localStorage에 TTL 없이
+ * 남으므로 몇 달 뒤 전송될 수 있다. 상한은 "명백한 쓰레기 값"만 거르는 용도.
+ */
+export const MAX_COMPLETED_AT_AGE_MS = 365 * 24 * 60 * 60 * 1000;

--- a/src/types/ranking.ts
+++ b/src/types/ranking.ts
@@ -20,6 +20,13 @@ export interface GameClearRequest {
   hintsUsed: number;
   /** 별점 (1~3) */
   stars: number;
+  /**
+   * 실제 클리어 일시 (ISO 8601, 선택)
+   *
+   * 생략하면 서버 수신 시각을 쓴다. 오프라인 큐는 나중에 flush되므로
+   * 이 값을 보내야 랭킹 타이브레이커(completedAt asc)가 실제 순서와 맞는다.
+   */
+  completedAt?: string;
 }
 
 /** POST /api/game/clear 응답 데이터 */


### PR DESCRIPTION
## 문제

`POST /api/game/clear`가 `completedAt: new Date()`로 **서버 수신 시각**을 저장했다.
반면 `POST /api/game/sync`(게스트 기록)는 이미 클라이언트가 보낸 값을 쓴다.
같은 컬럼(`GameRecord.completedAt`, 스키마 주석: `// 실제 클리어 일시`)에 의미가 섞여 있었다:

| 경로 | 저장되던 값 | 오차 |
| --- | --- | --- |
| 게스트 동기화 | 실제 클리어 시각 | 없음 |
| 로그인 온라인 | 서버 수신 시각 | 작음 |
| 로그인 오프라인 | **온라인 복귀 시각** | **큼 (며칠~)** |

오프라인 큐(`offline-clear-store` → `useOfflineClearSync`)는 나중에 flush되므로, 어제 푼 기록이 오늘 날짜로 저장된다.

**표시만의 문제가 아니다.** `completedAt`은 랭킹 정렬의 타이브레이커다:
- `src/app/api/ranking/route.ts` — `orderBy: [{ clearTime: "asc" }, { completedAt: "asc" }]`
- `src/app/api/ranking/me/route.ts`

동점자 순위가 실제 클리어 순서와 달라지고, `RankingList.tsx`에서 사용자에게 날짜로도 보인다.

## 변경 내용 (Backend만)

- `GameClearRequest`에 **선택적** `completedAt?: string` (ISO 8601) 추가
- `validateClearRequest`에 검증 추가 — 통과한 값을 저장, 없으면 기존대로 `new Date()`
- completedAt 검증을 `validateCompletedAt()`으로 추출해 **clear / sync 두 경로가 공유**
- 검증 단위 테스트 추가 (`__tests__/api/completed-at.test.ts`, 5건)

## 검증 규칙과 근거

| 규칙 | 값 | 근거 |
| --- | --- | --- |
| 타입 | 문자열이어야 함 | — |
| 파싱 | `Number.isNaN(new Date(v).getTime())` 거부 | ISO 8601 파싱 가능성 |
| 미래 상한 | **+5분** (`MAX_COMPLETED_AT_FUTURE_SKEW_MS`) | 클라이언트 시계는 NTP 동기화가 없으면 수 분씩 어긋난다. 너무 빡빡하면 정상 기록이 반려되는데, `useOfflineClearSync`는 4xx를 받으면 큐를 비우지 않고 `break` 하므로 **한 건이 반려되면 큐 전체가 영구히 막힌다.** |
| 과거 상한 | **365일** (`MAX_COMPLETED_AT_AGE_MS`) | 오프라인 큐와 게스트 기록은 localStorage에 TTL 없이 남으므로 몇 달 뒤 전송될 수 있다. 명백한 쓰레기 값(epoch 0 등)만 거르는 용도. |

### 위협 모델 메모

랭킹 타이브레이커가 `completedAt asc`라 **조작 이득 방향은 미래가 아니라 과거**다(이른 쪽이 유리). 그런데 오프라인 큐 때문에 과거 상한을 좁힐 수 없으므로, 이 검증은 위조 방지가 아니라 "말이 되는 범위"만 거르는 sanity check이다. 코드에 `ponytail:` 주석으로 한계와 업그레이드 경로(서버 발급 세션에 게임 시작 시각을 담아 대조)를 남겼다.

## sync 경로와의 일관성

기존 `validateGuestRecord`의 인라인 completedAt 검증을 그대로 두면 두 경로가 다른 규칙을 쓰게 되고, 그 자체가 새 버그다. 그래서 공용 `validateCompletedAt()`으로 추출하고 양쪽에서 호출한다.

- **sync 경로의 동작 변화**: 미래 허용치가 `+60초` → `+5분`으로 완화, 과거 상한 365일이 **새로 추가**됨. 위 표의 근거대로 clear 경로에 필요한 값이고, 두 경로가 갈리지 않도록 한 값으로 통일했다.

## 하위 호환성

- `completedAt`은 **선택 필드**. 필드가 없으면 지금과 동일하게 `new Date()` 폴백 → 기존 클라이언트 무변경 동작.
- 스키마 변경 없음 (`completedAt` 컬럼은 이미 존재). 마이그레이션 없음. 기존 데이터 백필 없음.
- `PendingClear extends GameClearRequest`라 오프라인 큐는 타입상 이미 이 필드를 통과시킨다.

## 후속 (Frontend PR)

클라이언트가 실제로 값을 보내는 변경(`ClearModal.tsx`, `offline-clear-store.ts`, `useOfflineClearSync.ts`)은 범위 밖이며 후속 PR에서 처리한다. 이 PR만으로는 저장되는 값이 바뀌지 않는다 — 서버가 받아들일 준비만 한다.

## 테스트 결과

- `pnpm type-check` 통과
- `pnpm lint` 통과 (경고 1건은 `coverage/` 산출물, 이 변경과 무관)
- `pnpm test` — **376건 전부 통과** (기존 371 + 신규 5)
- `pnpm exec next build` 통과

관련 이슈: #6 (랭킹 시스템)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
