### PR TITLE
[Backend] fix/ranking-best-per-user — 랭킹에서 사용자당 최고 기록 1건만 노출

### DIFF
--- a/__tests__/api/ranking.test.ts
+++ b/__tests__/api/ranking.test.ts
@@ -1,0 +1,67 @@
+/**
+ * GET /api/ranking — 사용자당 최고 기록 1건 보장
+ *
+ * 중복 제거가 SQL(DISTINCT ON)에서 일어나므로 실제 DB에 붙여야 검증된다.
+ * DATABASE_URL이 없는 환경(CI 등)에서는 통째로 건너뛴다.
+ */
+
+import { describe, it, expect } from "vitest";
+import { NextRequest } from "next/server";
+
+// vitest는 .env를 process.env에 넣어주지 않는다 (Node 20.12+ 내장 API 사용)
+try {
+  process.loadEnvFile(".env");
+} catch {
+  // .env 없음 — 아래 skipIf가 처리한다
+}
+
+const hasDb = Boolean(process.env.DATABASE_URL);
+
+const fetchRanking = async (stage: number, limit?: number) => {
+  const { GET } = await import("@/app/api/ranking/route");
+  const url = `http://localhost/api/ranking?stage=${stage}${limit ? `&limit=${limit}` : ""}`;
+  const res = await GET(new NextRequest(url));
+  const body = await res.json();
+  expect(body.success).toBe(true);
+  return body.data as import("@/types/ranking").RankingResponseData;
+};
+
+describe.skipIf(!hasDb)("GET /api/ranking", () => {
+  it("한 사용자는 한 스테이지에서 1번만 등장한다", async () => {
+    const { rankings } = await fetchRanking(1, 100);
+
+    const userIds = rankings.map((r) => r.userId);
+    expect(new Set(userIds).size).toBe(userIds.length);
+  });
+
+  it("중복 행이 있는 사용자는 가장 빠른 기록으로 나온다", async () => {
+    // 이 사용자는 stage 1에 128 / 156 / 171 / 171 네 행을 갖고 있다 (UNIQUE 제약 이전 데이터)
+    const { rankings } = await fetchRanking(1, 100);
+
+    const mine = rankings.filter(
+      (r) => r.userId === "cmnd9nelh0000k1ickjxq3u93",
+    );
+    expect(mine).toHaveLength(1);
+    expect(mine[0].clearTime).toBe(128);
+  });
+
+  it("clearTime 오름차순으로 정렬된다", async () => {
+    const { rankings } = await fetchRanking(1, 100);
+
+    const times = rankings.map((r) => r.clearTime);
+    expect([...times].sort((a, b) => a - b)).toEqual(times);
+    expect(rankings.map((r) => r.rank)).toEqual(
+      rankings.map((_, i) => i + 1),
+    );
+  });
+
+  it("limit은 중복 제거 후에 적용된다", async () => {
+    // 중복 제거 전에 limit이 걸리면 4위~7위를 한 사용자가 차지해 3건만 남는다
+    const { rankings, totalPlayers } = await fetchRanking(1, 4);
+
+    expect(rankings).toHaveLength(4);
+    expect(new Set(rankings.map((r) => r.userId)).size).toBe(4);
+    // totalPlayers는 행 수(7)가 아니라 실제 인원(4)
+    expect(totalPlayers).toBe(4);
+  });
+});

--- a/src/app/api/ranking/me/route.ts
+++ b/src/app/api/ranking/me/route.ts
@@ -2,7 +2,10 @@
  * GET /api/ranking/me
  *
  * 로그인 사용자의 스테이지별 최고 기록을 조회한다.
- * (userId, stage)당 1행만 보관하므로 저장된 행이 곧 최고 기록이다.
+ *
+ * ⚠️ UNIQUE(userId, stage) 이전 데이터에는 한 스테이지에 여러 행이 남아 있다.
+ *    그대로 읽으면 같은 스테이지가 중복되고 clearedStages도 부풀려지므로
+ *    /api/ranking과 동일하게 DISTINCT ON으로 스테이지당 1건만 뽑는다.
  *
  * - 인증 필수 (requireAuth)
  *
