### PR TITLE
[Backend] feat/api-record-per-stage — (사용자, 스테이지)당 1행 + 최고기록만 갱신

### DIFF
--- a/__tests__/api/records.test.ts
+++ b/__tests__/api/records.test.ts
@@ -1,0 +1,56 @@
+/**
+ * bestPerStage — 배치 내 스테이지별 최고 기록 선별
+ *
+ * upsertBestRecords는 한 문장에 같은 (userId, stage)가 두 번 들어오면 Postgres가
+ * 거부하므로, 이 선별이 깨지면 게스트 동기화가 통째로 실패한다.
+ */
+
+import { describe, it, expect } from "vitest";
+import { bestPerStage } from "@/lib/api/records";
+
+const rec = (stage: number, clearTime: number, completedAt: string) => ({
+  stage,
+  clearTime,
+  hintsUsed: 0,
+  stars: 3,
+  completedAt: new Date(completedAt),
+});
+
+describe("bestPerStage", () => {
+  it("스테이지별로 1건씩만 남긴다", () => {
+    const result = bestPerStage([
+      rec(1, 100, "2026-01-01T00:00:00Z"),
+      rec(1, 80, "2026-01-02T00:00:00Z"),
+      rec(2, 50, "2026-01-03T00:00:00Z"),
+    ]);
+
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.stage).sort()).toEqual([1, 2]);
+  });
+
+  it("같은 스테이지에서 가장 빠른 기록을 고른다", () => {
+    const result = bestPerStage([
+      rec(1, 100, "2026-01-01T00:00:00Z"),
+      rec(1, 42, "2026-01-02T00:00:00Z"),
+      rec(1, 77, "2026-01-03T00:00:00Z"),
+    ]);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].clearTime).toBe(42);
+  });
+
+  it("시간이 동률이면 먼저 달성한 기록을 고른다", () => {
+    const result = bestPerStage([
+      rec(1, 60, "2026-01-05T00:00:00Z"),
+      rec(1, 60, "2026-01-01T00:00:00Z"),
+    ]);
+
+    expect(result[0].completedAt.toISOString()).toBe(
+      "2026-01-01T00:00:00.000Z",
+    );
+  });
+
+  it("빈 배열은 빈 배열", () => {
+    expect(bestPerStage([])).toEqual([]);
+  });
+});

--- a/prisma/migrations/20260806000000_record_unique_user_stage/migration.sql
+++ b/prisma/migrations/20260806000000_record_unique_user_stage/migration.sql
@@ -1,0 +1,30 @@
+-- (userId, stage)당 1행 사양으로 전환한다.
+--
+-- ⚠️  이 마이그레이션은 파괴적이다. 3번 단계에서 중복 행을 영구 삭제한다.
+--     반드시 백업 후 적용할 것. 순서를 바꾸면 UNIQUE 제약 추가가 실패한다.
+--
+--   1. 중복 정리: (userId, stage)별 최고 기록 1건만 남기고 삭제
+--   2. 기존 비-유니크 인덱스 제거 (유니크 인덱스가 조회도 커버한다)
+--   3. UNIQUE(userId, stage) 추가
+
+-- ── 1. 중복 행 정리 ──
+-- 보존 기준: clearTime 오름차순 → 동률이면 completedAt 이른 순 (랭킹 타이브레이커와 동일)
+--            그래도 동률이면 id 오름차순 (결정적 선택을 위해)
+DELETE FROM "game_records" AS g
+USING (
+    SELECT
+        "id",
+        ROW_NUMBER() OVER (
+            PARTITION BY "userId", "stage"
+            ORDER BY "clearTime" ASC, "completedAt" ASC, "id" ASC
+        ) AS rn
+    FROM "game_records"
+) AS ranked
+WHERE g."id" = ranked."id"
+  AND ranked.rn > 1;
+
+-- ── 2. DropIndex ──
+DROP INDEX "game_records_userId_stage_idx";
+
+-- ── 3. CreateIndex ──
+CREATE UNIQUE INDEX "game_records_userId_stage_key" ON "game_records"("userId", "stage");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -91,9 +91,9 @@ model GameRecord {
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 
+  @@unique([userId, stage]) // (사용자, 스테이지)당 1행 — 최고 기록만 보관 (조회 인덱스 겸용)
   @@index([userId])
   @@index([stage, clearTime]) // 랭킹 조회: 스테이지별 최단 시간
-  @@index([userId, stage]) // 사용자별 스테이지 기록 조회
   @@map("game_records")
 }
 

