### PR TITLE
[Frontend] feat/ranking-stage-picker — 랭킹 화면 스테이지 1~50 개별 선택

### DIFF
--- a/src/app/ranking/RankingContent.tsx
+++ b/src/app/ranking/RankingContent.tsx
@@ -10,11 +10,12 @@
 
 "use client";
 
-import { useState, useCallback } from "react";
+import { useState, useCallback, useMemo } from "react";
 import { useAuth } from "@/hooks";
 import { useStageRanking } from "@/hooks/useRanking";
 import {
   DifficultyTabs,
+  StagePicker,
   RankingPodium,
   RankingList,
   RankingEmpty,
@@ -22,22 +23,23 @@ import {
   RankingError,
   LoginBanner,
   DIFFICULTY_TABS,
+  stagesOf,
   type DifficultyTab,
 } from "@/components/ranking";
 
 const RankingContent = () => {
   const { user, isAuthenticated } = useAuth();
   const [activeTab, setActiveTab] = useState<DifficultyTab>(DIFFICULTY_TABS[0]);
+  const [stage, setStage] = useState<number>(DIFFICULTY_TABS[0].startStage);
 
-  const {
-    data,
-    isLoading,
-    isError,
-    refetch,
-  } = useStageRanking(activeTab.stage);
+  const stages = useMemo(() => stagesOf(activeTab), [activeTab]);
 
+  const { data, isLoading, isError, refetch } = useStageRanking(stage);
+
+  // 탭을 바꾸면 그 구간의 첫 스테이지를 기본 선택으로
   const handleTabChange = useCallback((tab: DifficultyTab) => {
     setActiveTab(tab);
+    setStage(tab.startStage);
   }, []);
 
   // 포디움 (1~3위) / 리스트 (4위~) 분리
@@ -57,6 +59,25 @@ const RankingContent = () => {
       <div className="mt-4">
         <DifficultyTabs activeId={activeTab.id} onChange={handleTabChange} />
       </div>
+
+      {/* 스테이지 선택 — key로 탭 전환 시 가로 스크롤 위치를 처음으로 되돌린다 */}
+      <StagePicker
+        key={activeTab.id}
+        stages={stages}
+        activeStage={stage}
+        onChange={setStage}
+      />
+
+      {/* 현재 조회 중인 대상 — 탭 라벨만으로는 어느 스테이지인지 알 수 없다 */}
+      <p
+        aria-live="polite"
+        className="mx-4 text-sm font-semibold text-foreground"
+      >
+        {activeTab.label}
+        <span className="text-muted-foreground"> · </span>
+        스테이지 {stage}
+        <span className="font-medium text-muted-foreground"> 랭킹</span>
+      </p>
 
       {/* 콘텐츠 영역 */}
       <div className="mx-auto w-full max-w-[600px] flex-1 py-4 lg:max-w-full">

--- a/src/components/ranking/StagePicker.tsx
+++ b/src/components/ranking/StagePicker.tsx
@@ -1,0 +1,57 @@
+/**
+ * 스테이지 선택 칩 목록
+ *
+ * 난이도 탭 아래에서 그 구간의 스테이지를 하나 고른다.
+ * 스도쿠는 스테이지마다 퍼즐이 달라 같은 스테이지끼리만 기록을 겨룰 수 있으므로,
+ * 구간을 묶지 않고 스테이지 단위로 랭킹을 조회한다.
+ *
+ * 한 줄 가로 스크롤 — 전문가 구간 20개도 세로 공간을 먹지 않고,
+ * 데스크톱에서는 스크롤 없이 한 줄에 다 들어간다.
+ */
+
+"use client";
+
+import { cn } from "@/lib/utils";
+
+interface StagePickerProps {
+  /** 표시할 스테이지 번호 목록 */
+  stages: number[];
+  /** 현재 선택된 스테이지 */
+  activeStage: number;
+  /** 스테이지 변경 콜백 */
+  onChange: (stage: number) => void;
+}
+
+const StagePicker = ({ stages, activeStage, onChange }: StagePickerProps) => {
+  return (
+    <div
+      role="group"
+      aria-label="스테이지 선택"
+      className="flex gap-1.5 overflow-x-auto px-4 py-3 [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden"
+    >
+      {stages.map((stage) => {
+        const isActive = stage === activeStage;
+
+        return (
+          <button
+            key={stage}
+            type="button"
+            aria-pressed={isActive}
+            aria-label={`스테이지 ${stage}`}
+            onClick={() => onChange(stage)}
+            className={cn(
+              "size-11 shrink-0 cursor-pointer rounded-[var(--radius-sm)] border text-sm tabular-nums transition-colors duration-(--duration-normal)",
+              isActive
+                ? "border-foreground bg-foreground font-semibold text-background"
+                : "border-input font-medium text-muted-foreground hover:bg-accent hover:text-foreground",
+            )}
+          >
+            {stage}
+          </button>
+        );
+      })}
+    </div>
+  );
+};
+
+export default StagePicker;

--- a/src/components/ranking/index.ts
+++ b/src/components/ranking/index.ts
@@ -1,4 +1,5 @@
 export { default as DifficultyTabs } from "./DifficultyTabs";
+export { default as StagePicker } from "./StagePicker";
 export { default as RankingPodium } from "./RankingPodium";
 export { default as RankingList } from "./RankingList";
 export { default as RankingEmpty } from "./RankingEmpty";
@@ -8,5 +9,10 @@ export { default as LoginBanner } from "./LoginBanner";
 export { default as RankingAvatar } from "./RankingAvatar";
 export { default as StarRating } from "./StarRating";
 
-export { DIFFICULTY_TABS, formatTime, formatDate } from "./ranking-utils";
+export {
+  DIFFICULTY_TABS,
+  stagesOf,
+  formatTime,
+  formatDate,
+} from "./ranking-utils";
 export type { DifficultyTab } from "./ranking-utils";

--- a/src/components/ranking/ranking-utils.ts
+++ b/src/components/ranking/ranking-utils.ts
@@ -7,19 +7,43 @@
 
 // ─── 난이도 탭 데이터 ─────────────────────────────────
 
+import { DIFFICULTIES } from "@/components/home/difficulty-data";
+import { MAX_STAGE } from "@/types/guest";
+
 export interface DifficultyTab {
   id: string;
   label: string;
-  /** 대표 스테이지 번호 (API 조회용) */
-  stage: number;
+  /** 구간 첫 스테이지 — 탭 전환 시 기본 선택 */
+  startStage: number;
+  /** 구간 마지막 스테이지 */
+  endStage: number;
 }
 
-export const DIFFICULTY_TABS: readonly DifficultyTab[] = [
-  { id: "easy", label: "쉬움", stage: 1 },
-  { id: "medium", label: "보통", stage: 11 },
-  { id: "hard", label: "어려움", stage: 21 },
-  { id: "expert", label: "전문가", stage: 31 },
-] as const;
+/**
+ * 난이도 탭 — 홈 화면 난이도 카드(DIFFICULTIES)에서 구간을 파생한다.
+ *
+ * 구간 목록을 여기 다시 적으면 홈과 어긋날 수 있으므로 startStage만 가져와
+ * 다음 카드의 시작 - 1을 끝으로 잡는다. (쉬움 1~10 · 보통 11~20 ·
+ * 어려움 21~30 · 전문가 31~50)
+ *
+ * types/game.ts의 STAGE_RANGES는 엔진용 5구간이라 사용자가 보는 4단계와
+ * 다르다 — 그쪽을 기준으로 삼지 않는다.
+ */
+export const DIFFICULTY_TABS: readonly DifficultyTab[] = DIFFICULTIES.map(
+  ({ id, label, startStage }, i) => ({
+    id,
+    label,
+    startStage,
+    endStage: (DIFFICULTIES[i + 1]?.startStage ?? MAX_STAGE + 1) - 1,
+  }),
+);
+
+/** 구간에 속한 스테이지 번호 목록 */
+export const stagesOf = (tab: DifficultyTab): number[] =>
+  Array.from(
+    { length: tab.endStage - tab.startStage + 1 },
+    (_, i) => tab.startStage + i,
+  );
 
 // ─── 시간 포맷 ────────────────────────────────────────
 


### PR DESCRIPTION
## 무엇을 왜 바꿨나

랭킹 탭이 난이도 이름을 달고 있지만 실제로는 **대표 스테이지 1개만** 조회했다.

- `DIFFICULTY_TABS`가 `stage: 1 / 11 / 21 / 31` 고정 → 50개 스테이지 중 **4개만** 랭킹이 존재
- 스테이지 2~10을 깬 사람은 랭킹 어디에도 안 나옴
- 전문가 구간은 31~50인데 31만 조회 → **32~50은 랭킹이 아예 없음**

스도쿠는 스테이지마다 퍼즐이 달라 같은 스테이지끼리만 기록을 겨룰 수 있다. 그래서
구간을 하나로 묶지 않고 **스테이지 1~50을 각각 조회 가능**하게 바꿨다.

## 변경 내용

| 파일 | 변경 |
| --- | --- |
| `src/components/ranking/ranking-utils.ts` | `DifficultyTab`을 `startStage`/`endStage` 구간으로 변경. 목록을 하드코딩하지 않고 홈 화면 `DIFFICULTIES`에서 파생 + `stagesOf()` 추가 |
| `src/components/ranking/StagePicker.tsx` | (신규) 스테이지 선택 칩 목록 |
| `src/app/ranking/RankingContent.tsx` | `stage` 상태 분리, 탭 전환 시 구간 첫 스테이지로 초기화, 현재 조회 대상 캡션 추가 |
| `src/components/ranking/index.ts` | export 추가 |

### 난이도 구간을 홈과 일치시킨 방법

구간 목록을 랭킹 쪽에 다시 적으면 홈과 어긋날 수 있으므로,
`src/components/home/difficulty-data.ts`의 `DIFFICULTIES`에서 `startStage`만 가져오고
끝 스테이지는 "다음 카드의 시작 − 1"(마지막은 `MAX_STAGE`)로 계산한다.
홈 카드가 바뀌면 랭킹 탭도 자동으로 따라간다.

결과: 쉬움 1~10 · 보통 11~20 · 어려움 21~30 · 전문가 31~50.
`types/game.ts`의 `STAGE_RANGES`는 엔진용 5구간(입문·초급·중급·고급·마스터)이라
사용자가 보는 4단계와 다르므로 기준으로 삼지 않았다.

## 스테이지 선택 UI를 칩 가로 스크롤로 고른 이유

전문가 구간이 20개까지 늘어나므로 세 가지를 놓고 봤다.

- **드롭다운(`ui/select`)** — 세로 공간은 아끼지만 인접 스테이지를 오가려면 매번 열어야 하고,
  20개 항목을 팝업 안에서 스크롤하게 된다. 랭킹은 "옆 스테이지도 슬쩍 본다"가 주 동작이라 맞지 않았다.
- **줄바꿈 그리드** — 375px에서 20개가 3줄을 차지해 포디움이 화면 밖으로 밀린다.
- **한 줄 가로 스크롤 칩(채택)** — 세로 높이가 항상 한 줄로 고정되고,
  데스크톱에서는 20개가 스크롤 없이 한 줄에 다 들어간다. 탭 한 번으로 이웃 스테이지 이동.

세부 사항:

- 칩은 44×44px — 모바일 터치 타깃 최소 크기 충족
- 선택 칩은 `bg-foreground / text-background` 반전 — 라이트·다크 양쪽에서 대비 최대
- 탭 전환 시 `key={activeTab.id}`로 remount해 가로 스크롤 위치를 맨 앞으로 되돌린다
- 칩만으로는 어느 스테이지인지 스캔이 필요하므로 **"전문가 · 스테이지 41 랭킹"** 캡션을
  결과 바로 위에 `aria-live="polite"`로 노출 (기존에는 "쉬움" 탭이 스테이지 1이란 걸 알 방법이 없었음)
- 스크롤바는 숨기되 `overflow-x: auto` 유지 — 데스크톱 트랙패드/모바일 스와이프 모두 동작
- `aria-label="스테이지 선택"` 그룹 + 칩마다 `aria-pressed`, `aria-label="스테이지 N"`

## 검증

`pnpm dev`로 실제 확인 (스크린샷은 데스크톱 800px / 모바일 375×812).

| 확인 항목 | 결과 |
| --- | --- |
| 탭별 스테이지 목록 | 쉬움 1~10 · 보통 11~20 · 어려움 21~30 · 전문가 31~50 ✅ |
| 탭 전환 시 기본 선택 | 1 / 11 / 21 / 31, 가로 스크롤 위치도 0으로 리셋 ✅ |
| 스테이지별 랭킹이 실제로 다름 | 1→테스트2·1·3 / 11→테스트3·2·4 / 21→테스트4·3·5 / 31→테스트5·4·1 ✅ |
| **스테이지 41** (기존에 볼 수 없던 구간) | 테스트1·5·2 정상 표시 ✅ |
| 데이터 없는 스테이지 | 2·50에서 `RankingEmpty` 정상 표시 ✅ |
| 모바일 375px | 한 줄 스크롤로 50까지 도달 가능, 레이아웃 안 깨짐 ✅ |
| `pnpm type-check` | 통과 ✅ |
| `pnpm lint` | 0 errors (기존 `coverage/` 경고 1건만 잔존) ✅ |

## 건드리지 않은 것

- `RankingEntry` · `RankingResponseData` 스키마, `useStageRanking` 훅 시그니처 — 그대로
- `src/app/api/` 전체 — 변경 없음 (`GET /api/ranking?stage=N`이 이미 1~50을 받는다)

관련: Epic #6 — 랭킹 시스템