@@ -29,18 +32,23 @@ export const GET = async () => {
 
   try {
     // ── 2. 스테이지별 최고 기록 조회 ──
-    // (userId, stage)당 1행이므로 그대로 읽으면 스테이지별 최고 기록이다.
-    const bestRecords = await prisma.gameRecord.findMany({
-      where: { userId },
-      orderBy: { stage: "asc" },
-      select: {
-        stage: true,
-        clearTime: true,
-        hintsUsed: true,
-        stars: true,
-        completedAt: true,
-      },
-    });
+    // DISTINCT ON (stage)으로 스테이지당 최고 기록 1건만 남긴다.
+    // 판정 기준은 랭킹과 동일: 빠른 순 → 동률이면 먼저 달성한 쪽.
+    const bestRecords = await prisma.$queryRaw<
+      {
+        stage: number;
+        clearTime: number;
+        hintsUsed: number;
+        stars: number;
+        completedAt: Date;
+      }[]
+    >`
+      SELECT DISTINCT ON ("stage")
+        "stage", "clearTime", "hintsUsed", "stars", "completedAt"
+      FROM "game_records"
+      WHERE "userId" = ${userId}
+      ORDER BY "stage" ASC, "clearTime" ASC, "completedAt" ASC
+    `;
 
     const records: PersonalBestRecord[] = bestRecords.map((r) => ({
       stage: r.stage,

--- a/src/app/api/ranking/route.ts
+++ b/src/app/api/ranking/route.ts
@@ -2,7 +2,10 @@
  * GET /api/ranking?stage=1&limit=20
  *
  * 특정 스테이지의 랭킹(최단 클리어 시간)을 조회한다.
- * 저장 시점에 (userId, stage)당 최고 기록 1행만 유지되므로 단순 정렬 조회로 충분하다.
+ *
+ * ⚠️ (userId, stage) UNIQUE 제약(20260806000000_record_unique_user_stage)이 붙기 전
+ *    데이터가 운영 DB에 남아 있어, 같은 사용자가 한 스테이지에 여러 행을 갖는다.
+ *    기록을 지우지 않기로 했으므로 조회 단계에서 사용자당 최고 기록 1건만 뽑는다.
  *
  * - 인증 불필요 (공개 API)
  * - 쿼리 파라미터: stage (필수, 1~50), limit (선택, 기본 20, 최대 100)
@@ -16,6 +19,18 @@ import type { ApiResponse } from "@/types/api";
 import type { RankingEntry, RankingResponseData } from "@/types/ranking";
 import { RANKING_DEFAULT_LIMIT, RANKING_MAX_LIMIT } from "@/types/ranking";
 import { MIN_STAGE, MAX_STAGE } from "@/types/guest";
+
+/** DISTINCT ON 쿼리가 돌려주는 원시 행 (game_records + users 조인) */
+interface RankingRow {
+  userId: string;
+  clearTime: number;
+  hintsUsed: number;
+  stars: number;
+  completedAt: Date;
+  nickname: string | null;
+  name: string | null;
+  image: string | null;
+}
 
 export const GET = async (req: NextRequest) => {
   // ── 1. 쿼리 파라미터 파싱 ──
@@ -50,30 +65,37 @@ export const GET = async (req: NextRequest) => {
 
   try {
     // ── 2. 랭킹 조회 ──
-    // (userId, stage)당 1행이므로 정렬 후 자르면 그대로 랭킹이 된다.
-    const [records, totalPlayers] = await Promise.all([
-      prisma.gameRecord.findMany({
-        where: { stage },
-        // 같은 clearTime이면 먼저 달성한 사람이 상위
-        orderBy: [{ clearTime: "asc" }, { completedAt: "asc" }],
-        take: limit,
-        select: {
-          userId: true,
-          clearTime: true,
-          hintsUsed: true,
-          stars: true,
-          completedAt: true,
-          user: { select: { nickname: true, name: true, image: true } },
-        },
-      }),
-      prisma.gameRecord.count({ where: { stage } }),
+    // Postgres DISTINCT ON으로 사용자당 최고 기록 1건만 남긴 뒤 정렬·자른다.
+    // Prisma의 `distinct`는 커넥터에 따라 메모리에서 처리돼 `take`와 조합하면
+    // limit이 중복 제거 전에 적용되므로 쓰지 않는다.
+    const [rows, [{ count }]] = await Promise.all([
+      prisma.$queryRaw<RankingRow[]>`
+        SELECT b.* FROM (
+          SELECT DISTINCT ON (r."userId")
+            r."userId", r."clearTime", r."hintsUsed", r."stars", r."completedAt",
+            u."nickname", u."name", u."image"
+          FROM "game_records" r
+          JOIN "users" u ON u."id" = r."userId"
+          WHERE r."stage" = ${stage}
+          -- 사용자별 최고 기록 판정: 빠른 순 → 동률이면 먼저 달성한 쪽
+          ORDER BY r."userId", r."clearTime" ASC, r."completedAt" ASC
+        ) b
+        -- 랭킹 정렬: 같은 clearTime이면 먼저 달성한 사람이 상위
+        ORDER BY b."clearTime" ASC, b."completedAt" ASC
+        LIMIT ${limit}
+      `,
+      prisma.$queryRaw<{ count: number }[]>`
+        SELECT COUNT(DISTINCT "userId")::int AS count
+        FROM "game_records"
+        WHERE "stage" = ${stage}
+      `,
     ]);
 
-    const rankings: RankingEntry[] = records.map((r, index) => ({
+    const rankings: RankingEntry[] = rows.map((r, index) => ({
       rank: index + 1,
       userId: r.userId,
-      displayName: r.user.nickname ?? r.user.name ?? "익명",
-      profileImage: r.user.image,
+      displayName: r.nickname ?? r.name ?? "익명",
+      profileImage: r.image,
       clearTime: r.clearTime,
       hintsUsed: r.hintsUsed,
       stars: r.stars,
@@ -83,7 +105,8 @@ export const GET = async (req: NextRequest) => {
     const responseData: RankingResponseData = {
       stage,
       rankings,
-      totalPlayers,
+      // 행 수가 아니라 실제 참여 인원 (중복 제거)
+      totalPlayers: count,
     };
 
     return NextResponse.json<ApiResponse<RankingResponseData>>(


### PR DESCRIPTION
## 무엇을 왜 고쳤나

`GET /api/ranking?stage=N` 이 한 사용자를 여러 번 반환했다.

`prisma/migrations/20260806000000_record_unique_user_stage` (UNIQUE(userId, stage))가 **운영 DB에 아직 적용되지 않은 상태**라, 제약이 생기기 전 데이터가 그대로 남아 있다. `prisma migrate status` 확인 결과:

```
Following migration have not yet been applied:
20260806000000_record_unique_user_stage
```

실제로 `cmnd9nelh0000k1ickjxq3u93` 가 `stage = 1` 에 4행(clearTime 128 · 156 · 171 · 171)을 갖고 있었다. 라우트 상단 주석은 "저장 시점에 (userId, stage)당 1행만 유지되므로 단순 정렬 조회로 충분하다"고 전제하고 있었지만 그 전제가 성립하지 않았다.

증상:
- 랭킹 화면에서 같은 사람이 4위~7위를 독식
- 목록이 `userId` 를 React key 로 쓰기 때문에 콘솔에 "Encountered two children with the same key" 3건
- `totalPlayers` 가 행 수(7)를 세서 실제 인원(4)과 어긋남

기록은 지우지 않기로 했으므로(사용자 요청) **조회 단계에서** 해결했다.

## 어떤 방법을 골랐고 왜

**Postgres `DISTINCT ON` + `$queryRaw`** 를 골랐다.

Prisma 의 `distinct` 를 쓰지 않은 이유: Prisma 는 `distinct` 를 커넥터/메모리 레벨에서 처리하는데, `take` 는 DB 에 `LIMIT` 으로 내려간다. 즉 **중복 제거보다 limit 이 먼저** 적용된다. 이 케이스에서 `limit=4` 로 조회하면 DB 가 상위 4행(92 · 108 · 121 · 128)을 주고 그중 중복을 걸러 내므로, 화면에는 4명이 아니라 4행 중 살아남은 수만 남는다. 즉 `take` 와 조합하면 결과 개수 자체가 틀어진다.

`DISTINCT ON` 은 이걸 DB 안에서 한 번에 끝낸다. 서브쿼리에서 사용자당 1행을 뽑고, 바깥에서 랭킹 정렬 후 `LIMIT` 을 건다 — 순서가 보장된다.

```sql
SELECT b.* FROM (
  SELECT DISTINCT ON (r."userId")
    r."userId", r."clearTime", r."hintsUsed", r."stars", r."completedAt",
    u."nickname", u."name", u."image"
  FROM "game_records" r
  JOIN "users" u ON u."id" = r."userId"
  WHERE r."stage" = $1
  ORDER BY r."userId", r."clearTime" ASC, r."completedAt" ASC  -- 최고 기록 판정
) b
ORDER BY b."clearTime" ASC, b."completedAt" ASC  -- 랭킹 정렬 (기존과 동일)
LIMIT $2
```

전체 행을 가져와 JS 로 거르는 방법도 검토했지만, 스테이지의 행 수만큼 무제한 페치가 되고 `limit` 의 의미가 사라져 버려 택하지 않았다.

## 변경 사항

- `src/app/api/ranking/route.ts`
  - `findMany` → `DISTINCT ON` raw 쿼리. 최고 기록 판정은 `clearTime ASC → completedAt ASC`
  - 기존 랭킹 정렬 규칙(같은 `clearTime` 이면 먼저 달성한 사람이 상위) 유지
  - `totalPlayers` 를 `count()` → `COUNT(DISTINCT "userId")::int` 로 변경
- `src/app/api/ranking/me/route.ts`
  - **같은 문제가 있었다.** 중복 행을 그대로 읽어 스테이지가 중복 노출되고 `clearedStages` 도 부풀려졌다 (해당 사용자 기준 4 → 1). `DISTINCT ON ("stage")` 로 수정
- `__tests__/api/ranking.test.ts` — 회귀 테스트 신규

응답 스키마(`RankingEntry` · `RankingResponseData`)는 **변경하지 않았다.** 프론트가 병렬 작업 중이므로 그대로 둔다.

## 검증

개발 서버(`pnpm dev`)를 띄워 실제 호출:

**`GET /api/ranking?stage=1`** — `cmnd9nelh0000k1ickjxq3u93` 가 **1번만**, `clearTime 128` 로 나온다.

```
totalPlayers: 4          (수정 전에는 행 수 7)
  1 cmttq3ur90000k148xz0bjrnv 테스트1 92
  2 cmttq3uuh0001k148l2sbm7cq 테스트2 108
  3 cmttq3uv90002k148ec4liqmk 테스트3 121
  4 cmnd9nelh0000k1ickjxq3u93 익명    128   ← 4위 1건 (기존에는 4~7위 독식)
```

**다른 스테이지 — 기존과 동일**

| stage | totalPlayers | 순위 |
|---|---|---|
| 11 | 3 | 테스트2 342 · 테스트3 397 · 테스트4 468 |
| 21 | 3 | 테스트3 486 · 테스트4 572 · 테스트5 655 |
| 31 | 3 | 테스트4 703 · 테스트5 812 · 테스트1 934 |
| 41 | 3 | 테스트5 908 · 테스트1 1086 · 테스트2 1247 |

**`limit` 과의 조합** — `?stage=1&limit=4` → 4행, 서로 다른 사용자 4명. 중복 제거가 `LIMIT` 보다 먼저 적용됨을 확인.

**`GET /api/ranking/me`** — 해당 사용자 원본 4행 → 결과 1건(`stage 1: 128s`), `clearedStages` 4 → 1.

**커맨드**

```
pnpm type-check   ✅ 통과
pnpm lint         ✅ 에러 0 (경고 1건은 생성물 coverage/ 로 이번 변경과 무관)
pnpm test         ✅ 22 files / 384 tests 통과 (신규 4건 포함)
```

## 테스트

`__tests__/api/ranking.test.ts` — 중복 제거는 SQL 에서 일어나므로 순수 단위 테스트로는 깨져도 잡히지 않는다. 라우트 핸들러를 직접 호출해 실제 DB 로 검증한다.

- 한 스테이지에서 `userId` 중복 없음
- 중복 행이 있는 사용자는 가장 빠른 기록(128)으로 1건만
- `clearTime` 오름차순 정렬 + `rank` 연속성
- `limit=4` 일 때 4명이 나오고 `totalPlayers` 는 4

`DATABASE_URL` 이 없으면 `describe.skipIf` 로 통째로 건너뛰므로 CI 를 막지 않는다.

## 참고 — 남은 후속 작업 (이 PR 범위 밖)

이 PR 은 조회만 고친다. 근본 원인인 **미적용 마이그레이션**은 그대로다. `prisma migrate deploy` 는 중복 행을 영구 삭제하므로(마이그레이션 1단계 `DELETE`) 사용자 판단이 필요하다. 적용 전까지는 이 조회 로직이 방어선이고, 적용 후에도 `DISTINCT ON` 은 무해하다(사용자당 1행이면 결과 동일).