--- a/src/app/api/game/clear/route.ts
+++ b/src/app/api/game/clear/route.ts
@@ -5,14 +5,15 @@
  *
  * - 인증 필수 (requireAuth)
  * - 요청 본문: { stage, clearTime, hintsUsed, stars }
- * - 유효성 검증 후 GameRecord 테이블에 저장
- * - 개인 최고 기록 여부를 함께 응답
+ * - (userId, stage)당 1행. 기존 기록보다 빠를 때만 갱신하고, 느리면 기존 최고 기록 유지
+ * - 이번 기록이 갱신에 성공했는지(isPersonalBest)를 함께 응답
  *
  * @see docs/adr/204-game-record-schema.md
  */
 
 import { NextResponse } from "next/server";
 import { requireAuth } from "@/lib/auth/helpers";
+import { upsertBestRecords } from "@/lib/api/records";
 import { prisma } from "@/lib/prisma";
 import type { ApiResponse } from "@/types/api";
 import type { GameClearRequest, GameClearResponseData } from "@/types/ranking";
@@ -131,35 +132,36 @@ export const POST = async (req: Request) => {
   const userId = session.user.id;
 
   try {
-    // ── 4. 기록 저장 ──
-    const record = await prisma.gameRecord.create({
-      data: {
-        userId,
-        stage,
-        clearTime,
-        hintsUsed,
-        stars,
-        completedAt: new Date(),
-      },
-      select: { id: true },
-    });
+    // ── 4. 기록 저장 (기존보다 빠를 때만 갱신) ──
+    const [saved] = await upsertBestRecords(userId, [
+      { stage, clearTime, hintsUsed, stars, completedAt: new Date() },
+    ]);
 
-    // ── 5. 개인 최고 기록 확인 ──
-    const personalBest = await prisma.gameRecord.findFirst({
-      where: { userId, stage },
-      orderBy: { clearTime: "asc" },
-      select: { clearTime: true },
-    });
+    // ── 5. 응답 데이터 ──
+    // saved가 있으면 이번 기록이 기존을 갱신한 것 → 개인 최고 기록
+    let responseData: GameClearResponseData;
 
-    const personalBestTime = personalBest?.clearTime ?? clearTime;
-    const isPersonalBest = clearTime <= personalBestTime;
+    if (saved) {
+      responseData = {
+        recordId: saved.id,
+        isPersonalBest: true,
+        personalBestTime: clearTime,
+      };
+    } else {
+      // 기존 기록이 더 빠르거나 같아 유지됨
+      const existing = await prisma.gameRecord.findUnique({
+        where: { userId_stage: { userId, stage } },
+        select: { id: true, clearTime: true },
+      });
 
-    // ── 6. 응답 ──
-    const responseData: GameClearResponseData = {
-      recordId: record.id,
-      isPersonalBest,
-      personalBestTime,
-    };
+      if (!existing) throw new Error("갱신되지 않았는데 기존 기록이 없습니다");
+
+      responseData = {
+        recordId: existing.id,
+        isPersonalBest: false,
+        personalBestTime: existing.clearTime,
+      };
+    }
 
     return NextResponse.json<ApiResponse<GameClearResponseData>>(
       { success: true, data: responseData },

--- a/src/app/api/game/sync/route.ts
+++ b/src/app/api/game/sync/route.ts
@@ -6,8 +6,8 @@
  *
  * - 인증 필수 (requireAuth)
  * - 요청 본문: { records: GuestGameRecord[] }
- * - 각 레코드를 유효성 검증 후 GameRecord 테이블에 저장
- * - 중복/유효하지 않은 건은 스킵하고 개별 결과를 응답
+ * - (userId, stage)당 1행이므로 스테이지별 최고 기록만, 그것도 기존보다 빠를 때만 저장
+ * - 밀린 기록/유효하지 않은 건은 스킵하고 개별 결과를 응답
  *
  * @see docs/adr/203-guest-mode.md
  */
@@ -15,7 +15,7 @@
 import { NextResponse } from "next/server";
 import { requireAuth } from "@/lib/auth/helpers";
 import { validateSyncRequest } from "@/lib/api/guest";
-import { prisma } from "@/lib/prisma";
+import { bestPerStage, upsertBestRecords } from "@/lib/api/records";
 import type { ApiResponse } from "@/types/api";
 import type { GuestSyncResponseData } from "@/types/guest";
 
@@ -54,21 +54,33 @@ export const POST = async (req: Request) => {
   const userId = session.user.id;
 
   try {
-    await prisma.gameRecord.createMany({
-      data: validRecords.map((r) => ({
-        userId,
+    // (userId, stage)당 1행이므로 배치 내 같은 스테이지는 가장 빠른 것만 남긴다.
+    const candidates = bestPerStage(
+      validRecords.map((r) => ({
+        guestRecordId: r.id,
         stage: r.stage,
         clearTime: r.clearTime,
         hintsUsed: r.hintsUsed,
         stars: r.stars,
         completedAt: new Date(r.completedAt),
       })),
-    });
+    );
 
-    // 저장 성공 → pending 상태를 synced로 전환
+    // DB의 기존 기록보다 빠른 건만 실제로 저장된다
+    const saved = await upsertBestRecords(userId, candidates);
+    const savedStages = new Set(saved.map((s) => s.stage));
+    const syncedIds = new Set(
+      candidates
+        .filter((c) => savedStages.has(c.stage))
+        .map((c) => c.guestRecordId),
+    );
+
+    // 저장된 건만 synced, 더 느려서 밀린 건은 duplicate(중복 스킵)
     for (const result of results) {
       if (result.status === "pending") {
-        result.status = "synced";
+        result.status = syncedIds.has(result.guestRecordId)
+          ? "synced"
+          : "duplicate";
       }
     }
   } catch (error) {

--- a/src/app/api/ranking/me/route.ts
+++ b/src/app/api/ranking/me/route.ts
@@ -2,7 +2,7 @@
  * GET /api/ranking/me
  *
  * 로그인 사용자의 스테이지별 최고 기록을 조회한다.
- * 각 스테이지의 최단 클리어 시간 + 플레이 횟수를 반환.
+ * (userId, stage)당 1행만 보관하므로 저장된 행이 곧 최고 기록이다.
  *
  * - 인증 필수 (requireAuth)
  *
@@ -28,37 +28,11 @@ export const GET = async () => {
   const userId = session.user.id;
 
   try {
-    // ── 2. 스테이지별 집계 (최소 clearTime + 플레이 횟수) ──
-    const stageStats = await prisma.gameRecord.groupBy({
-      by: ["stage"],
-      where: { userId },
-      _min: { clearTime: true },
-      _count: { id: true },
-      orderBy: { stage: "asc" },
-    });
-
-    if (stageStats.length === 0) {
-      const responseData: MyRankingResponseData = {
-        records: [],
-        clearedStages: 0,
-        totalPlays: 0,
-      };
-      return NextResponse.json<ApiResponse<MyRankingResponseData>>(
-        { success: true, data: responseData },
-        { status: 200 },
-      );
-    }
-
-    // ── 3. 각 스테이지 최고 기록 상세 조회 ──
+    // ── 2. 스테이지별 최고 기록 조회 ──
+    // (userId, stage)당 1행이므로 그대로 읽으면 스테이지별 최고 기록이다.
     const bestRecords = await prisma.gameRecord.findMany({
-      where: {
-        userId,
-        OR: stageStats.map((s) => ({
-          stage: s.stage,
-          clearTime: s._min.clearTime!,
-        })),
-      },
-      orderBy: [{ stage: "asc" }, { completedAt: "asc" }],
+      where: { userId },
+      orderBy: { stage: "asc" },
       select: {
         stage: true,
         clearTime: true,
@@ -68,35 +42,17 @@ export const GET = async () => {
       },
     });
 
-    // 스테이지별 중복 제거 (같은 최고 시간이 여러 개면 가장 먼저 달성한 것)
-    const seenStages = new Set<number>();
-    const uniqueBests = bestRecords.filter((r) => {
-      if (seenStages.has(r.stage)) return false;
-      seenStages.add(r.stage);
-      return true;
-    });
-
-    // playCount 맵 생성
-    const playCountMap = new Map(
-      stageStats.map((s) => [s.stage, s._count.id]),
-    );
-
-    // ── 4. 응답 데이터 조합 ──
-    const records: PersonalBestRecord[] = uniqueBests.map((r) => ({
+    const records: PersonalBestRecord[] = bestRecords.map((r) => ({
       stage: r.stage,
       clearTime: r.clearTime,
       hintsUsed: r.hintsUsed,
       stars: r.stars,
       completedAt: r.completedAt.toISOString(),
-      playCount: playCountMap.get(r.stage) ?? 1,
     }));
-
-    const totalPlays = stageStats.reduce((sum, s) => sum + s._count.id, 0);
 
     const responseData: MyRankingResponseData = {
       records,
-      clearedStages: stageStats.length,
-      totalPlays,
+      clearedStages: records.length,
     };
 
     return NextResponse.json<ApiResponse<MyRankingResponseData>>(

--- a/src/app/api/ranking/route.ts
+++ b/src/app/api/ranking/route.ts
@@ -2,7 +2,7 @@
  * GET /api/ranking?stage=1&limit=20
  *
  * 특정 스테이지의 랭킹(최단 클리어 시간)을 조회한다.
- * 사용자별 최고 기록만 추출하여 순위를 매긴다.
+ * 저장 시점에 (userId, stage)당 최고 기록 1행만 유지되므로 단순 정렬 조회로 충분하다.
  *
  * - 인증 불필요 (공개 API)
  * - 쿼리 파라미터: stage (필수, 1~50), limit (선택, 기본 20, 최대 100)
@@ -49,82 +49,41 @@ export const GET = async (req: NextRequest) => {
     : RANKING_DEFAULT_LIMIT;
 
   try {
-    // ── 2. 사용자별 최고 기록 조회 ──
-    // 각 사용자의 해당 스테이지 최단 클리어 시간 기록을 가져온다.
-    // Prisma에서 groupBy + min 후 상세 정보를 가져오는 2단계 쿼리.
-
-    // 2-1. 사용자별 최소 clearTime 추출
-    const bestTimes = await prisma.gameRecord.groupBy({
-      by: ["userId"],
-      where: { stage },
-      _min: { clearTime: true },
-    });
-
-    if (bestTimes.length === 0) {
-      const responseData: RankingResponseData = {
-        stage,
-        rankings: [],
-        totalPlayers: 0,
-      };
-      return NextResponse.json<ApiResponse<RankingResponseData>>(
-        { success: true, data: responseData },
-        { status: 200 },
-      );
-    }
-
-    // 2-2. 각 사용자의 최고 기록 상세 정보 조회
-    const records = await prisma.gameRecord.findMany({
-      where: {
-        stage,
-        OR: bestTimes.map((bt) => ({
-          userId: bt.userId,
-          clearTime: bt._min.clearTime!,
-        })),
-      },
-      // 같은 clearTime 기록이 복수일 때 가장 먼저 달성한 것 선택
-      orderBy: [{ clearTime: "asc" }, { completedAt: "asc" }],
-      select: {
-        userId: true,
-        clearTime: true,
-        hintsUsed: true,
-        stars: true,
-        completedAt: true,
-        user: {
-          select: {
-            nickname: true,
-            name: true,
-            image: true,
-          },
+    // ── 2. 랭킹 조회 ──
+    // (userId, stage)당 1행이므로 정렬 후 자르면 그대로 랭킹이 된다.
+    const [records, totalPlayers] = await Promise.all([
+      prisma.gameRecord.findMany({
+        where: { stage },
+        // 같은 clearTime이면 먼저 달성한 사람이 상위
+        orderBy: [{ clearTime: "asc" }, { completedAt: "asc" }],
+        take: limit,
+        select: {
+          userId: true,
+          clearTime: true,
+          hintsUsed: true,
+          stars: true,
+          completedAt: true,
+          user: { select: { nickname: true, name: true, image: true } },
         },
-      },
-    });
+      }),
+      prisma.gameRecord.count({ where: { stage } }),
+    ]);
 
-    // 2-3. 사용자별 중복 제거 (가장 빠른 기록만)
-    const seenUsers = new Set<string>();
-    const uniqueRecords = records.filter((r) => {
-      if (seenUsers.has(r.userId)) return false;
-      seenUsers.add(r.userId);
-      return true;
-    });
-
-    // 2-4. limit 적용 + 순위 부여
-    const rankings: RankingEntry[] = uniqueRecords
-      .slice(0, limit)
-      .map((r, index) => ({
-        rank: index + 1,
-        userId: r.userId,
-        displayName: r.user.nickname ?? r.user.name ?? "익명",
-        profileImage: r.user.image,
-        clearTime: r.clearTime,
-        hintsUsed: r.hintsUsed,
-        stars: r.stars,
-        completedAt: r.completedAt.toISOString(),
-      }));
+    const rankings: RankingEntry[] = records.map((r, index) => ({
+      rank: index + 1,
+      userId: r.userId,
+      displayName: r.user.nickname ?? r.user.name ?? "익명",
+      profileImage: r.user.image,
+      clearTime: r.clearTime,
+      hintsUsed: r.hintsUsed,
+      stars: r.stars,
+      completedAt: r.completedAt.toISOString(),
+    }));
 
     const responseData: RankingResponseData = {
       stage,
       rankings,
-      totalPlayers: bestTimes.length,
+      totalPlayers,
     };
 
     return NextResponse.json<ApiResponse<RankingResponseData>>(

--- a/src/hooks/useOfflineClearSync.ts
+++ b/src/hooks/useOfflineClearSync.ts
@@ -9,9 +9,8 @@
  * - 하나라도 성공하면 랭킹 캐시 무효화
  * - 동시 flush 방지 (ref 가드)
  *
- * ponytail: POST 성공 직후 앱이 죽으면 해당 건이 재전송되어 중복 행이 생길 수 있음
- * (창이 매우 좁음). /api/game/clear가 append-only라 발생 시 중복은 무해한 잉여 행.
- * 문제가 되면 서버에 (userId,stage,completedAt) 멱등 upsert 추가.
+ * POST 성공 직후 앱이 죽어 같은 건이 재전송돼도 안전하다. /api/game/clear가
+ * (userId, stage)당 1행을 더 빠를 때만 갱신하므로 재전송은 no-op이 된다.
  *
  * @see src/stores/offline-clear-store.ts
  */

--- a/src/lib/api/records.ts
+++ b/src/lib/api/records.ts
@@ -1,0 +1,78 @@
+/**
+ * 게임 기록 저장 헬퍼
+ *
+ * `GameRecord`는 (userId, stage)당 1행만 보관하고, 더 빠른 기록일 때만 갱신한다.
+ * Prisma의 `upsert`는 update 블록에 조건을 넣을 수 없어 raw SQL로 처리한다.
+ *
+ * @see prisma/migrations/20260806000000_record_unique_user_stage
+ */
+
+import { Prisma } from "@prisma/client";
+import { prisma } from "@/lib/prisma";
+
+/** 저장할 클리어 기록 1건 */
+export interface ClearRecordInput {
+  stage: number;
+  clearTime: number;
+  hintsUsed: number;
+  stars: number;
+  completedAt: Date;
+}
+
+/**
+ * 같은 스테이지가 여러 건이면 가장 빠른 것만 남긴다.
+ * 동률이면 completedAt이 이른 것 (랭킹 타이브레이커와 동일 기준).
+ *
+ * `upsertBestRecords`는 한 문장에 같은 (userId, stage)가 두 번 들어오면
+ * Postgres가 거부하므로("cannot affect row a second time") 호출 전 필수.
+ */
+export const bestPerStage = <T extends ClearRecordInput>(records: T[]): T[] => {
+  const best = new Map<number, T>();
+
+  for (const r of records) {
+    const prev = best.get(r.stage);
+    const isBetter =
+      !prev ||
+      r.clearTime < prev.clearTime ||
+      (r.clearTime === prev.clearTime && r.completedAt < prev.completedAt);
+
+    if (isBetter) best.set(r.stage, r);
+  }
+
+  return [...best.values()];
+};
+
+/**
+ * 기록을 저장하되, 기존 기록보다 빠를 때만 갱신한다 (원자적 단일 쿼리).
+ *
+ * @returns 실제로 저장/갱신된 행. 기존 기록이 더 빠르면 그 스테이지는 포함되지 않는다.
+ */
+export const upsertBestRecords = async (
+  userId: string,
+  records: ClearRecordInput[],
+): Promise<{ id: string; stage: number }[]> => {
+  if (records.length === 0) return [];
+
+  const values = records.map(
+    (r) =>
+      // ponytail: id는 cuid 대신 crypto.randomUUID(). TEXT 컬럼이라 형식 무관하고
+      // cuid 생성기를 별도 의존성으로 추가할 이유가 없다.
+      Prisma.sql`(${crypto.randomUUID()}, ${userId}, ${r.stage}, ${r.clearTime}, ${r.hintsUsed}, ${r.stars}, ${r.completedAt}, NOW(), NOW())`,
+  );
+
+  return prisma.$queryRaw<{ id: string; stage: number }[]>`
+    INSERT INTO "game_records" (
+      "id", "userId", "stage", "clearTime", "hintsUsed", "stars",
+      "completedAt", "createdAt", "updatedAt"
+    )
+    VALUES ${Prisma.join(values)}
+    ON CONFLICT ("userId", "stage") DO UPDATE SET
+      "clearTime"   = EXCLUDED."clearTime",
+      "hintsUsed"   = EXCLUDED."hintsUsed",
+      "stars"       = EXCLUDED."stars",
+      "completedAt" = EXCLUDED."completedAt",
+      "updatedAt"   = NOW()
+    WHERE EXCLUDED."clearTime" < "game_records"."clearTime"
+    RETURNING "id", "stage"
+  `;
+};

--- a/src/types/guest.ts
+++ b/src/types/guest.ts
@@ -42,7 +42,7 @@ export interface GuestSyncResultItem {
    * 동기화 상태
    * - synced: DB에 저장 완료
    * - pending: 유효성 검증 통과, DB 저장 대기 (Epic #6 연결 전)
-   * - duplicate: 중복 스킵
+   * - duplicate: 중복 스킵 (같은 ID 재전송, 또는 같은 스테이지에 더 빠른 기록이 있어 밀림)
    * - invalid: 유효성 검증 실패
    */
   status: "synced" | "pending" | "duplicate" | "invalid";

--- a/src/types/ranking.ts
+++ b/src/types/ranking.ts
@@ -24,11 +24,11 @@ export interface GameClearRequest {
 
 /** POST /api/game/clear 응답 데이터 */
 export interface GameClearResponseData {
-  /** 저장된 기록 ID */
+  /** 해당 스테이지의 기록 행 ID ((userId, stage)당 1행) */
   recordId: string;
-  /** 해당 스테이지 개인 최고 기록 여부 */
+  /** 이번 기록이 기존 최고 기록을 갱신했는지 */
   isPersonalBest: boolean;
-  /** 해당 스테이지 개인 최고 클리어 시간 (초) */
+  /** 갱신 후의 개인 최고 클리어 시간 (초) */
   personalBestTime: number;
 }
 
@@ -76,10 +76,8 @@ export interface PersonalBestRecord {
   hintsUsed: number;
   /** 별점 */
   stars: number;
-  /** 클리어 일시 (ISO 8601) */
+  /** 최고 기록 달성 일시 (ISO 8601) */
   completedAt: string;
-  /** 해당 스테이지 플레이 횟수 */
-  playCount: number;
 }
 
 /** GET /api/ranking/me 응답 데이터 */
@@ -88,8 +86,6 @@ export interface MyRankingResponseData {
   records: PersonalBestRecord[];
   /** 클리어한 스테이지 총 수 */
   clearedStages: number;
-  /** 전체 플레이 횟수 */
-  totalPlays: number;
 }
 
 // ─── 상수 ────────────────────────────────────────────


### PR DESCRIPTION
## 사양 변경

게임 기록이 클리어할 때마다 행을 쌓는 **append-only**였는데, **(userId, stage)당 1행**으로 바꾼다.

- 같은 스테이지를 다시 깨면 **더 빠를 때만 갱신**, 느리면 기존 최고 기록 유지
- 동률(같은 시간)은 갱신하지 않음 — "더 빠른"이 아니므로
- 갱신 시 `completedAt`도 새 클리어 시각으로 함께 갱신 (그 기록을 달성한 시점이므로)
- 스테이지 1과 2는 각각 별도 행

## ⚠️ 마이그레이션 경고 — 파괴적이며 아직 적용되지 않음

`prisma/migrations/20260806000000_record_unique_user_stage/migration.sql`

- **아직 DB에 적용하지 않았다.** `DATABASE_URL`이 Supabase 프로덕션을 가리키므로 `migrate dev` / `db push` 모두 실행하지 않았다 (`migrate dev --create-only`도 non-interactive 환경에서 거부됨 → SQL 직접 작성)
- **기존 중복 행을 영구 삭제한다.** 적용 전 백업 필수
- 적용 순서가 SQL에 그대로 담겨 있고, **뒤바뀌면 제약 추가가 실패한다**

```
1. 중복 정리   DELETE ... USING (ROW_NUMBER() OVER (PARTITION BY "userId","stage"
                 ORDER BY "clearTime" ASC, "completedAt" ASC, "id" ASC)) WHERE rn > 1
2. DROP INDEX  "game_records_userId_stage_idx"      (유니크 인덱스가 조회도 커버)
3. CREATE UNIQUE INDEX "game_records_userId_stage_key" ON "game_records"("userId","stage")
```

보존 기준은 `clearTime` 최소 → 동률이면 `completedAt` 이른 순 → 그래도 동률이면 `id` 순으로, 랭킹 타이브레이커와 일치시켰다. 컬럼명은 `@@map("game_records")` + 카멜케이스 그대로(init 마이그레이션과 대조 확인).

적용은 사용자가 백업 후 직접 `prisma migrate deploy`로.

## 저장 로직 — 조건부 upsert

Prisma `upsert`는 update 블록에 조건을 넣을 수 없어 **raw SQL 단일 쿼리**를 택했다 (`src/lib/api/records.ts`).

```sql
INSERT INTO "game_records" (...) VALUES ...
ON CONFLICT ("userId","stage") DO UPDATE SET ...
WHERE EXCLUDED."clearTime" < "game_records"."clearTime"
RETURNING "id", "stage"
```

findFirst → 비교 → update/create는 쿼리 2번 + 동시 요청 경합이 있어 제외. RETURNING이 **실제 저장/갱신된 행만** 돌려주므로 `isPersonalBest`를 그 결과로 판정한다.

- `isPersonalBest` = 이번 기록이 기존을 갱신했는가
- `personalBestTime` = 갱신 후의 최고 기록
- `recordId` = 해당 스테이지의 행 id (갱신됐으면 그 행)

## `/api/game/sync` 대응 (필수)

유니크 제약이 걸리면 배치 안에 같은 스테이지가 두 건만 있어도 **동기화 전체가 실패**한다. 그래서:

1. `bestPerStage()`로 배치 내 스테이지별 최고 기록만 추림 (Postgres는 한 문장에서 같은 행을 두 번 갱신하면 거부)
2. 추려진 건을 위 upsert로 저장 → DB 기존 기록보다 빠른 것만 실제 반영
3. 결과 상태: 저장된 건 `synced`, 더 느려서 밀린 건 `duplicate` (기존 enum 그대로, 타입 변경 없음)

## 랭킹 단순화

데이터가 이미 (user, stage)당 1행이므로 중복 제거 로직이 전부 불필요해졌다.

- `/api/ranking`: `groupBy(_min)` → `findMany(OR:[...])` → `seenUsers` Set 3단계를 `where:{stage}` + `orderBy:[clearTime, completedAt]` + `take:limit` 단순 조회로 대체. `totalPlayers`는 이제 행 수와 같으므로 `count` 하나. **-70줄**
- `/api/ranking/me`: 동일하게 `findMany({where:{userId}})` 한 번으로. **-30줄**
- `playCount` / `totalPlays`는 항상 1 / `clearedStages`와 같아져 의미가 사라져 타입에서 제거 (현재 프론트 소비처 없음 — grep 확인)

## 기타

- `useOfflineClearSync.ts`의 "append-only라 중복은 무해" ponytail 주석이 사실과 달라져 갱신 (주석만, 로직 변경 없음). 재전송은 이제 no-op이라 오히려 멱등해졌다
- 새 행 id는 `crypto.randomUUID()` (TEXT 컬럼이라 형식 무관, cuid 생성기 의존성 추가 회피). 기존 cuid 행과 혼재하지만 무해

## 테스트

`__tests__/api/records.test.ts` — `bestPerStage` 단위 테스트 4건 (스테이지별 1건, 최속 선택, 동률 시 먼저 달성한 것, 빈 배열). 이게 깨지면 게스트 동기화가 제약 위반으로 통째로 실패하므로 커버.

| 검증 | 결과 |
|---|---|
| `pnpm type-check` | 통과 |
| `pnpm lint` | 통과 (경고 1건은 `coverage/` 산출물, 기존) |
| `pnpm test` | 375 통과 (신규 4건 포함) |
| `pnpm exec next build` | 통과 |

관련 이슈: #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)
